### PR TITLE
Split main merge gate from dev validation

### DIFF
--- a/.github/workflows/main-merge-gate.yml
+++ b/.github/workflows/main-merge-gate.yml
@@ -1,0 +1,16 @@
+name: Main Merge Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  main-merge-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require dev source
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ] || [ "${{ github.event.pull_request.head.ref }}" != "dev" ]; then
+            echo "::error::Pull requests into main must come from the dev branch in this repository."
+            exit 1
+          fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,22 +3,12 @@ name: Validate Config
 on:
   push:
     branches: [dev]
-  pull_request:
-    branches: [main]
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Enforce main merge source
-        if: github.event_name == 'pull_request'
-        run: |
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ] || [ "${{ github.event.pull_request.head.ref }}" != "dev" ]; then
-            echo "::error::Pull requests into main must come from the dev branch in this repository."
-            exit 1
-          fi
 
       - name: Validate JSON files
         run: |


### PR DESCRIPTION
## Summary
- Keep full Validate Config on dev pushes only
- Add a lightweight Main Merge Gate for PRs into main
- Preserve the dev-only source check without rerunning the full validation suite on every main PR

## Verification
- YAML parse passed for all workflows
- git diff --check passed
- node scripts/check-code-style.mjs passed with existing function-lines advisory only
- dev push CI run 28700891807 passed