### PR TITLE
feat: add cross-review gate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,6 +109,33 @@ The workflow runner is currently single-pass: iteration caps and stop
 conditions are recorded as contract metadata, but convergence loops are not yet
 autonomously executed by the runtime.
 
+## Cross-Review Gate
+
+The cross-review gate is a session-scoped evidence gate for work that must be
+reviewed by the other host family before the implementer can finish.
+`goldband-cross-review start` writes a contract under
+`${GOLDBAND_HOME:-$HOME/.goldband}/cross-review/`, and the Stop hook checks only
+that contract, the plan marker, the reviewer artifact, and a deterministic
+review-scope hash. The hook never starts Claude, Codex, or another LLM.
+
+The review scope is `tracked-and-untracked-vs-base`: `git diff --binary` from
+the armed base commit plus sorted untracked file bytes. The hash is drift
+detection, not a security boundary against same-permission tampering. A valid
+approval requires a reviewer artifact in the cross-review state directory and a
+matching marker in the plan file.
+
+When review cannot converge, the runtime writes an escalation summary under the
+cross-review state directory and keeps the contract active until a human
+override, expiry, or a valid approval marker. Runtime usage events record arm,
+round verdict, implementer response, escalation, override, and done events using
+the shared telemetry schema.
+
+Claude Stop can block through the existing router `exit(2)` path. Codex uses
+the same gate logic and blocks cross-review Stop failures by exiting the hook
+process with code `2`. The 2026-07-05 local probe showed that JSON
+`systemMessage` is advisory for final responses, while a non-zero Stop hook
+exit makes Codex show `Stop Blocked` and prevents that turn from finishing.
+
 ## Observability Pipeline
 
 Goldband telemetry is intentionally local-first:

--- a/README.en.md
+++ b/README.en.md
@@ -96,6 +96,39 @@ Global guidance only covers daily response style, verification posture, and work
 boundaries. Review, debugging, security, planning, and QA flows live in
 `goldband-*` workflows, commands, skills, hooks, and rules.
 
+## Cross-Review Gate
+
+For work that must be approved by the other host family before the implementer
+can finish, arm the cross-review gate:
+
+```bash
+goldband-loop/bin/goldband-cross-review start --plan docs/plans/feature.md --reviewer codex
+goldband-loop/bin/goldband-cross-review run
+```
+
+`run` defaults to the real reviewer CLI. `--review-mode mock` is only for CI and local contract tests, and mock artifacts are not accepted by the Stop gate as production approval evidence.
+
+The Stop hook only checks deterministic evidence: the session contract, plan
+marker, reviewer artifact, and current diff/untracked bundle `reviewed-sha`.
+It never starts Claude or Codex from inside the hook. Claude Stop blocks through
+the existing router `exit(2)` path. Codex cross-review Stop blocks through hook
+process `exit(2)`: the 2026-07-05 local probe showed JSON `systemMessage` is
+only advisory, while a non-zero hook exit makes Codex show `Stop Blocked` and
+prevents that turn from finishing.
+
+This is an evidence gate for preventing accidental completion and encouraging
+cross-model review, not a security boundary. The implementer and reviewer run on
+the same machine with the same user-level permissions, so this cannot resist a
+same-permission operator intentionally forging state or artifacts. Claude also
+short-circuits when `stop_hook_active` is set to avoid Stop-hook recursion,
+while Codex relies on exit code `2` to re-enter the turn; the two hosts are not
+interaction-identical.
+
+If max rounds or `ESCALATE` requires human arbitration, the runtime writes an
+escalation summary in the cross-review state directory and includes its path in
+the Stop message. Arm, round verdict, response, escalation, override, and done
+events are recorded in usage telemetry.
+
 ## Permission Boundary
 
 Claude `hooks/hooks.json` uses `defaultMode: acceptEdits`. This is a convenience

--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ goldband 不再維護 native PowerShell installer。Windows 請用 Git Bash 或 
 
 全域守則只放日常回覆、查證口徑和工作邊界。review、debug、security、planning、QA 這類重流程走 `goldband-*` workflow、commands、skills、hooks 和 rules。
 
+## 交互審查閘門
+
+需要另一個 host 家族審查才能收工的工作，可以用 cross-review gate：
+
+```bash
+goldband-loop/bin/goldband-cross-review start --plan docs/plans/feature.md --reviewer codex
+goldband-loop/bin/goldband-cross-review run
+```
+
+`run` 預設會呼叫真實 reviewer CLI。`--review-mode mock` 只給 CI/本機契約測試使用，mock artifact 不能作為 Stop gate 的正式通過證據。
+
+Stop hook 只做純檢查：session contract、plan marker、reviewer artifact、以及目前 diff/untracked bundle 的 `reviewed-sha`。它不會在 hook 裡啟動 Claude 或 Codex。Claude 端 Stop gate 會用 router `exit(2)` 擋下未通過的 session；Codex 端 cross-review Stop gate 也走 hook process `exit(2)`，因為 2026-07-05 本機實測確認 JSON `systemMessage` 只是 advisory，只有非零退出會讓 Codex 顯示 `Stop Blocked` 並阻止該輪結束。
+
+這是防手滑、促成跨模型互審的 evidence gate，不是安全邊界。實作者與 reviewer 在同一台機器、同一權限下運作，無法抵抗有意偽造 state/artifact 的同權限操作者。Claude 端為避免 Stop hook 自我觸發風暴，`stop_hook_active` 時會短路 allow；Codex 端則靠 exit code `2` 讓 turn 重進，因此兩邊的互動強制力不完全相同。
+
+若回合上限或 `ESCALATE` 觸發人類仲裁，runtime 會在 cross-review state 目錄寫 escalation summary，Stop 訊息會附路徑；arm、round verdict、response、escalation、override 和 done 也會寫進 usage telemetry。
+
 ## 權限邊界
 
 Claude `hooks/hooks.json` 使用 `defaultMode: acceptEdits`，定位是信任本機開發環境的便利 profile，不是 sandbox。它會用 hooks、permissions 和 deny list 降低誤操作風險，但不能把惡意或任意 shell 視為已隔離。`node`、`python`、`xargs`、`find` 和 `sed` 這類可包裝或批次執行其他動作的 broad allow pattern 不應放回 source auto-allow；需要時應由使用者針對具體命令確認，或在本機 overlay 裡明確承擔信任邊界。

--- a/codex/hooks/hook-router.js
+++ b/codex/hooks/hook-router.js
@@ -10,6 +10,10 @@ const {
   findHighRiskPatch,
 } = require('./high-risk-policy');
 const { dataRoot, recordHookTelemetry } = require('./telemetry');
+const {
+  armFromPrompt,
+  evaluateCrossReviewGate,
+} = require('../../hooks/scripts/lib/hook-router/cross-review-gate');
 
 const ADVISORY_SECRET_PATTERNS = [
   /\bxox[baprs]-[A-Za-z0-9-]{20,}\b/,
@@ -17,6 +21,7 @@ const ADVISORY_SECRET_PATTERNS = [
   /(?:api[_-]?key|api[_-]?secret|access[_-]?token|auth[_-]?token)\s*[=:]\s*['"][A-Za-z0-9_-]{20,}['"]/i,
 ];
 const DEFAULT_DEDUPE_RETENTION_DAYS = 30;
+const CODEX_STOP_BLOCK_EXIT_CODE = 2;
 
 const WORKFLOW_HINTS = [
   {
@@ -87,6 +92,24 @@ function buildSystemMessageOutput(message) {
   return { systemMessage: message };
 }
 
+function buildStopBlockOutput(
+  message,
+  telemetryName = 'cross-review-required',
+) {
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'Stop',
+      telemetryName,
+      decision: {
+        behavior: 'deny',
+        message,
+      },
+    },
+    codexExitCode: CODEX_STOP_BLOCK_EXIT_CODE,
+    stderr: message,
+  };
+}
+
 function buildPreToolUseDeny(reason, telemetryName = null) {
   return {
     hookSpecificOutput: {
@@ -117,6 +140,10 @@ function resultAdditionalContext(hookEventName, additionalContext) {
 
 function resultSystemMessage(message) {
   return buildSystemMessageOutput(message);
+}
+
+function resultStopBlock(message, telemetryName) {
+  return buildStopBlockOutput(message, telemetryName);
 }
 
 function resultPreToolUseDeny(decision) {
@@ -314,6 +341,11 @@ function evaluateSubagentStopResult(input) {
 }
 
 function evaluateStopResult(input) {
+  const gateResult = evaluateCrossReviewGate(input);
+  if (gateResult.decision === 'block') {
+    return resultStopBlock(gateResult.logs.join('\n'), gateResult.blockedBy);
+  }
+
   const message = input.last_assistant_message || '';
   if (hasCompletionClaim(message) && !hasEvidence(message)) {
     return resultSystemMessage(
@@ -341,16 +373,45 @@ function evaluateLifecycleResult(input) {
 
 function evaluateUserPromptSubmitResult(input) {
   const prompt = input.prompt || '';
+  const crossReviewContract = armCrossReviewIfRequested(input);
   if (/\/goldband-|\/plan\b/.test(prompt)) {
-    return null;
+    return crossReviewContract
+      ? resultAdditionalContext(
+          'UserPromptSubmit',
+          formatCrossReviewArmMessage(crossReviewContract),
+        )
+      : null;
   }
 
   const messages = WORKFLOW_HINTS.filter((hint) =>
     hint.pattern.test(prompt),
   ).map((hint) => hint.message);
 
+  if (crossReviewContract) {
+    messages.unshift(formatCrossReviewArmMessage(crossReviewContract));
+  }
+
   if (messages.length === 0) return null;
   return resultAdditionalContext('UserPromptSubmit', messages.join(' '));
+}
+
+function armCrossReviewIfRequested(input) {
+  try {
+    return armFromPrompt(input, { implementer: 'codex' });
+  } catch (error) {
+    return {
+      reviewer: 'unknown',
+      planFile: null,
+      error: error && error.message ? error.message : String(error),
+    };
+  }
+}
+
+function formatCrossReviewArmMessage(contract) {
+  if (contract.error) {
+    return `Cross-review gate was requested but could not be armed: ${contract.error}`;
+  }
+  return `Cross-review gate armed for this session. Reviewer: ${contract.reviewer}. Plan: ${contract.planFile || 'not bound yet'}.`;
 }
 
 function evaluatePreToolUseResult(input) {
@@ -441,6 +502,10 @@ async function main() {
   const input = parseInput(await readStdinRaw());
   const result = evaluateInput(input);
   recordHookTelemetry(input, result);
+  if (result?.codexExitCode) {
+    if (result.stderr) console.error(result.stderr);
+    process.exit(result.codexExitCode);
+  }
   writeResult(result);
 }
 

--- a/commands/goldband-cross-review.md
+++ b/commands/goldband-cross-review.md
@@ -1,0 +1,23 @@
+---
+description: Arm and run the Claude/Codex cross-review gate for the current session.
+---
+
+# Goldband Cross Review
+
+Use this command when a task must be reviewed by the other host family before the implementer can finish.
+
+Programmatic entrypoint:
+
+```bash
+goldband-loop/bin/goldband-cross-review start --plan <path> --reviewer <codex|claude>
+goldband-loop/bin/goldband-cross-review run
+goldband-loop/bin/goldband-cross-review respond --session-id <id> --finding-id <id> --response fixed|rebutted|ask-human --summary <text>
+goldband-loop/bin/goldband-cross-review done --session-id <id>
+goldband-loop/bin/goldband-cross-review override --session-id <id> --reason <reason>
+```
+
+The Stop hook checks the session contract, plan marker, reviewer artifact, and current review-scope hash. It does not run an LLM inside the hook.
+
+Implementer responses are written to the cross-review response log and included in the next reviewer prompt. If review escalates or reaches max rounds, the runtime writes a human-arbitration summary path into the active contract and Stop message. Cross-review arm, round, response, escalation, override, and done events are recorded in usage telemetry.
+
+Default review mode is `real`; it invokes the configured reviewer CLI. `--review-mode mock` is only for CI and local contract tests, and mock artifacts are not accepted by the Stop gate as production approval evidence.

--- a/docs/prompts/04-cross-review-gate.md
+++ b/docs/prompts/04-cross-review-gate.md
@@ -1,0 +1,414 @@
+# 實作 Prompt 4:Claude ↔ Codex 交互審查閘門(cross-review gate)
+
+> 使用方式:把本檔全文貼給一個乾淨的 Claude Code 或 Codex session,工作目錄為
+> goldband repo 根目錄。本檔是「實作規格 + 計畫」,不是最小可行版本;請按階段實作,
+> 每個階段都要有測試與證據才算完成。
+
+---
+
+## 背景
+
+goldband 是 Claude Code + Codex 的 guardrail control plane。目前兩個 host 各有
+Stop hook(`hooks/hooks.json`、`codex/hooks.json`)與各自 router。Claude 側走
+`hooks/scripts/hooks/hook-router.js` 與
+`hooks/scripts/lib/hook-router/stop-policy.js` 的 `evaluateStop(input)`;
+要擋下收工可回 `decision:'block'`,router 會 `exit(2)` 把理由回注給實作方。
+Codex 側走 `codex/hooks/hook-router.js`,目前 Stop surface 主要是 advisory/system
+message;**實作前必須先驗證 Codex Stop hook 的 blocking 語意與輸出格式**,不得假設
+與 Claude 完全相同。已有 `goldband-loop/codex`(codex review/challenge/consult,
+目前以文字 marker 判定 pass/fail gate)與 `goldband-loop/review`。
+
+目前缺的是:讓「實作方」與「審查方」由**不同模型**擔任,並用 Stop hook **強制**
+「未通過交互審查不得收工」。這正好呼應本 repo 的立身目標:Claude/Codex 雙工具對等。
+
+## 目標
+
+一個由不同模型交互審查、且**可驗證**(不是靠信任)的收工閘門:
+
+1. 其中一個工具(Claude 或 Codex)實作,**另一個**工具審查。
+2. 實作方想收工時,Stop hook 觸發,檢查 plan 檔是否有**有效**的審核通過 marker。
+3. marker 無效或不存在 → 擋下收工,指示去跑交互審查 orchestrator。
+4. orchestrator 驅動審查方 CLI review 實作方的 diff,雙方有界地來回,直到審查方
+   明確通過。
+5. 通過後由審查流程寫入 marker;marker **同時綁定 reviewer artifact 與被審查內容雜湊**,
+   下次 Stop hook 重算比對一致才放行。
+6. 全程只在**被明確 arm 的 session**生效,不污染其他對話。
+
+### 非目標(本版不做)
+- 不做三方以上審查;先把 Claude↔Codex 兩方跑順。
+- 不做 GitHub PR 上的雲端審查(那是 `/code-review ultra` 的範疇)。
+- 不在 Stop hook 內部直接 spawn 審查方 CLI(見「架構原則」)。
+
+---
+
+## 架構原則(先讀,違反就是設計錯)
+
+1. **Hook 要薄、要 deterministic、不呼叫 LLM。** Stop gate 只做「驗 marker/artifact
+   有效性」這件純檢查(讀檔、驗欄位、算 hash、比對),絕不在 hook 裡跑 `codex` /
+   `claude` 子行程。真正的審查迴圈放在 `/goldband-cross-review run` 背後的
+   程式化 orchestrator。
+2. **hash 只防 drift,不防同權限偽造。** 實作方對 plan 檔有寫入權,所以 plan marker
+   光有文字與 `reviewed-sha` 不足以證明另一個模型真的審過。`reviewed-sha` 只能防
+   「approve 後又改碼」或「審查 scope 與現況不一致」。要防假 approval,還必須保存
+   reviewer artifact(審查方原始輸出、verdict JSON、transcript 摘要、CLI exit/status)
+   到 `${GOLDBAND_HOME}` 下由 orchestrator 寫入的 artifact 檔,marker 只引用該 artifact。
+3. **審查方必須是另一個模型。** 價值來自跨模型;orchestrator 與 gate 契約都要強制
+   `reviewer != implementer`。
+4. **不是叫 AI 自己去讀 review skill。** 實作方不需要讀 `goldband-loop/review`;
+   審查方也不需要自行 discover/invoke review skill。orchestrator 會程式化讀取
+   `goldband-loop/cross-review/reviewer-prompt.md` 與 `rubric.md`,再把 diff、plan、
+   上輪 findings、實作方回應一起餵給審查方 CLI。
+5. **討論可以自由,結論要固定格式。** 每輪允許審查方提出 blocker、實作方修正或反駁、
+   審查方接受/拒絕反駁;但每輪最後必須輸出可 parse verdict,讓 gate 能判定。
+6. **收斂要有界。** 用嚴重度閘、回合上限、rubric 綁定、移動門柱禁令四道機制,避免
+   審查方無限挑毛病;到達回合上限則升級給人類仲裁,不得無限迴圈。
+7. **人類永遠有逃生門。** 任何時候可用 override 指令解除閘門,避免把使用者鎖死在
+   一個無法收斂的 session。
+8. **雙 host 對等。** Claude 與 Codex 兩側 hook、installer、README、inventory 一起
+   更新;未同步前不得宣稱 dual-tool parity(見 repo `CLAUDE.md`)。
+
+---
+
+## 觸發設計(重點:不是整個對話都開)
+
+核心機制:**gate 契約檔以 session_id 為 key**。Stop hook input 帶 `session_id`;
+沒有對應契約檔 = 這個 session 沒被 arm = gate 完全不介入。三種 arm 途徑,由弱到強:
+
+### A. 顯式指令 arm(預設、最推薦)
+使用者明確宣告「這件工作要交互審查」:
+
+```
+/goldband-cross-review start --plan docs/plans/feature-x.md --reviewer codex
+```
+
+寫出契約檔(見下)。工作跑完、marker 驗證通過後自動 disarm;或手動
+`/goldband-cross-review done`。
+
+### B. 單則訊息內的指令詞 arm(回答你「某次訊息需要」)
+新增一個 `UserPromptSubmit` step:Claude 側目前是 skill suggestion hook;Codex 側是
+`codex/hooks/hook-router.js`。實作時要先確認兩側實際 hook surface,再接入同一套 arm
+邏輯。當該則使用者訊息含指令詞
+(例如 `[[cross-review]]` 或中文「開啟交互審查」),就地 arm 當前 session,並嘗試
+從訊息推斷 plan 檔;推斷不到就在契約檔標 `planFile: null`,Stop 時提示補綁。
+這讓「只有這次訊息需要」成立:不下指令詞的訊息完全不受影響。
+
+### C. plan 檔宣告(選配、與 A/B 疊加)
+plan 檔 front-matter 或檔頭放 `cross-review: required`。arm 時 orchestrator 讀到
+就沿用該設定。這只是「宣告來源」,實際開關仍是 session 契約檔的存在與否。
+
+> 設計取捨:arm 一旦成立會**持續**到通過審查或 disarm,無法對「已送出的過去訊息」
+> 追溯開啟。這是刻意的——閘門要在工作開始時宣告,語意才乾淨。
+
+### gate 契約檔 schema
+路徑:`${GOLDBAND_HOME:-$HOME/.goldband}/cross-review/<session_id>.json`
+(放持久資料路徑而非 repo,避免把 session 狀態 commit 進版控)。
+
+```json
+{
+  "schemaVersion": 1,
+  "sessionId": "…",
+  "host": "claude",
+  "implementer": "claude",
+  "reviewer": "codex",
+  "planFile": "docs/plans/feature-x.md",
+  "baseCommit": "<arm 時的 git HEAD sha>",
+  "reviewScope": "tracked-and-untracked-vs-base",
+  "maxRounds": 3,
+  "roundsUsed": 0,
+  "status": "active",
+  "armedAt": "2026-07-05T…Z",
+  "expiresAt": "2026-07-06T…Z"
+}
+```
+
+- `expiresAt`:TTL(預設 24h),過期契約 Stop hook 視為未 arm,避免殭屍閘門。
+- `status`:`active | passed | overridden | expired`。
+
+---
+
+## marker / verdict 協定(可驗證的核心)
+
+### 審查方輸出的結構化 verdict(不要 parse 自然語言)
+審查方每回合須輸出一行機器可讀 verdict,並保存完整 artifact:
+
+```
+GOLDBAND-CROSS-REVIEW-VERDICT: <APPROVED|CHANGES_REQUESTED|ESCALATE>
+  reviewer=<codex|claude> reviewed-sha=<sha256> round=<n>
+  blocking=<count> advisory=<count> artifact=<artifact-id>
+```
+
+外加結構化 findings(JSON),每筆:`{severity, ruleId, file, line, failureScenario,
+status: open|resolved|rebutted-accepted|rebutted-rejected}`。
+
+artifact 存在 `${GOLDBAND_HOME:-$HOME/.goldband}/cross-review/artifacts/`,至少包含:
+`sessionId`,`reviewer`,`implementer`,`baseCommit`,`reviewedSha`,`round`,
+`verdict`,`findings`,`reviewerCommand`,`reviewerExitCode`,`rawOutputPath`,
+`createdAt`。Stop gate 不相信 plan marker 本身;它要能讀到 marker 指向的 artifact,
+確認 artifact 的 `reviewedSha`、`reviewer`、`implementer`、`sessionId` 與契約一致。
+
+### 寫進 plan 檔尾的 marker(人類可見 + 機器可驗)
+審查通過後,orchestrator(代表審查方)在 plan 檔尾追加:
+
+```
+<!-- GOLDBAND-CROSS-REVIEW: APPROVED reviewer=codex implementer=claude
+     reviewed-sha=<sha256-of-review-scope-diff> rounds=2
+     artifact=<artifact-id> at=2026-07-05T…Z session=<session_id> -->
+```
+
+### reviewed-sha 的定義(必須明確且 deterministic)
+`review scope` 必須包含 tracked 與 untracked 工作內容,否則新增但未 staged 的檔案會
+逃過審查。實作時二選一,並在 Phase 0 固定:
+
+- **建議方案**:`review scope` = canonical bundle,由下列內容組成:
+  1. `git -c core.autocrlf=false diff --no-ext-diff --binary <baseCommit>`
+  2. `git ls-files --others --exclude-standard -z` 排序後,逐檔寫入
+     `UNTRACKED <path>\0<sha256(file-bytes)>\0<file-bytes>`。
+- **簡化方案**:強制 orchestrator review 前先要求所有被審查檔案 staged,並用
+  `git diff --cached --binary <baseCommit>`;若有 untracked 或 unstaged tracked 變更,
+  orchestrator 與 Stop gate 都必須 block。
+
+`reviewed-sha` = canonical bundle bytes 的 sha256。Stop hook 放行前用同一份
+`baseCommit` 與同一個 canonicalizer 重算,一致才放行。
+
+### Stop hook gate 判定流程(純檢查,無 LLM)
+於 `evaluateStop` 內新增 `evaluateCrossReviewGate(input)`:
+
+1. 讀 `session_id` → 找契約檔。無 / 過期 / `status != active` → **allow**(不介入)。
+2. 契約 `planFile == null` → **block**,提示先綁 plan 檔。
+3. 讀 plan 檔尾 marker。無 marker → **block**,注入:「本工作在交互審查閘門下,
+   請執行 `/goldband-cross-review run`,由 {reviewer} 審查後才能收工。」
+4. 有 marker → 讀 marker 指向的 artifact,驗證 artifact 存在且 `reviewer != implementer`,
+   `reviewer`/`implementer`/`sessionId`/`baseCommit` 與契約一致,且 verdict 為
+   `APPROVED`。再用契約 `baseCommit` 重算現況 `reviewed-sha`:
+   - 一致 → **allow**;把契約標 `status: passed`(自動 disarm)。這只結束本次已 arm
+     工作,不代表同一 session 後續新工作自動通過。
+   - 不一致 → **block**:「程式碼在通過後又變動(approved-sha ≠ now-sha),需重審。」
+5. **防迴圈**:契約 `status == overridden` → allow;`roundsUsed >= maxRounds` 且仍無
+   有效 marker → **block** 但改注入「升級人類仲裁」訊息(附雙方立場摘要路徑),
+   不再叫它自己重跑。搭配 Stop input 的 `stop_hook_active` 避免 hook 自我觸發風暴。
+
+---
+
+## 交互審查 orchestrator(驅動迴圈的程式入口)
+
+新增 `/goldband-cross-review run` 指令,由程式化 orchestrator 驅動。
+`goldband-loop/cross-review/` 是內部 runtime asset,**不暴露成一般對話入口 skill**,
+不需要 trigger/preamble,也不讓使用者或 reviewer 直接 invoke。使用者面只暴露
+`/goldband-cross-review start|run|done|override`;審查方 CLI 只收到 orchestrator 組好的
+bounded prompt。
+
+orchestrator 的責任:
+
+1. 讀契約檔、專用 reviewer prompt、專用 rubric。
+2. 算 canonical review scope 與 `reviewed-sha`。
+3. spawn 另一個模型 CLI。
+4. 把 diff、plan、rubric、上一輪 findings、實作方回應/修正摘要一起傳給審查方。
+5. 解析審查方 verdict/findings,保存 artifact。
+6. 在通過時寫 marker;未通過時把下一輪需要的 blocker 與實作方待回應事項寫入狀態。
+
+原有 `goldband-loop/review` / `goldband-loop/codex` 只能作為 review 原則與既有 CLI
+呼叫方式的參考來源;不得在 runtime 要求實作方或審查方「去讀那個 skill 再自己決定」。
+新的 cross-review 內容若放在 `goldband-loop/cross-review/`,也應被安裝成 command
+可讀取的資料/程式,不是一般對話可主動選用的 skill。
+
+### 單回合流程
+1. 讀契約 → 算 review scope diff + `reviewed-sha`。
+2. 組 reviewer prompt:專用 prompt + rubric + diff + plan 檔 + 上一回合 findings +
+   實作方上一回合修正/反駁。
+3. 呼叫審查方 CLI(見「跨工具呼叫」),審查方可以用自然語言分析與回應反駁,但最後
+   必須輸出結構化 verdict + findings。
+4. 解析審查方的結構化 verdict + findings,保存完整 artifact 與 raw output。
+5. 分流:
+   - `APPROVED` → 寫 artifact → 寫 marker(綁 `reviewed-sha` 與 artifact id)→ 契約
+     `status: passed` → 結束。
+   - `CHANGES_REQUESTED` → 對每筆 **CRITICAL/HIGH** open finding,實作方擇一:
+     (a) 修正(改碼);(b) 反駁(附理由與證據);(c) 請人類裁決。MEDIUM/LOW 記為
+     plan 內 follow-up,不擋收工。orchestrator 記錄實作方回應,`roundsUsed++`,
+     回到步驟 1(diff 或回應變了 → 需重審)。
+   - `ESCALATE` 或 `roundsUsed >= maxRounds` → 產出雙方立場摘要檔,契約保持 active,
+     Stop hook 會以「人類仲裁」訊息擋收工,等使用者裁決或 override。
+
+### 實作方辯解/修正協定
+
+實作方每輪對 blocking findings 的回應要被 orchestrator 記錄成結構化資料,而不是只
+留在聊天紀錄裡:
+
+```json
+{
+  "findingId": "CR-001",
+  "response": "fixed | rebutted | ask-human",
+  "summary": "已補 canonical bundle 覆蓋 untracked files",
+  "evidence": ["tests/cross-review-hash.test.js", "node scripts/test-cross-review.mjs"]
+}
+```
+
+下一輪 reviewer prompt 必須包含這些回應。審查方可以接受反駁
+(`rebutted-accepted`)、拒絕反駁(`rebutted-rejected`)、或確認修正已解
+(`resolved`)。這就是有界討論:可以辯解,但每輪都要落回 findings 狀態與 verdict。
+
+### 防「無限挑毛病」四道機制(全部要實作)
+1. **嚴重度閘**:只有 CRITICAL/HIGH 能擋 marker;MEDIUM/LOW 一律 advisory。
+2. **回合上限**:`maxRounds`(預設 3),超過即升級人類,不再自動續跑。
+3. **rubric 綁定**:每筆 blocking finding 必須帶 `ruleId`(對到共享 rubric)與具體
+   `failureScenario`。缺任一 → 自動降級為 advisory(不得擋人)。
+4. **移動門柱禁令**:第 2 回合起,審查方只能 (a) 判定既有 blocker 已解/未解,或
+   (b) 提出**新的 CRITICAL 且是實作方本回修正引入的 regression**。不得對無關新點
+   重開戰場。已被接受的反駁(`rebutted-accepted`)之後不得再提。
+
+### 共享 rubric
+`goldband-loop/cross-review/rubric.md`:分級列出 blocking 類別(正確性、安全、資料
+遺失、契約破壞、明確 regression)與 advisory 類別(風格、命名、微效能、可讀性)。
+審查方 prompt 必須引用它,把「可否擋人」變成規則而非品味。
+
+---
+
+## 跨工具呼叫(reviewer adapter)
+
+- **Claude 實作 → Codex 審查**:adapter 以 `codex exec` 或可驗證的 `codex review`
+  模式呼叫 Codex,但 prompt 由 cross-review orchestrator 產生。現有
+  `goldband-loop/codex` 的 `[P1]`/`[P2]` gate 只能當參考,不能直接當本 gate 的機器契約。
+- **Codex 實作 → Claude 審查**:adapter 以 `claude -p`(headless)呼叫 Claude,同樣餵
+  cross-review 專用 prompt/rubric,不得要求 Claude 自己讀 `goldband-loop/review` skill。
+- 兩個 adapter 共用同一 verdict/findings schema 與 rubric,讓方向對稱、可互換。
+- adapter 必須斷言 `reviewer` 模型家族 ≠ `implementer`,否則拒跑(避免自審)。
+- adapter 的輸入必須是 bounded bundle(diff、plan、rubric、finding history、
+  implementer responses),不要把整包原有 review skill 當 prompt 塞給 reviewer。
+
+---
+
+## 元件清單與落點
+
+| 元件 | 路徑 | 說明 |
+|---|---|---|
+| Stop gate(純檢查) | `hooks/scripts/lib/hook-router/cross-review-gate.js` | `evaluateStop` 內呼叫 |
+| Codex 對稱 gate | `codex/hooks/…`(對應 router) | 同邏輯、共享 lib 為佳 |
+| arm/disarm 指令 | `commands/…` + `goldband-loop/cross-review` | A 途徑 |
+| UserPromptSubmit arm step | router lifecycle | B 途徑(指令詞) |
+| orchestrator command | `goldband-loop/cross-review/` | 內部 runtime asset,不暴露成對話入口 skill |
+| reviewer prompt | `goldband-loop/cross-review/reviewer-prompt.md` | 審查方固定任務與輸出格式 |
+| rubric | `goldband-loop/cross-review/rubric.md` | 可否擋人的規則 |
+| implementer response log | `${GOLDBAND_HOME}/cross-review/responses/` | 修正/反駁/人類裁決紀錄 |
+| reviewer adapters | `codex`/`claude -p` adapter | 雙向對稱 |
+| verdict/marker schema | `schemas/cross-review-*.json` | 共享契約 |
+| reviewer artifact store | `${GOLDBAND_HOME}/cross-review/artifacts/` | verdict/raw output/metadata |
+| 契約檔 | `${GOLDBAND_HOME}/cross-review/<session>.json` | 執行期狀態 |
+| override 指令 | `/goldband-cross-review override` | 人類逃生門 |
+| telemetry | 沿用 `usage-telemetry.js` | 記回合/verdict/升級 |
+
+---
+
+## Decision Check
+- **建議方向**:session_id 綁定的 gate 契約 + reviewer artifact + 內容雜湊綁定的
+  marker + 薄 Stop hook + 獨立 orchestrator 迴圈。
+- **為何現在合適**:精準解決「不要整場對話都開」與「approve 後內容漂移」兩個核心風險,
+  且可複用既有 router / stop-policy / CLI 呼叫經驗。注意:現有 review skill 不是
+  本 gate 所需的機器契約,只能作為 rubric/prompt 設計參考。
+- **必須成立的假設**:Claude Code 與 Codex 的 Stop hook input 都提供穩定的
+  `session_id` 與 `stop_hook_active`;Codex Stop hook 有可驗證的 blocking 方式;headless
+  `claude -p` 與 `codex` 都能非互動輸出結構化文字。**Phase 0 必須先實測這些假設**。
+- **次佳方案**:若 session_id 不穩定,退回「plan 檔內 front-matter 開關 + 檔案雜湊」
+  純檔案驅動閘門(丟失 session 粒度,但仍可運作)。當「B 途徑指令詞 arm」無法可靠
+  拿到 session_id 時切換。
+
+## Pre-Mortem
+- **失敗模式**:Stop hook 把不該擋的一般 session 擋住(誤傷)。**早期訊號**:未 arm
+  的 session 出現 gate 訊息。**退路**:gate 第一步「無契約即 allow」要有單元測試與
+  replay fixture 守護,預設完全不介入。
+- **失敗模式**:reviewed-sha 因 diff 不 deterministic(檔案順序、CRLF)而時好時壞。
+  **早期訊號**:同一份碼重算 hash 不一致。**退路**:固定 `git -c core.autocrlf=false
+  diff` 參數並排序 pathspec,對 hash 輸入做正規化,並寫 golden 測試。
+- **失敗模式**:審查方仍變相無限挑毛病(靠升 severity 繞過閘)。**早期訊號**:回合數
+  逼近上限、blocking findings 每回換題目。**退路**:移動門柱禁令 + rubric 降級 +
+  回合上限升級人類。
+- **失敗模式**:實作方的反駁留在聊天裡,下一輪 reviewer 看不到。**早期訊號**:同一個
+  finding 反覆重講、審查方沒有處理 rebuttal。**退路**:orchestrator 必須保存
+  implementer response log,下一輪 prompt 必須引用。
+- **失敗模式**:新增但未 staged 的檔案未被 hash/review 包住。**早期訊號**:review 通過
+  但 `git status --short` 還有 `??` 或 unstaged entries。**退路**:canonical bundle
+  包 untracked,或採 staged-only 並硬擋 dirty scope。
+- **失敗模式**:marker 被同權限實作方偽造。**早期訊號**:plan marker 存在但沒有對應
+  reviewer artifact / raw output。**退路**:Stop gate 要求 artifact 存在且欄位一致;
+  文件不得宣稱這能抵抗有意偽造,只能抵抗 drift 與缺證據。
+- **未知待驗證**:(1) 兩 host 的 Stop input 欄位實測;(2) Codex Stop hook blocking
+  語意;(3) `claude -p` 對長 diff 的穩定輸出;(4) override 指令如何在被 Stop hook 擋住的
+  session 內仍能執行(可能需 PreToolUse allow-list 讓 override 指令永遠可跑)。
+
+## Implementation Phases
+
+### Phase 0:協定與驗證 spike(先做,別跳)
+- 定 verdict/findings/marker/artifact/implementer-response JSON schema 於 `schemas/`。
+- 寫 replay/fixture 小腳本實測 Claude 與 Codex 的 Stop hook input,確認 `session_id`/
+  `stop_hook_active` 欄位存在且穩定。
+- 實測 Claude Stop blocking 與 Codex Stop blocking:要能證明「block 會阻止收工」,
+  並記錄各自需要的輸出格式 / exit code / hookSpecificOutput。
+- 決定 reviewed-sha canonical bundle 規則,必須明確處理 tracked、staged、unstaged、
+  untracked、新增 binary、CRLF。寫 golden 測試。
+- 實測 `claude -p` 與 `codex` 能在非互動模式輸出可 parse verdict;不能穩定輸出時,
+  先停在 mock reviewer,不要接真 CLI。
+- Phase 0 結尾要輸出一份 `docs/reports/cross-review-phase-0.md`,列出 confirmed /
+  rejected / fallback decisions。未完成這份報告不得進 Phase 1。
+
+### Phase 1:Stop gate(純檢查,單 host 先行)
+- 實作 `cross-review-gate.js`:契約查找、marker 解析、artifact 驗證、hash 比對、
+  四種 block 訊息。
+- 接進 `evaluateStop`;預設「無契約即 allow」。
+- replay fixtures(比照 `hooks/fixtures/router/replay-fixtures.json`):未 arm/無
+  marker/marker 無 artifact/marker 有效/sha 不符/回合耗盡/override 六種情境。
+
+### Phase 2:arm/disarm + orchestrator 骨架
+- `/goldband-cross-review start|done|override` 指令與契約檔讀寫。
+- orchestrator command 骨架:算 canonical bundle、算 sha、寫 implementer response log、
+  artifact + marker(先用 **mock reviewer** 驗迴圈與收斂邏輯,不接真 CLI)。
+- 嚴重度閘、回合上限、rubric 降級、移動門柱禁令的單元測試(用 mock findings)。
+- 實作方回應流程測試:fixed / rebutted / ask-human 都要能進下一輪 reviewer prompt。
+
+### Phase 3:接真 reviewer(Claude→Codex 方向)
+- 把 `goldband-loop/codex` review 輸出升級成結構化 verdict + findings。
+- 併入 rubric;端到端跑一次真實 Claude 實作 → Codex 審查。
+
+### Phase 4:反向對稱(Codex→Claude)+ 雙 host 對等
+- `claude -p` reviewer adapter;Codex 側 Stop gate。
+- 更新 installer、README、inventory 文件;跑 repo 的
+  `/claude-config-verification` 與 `codex execpolicy check`。
+
+### Phase 5:B 途徑(指令詞 arm)+ telemetry + 收尾
+- UserPromptSubmit arm step 與指令詞解析。
+- telemetry:記 rounds / verdict / 升級 / override。
+- override 可執行性驗證(被擋 session 內仍能跑)。
+
+## Dependencies
+- 既有:`hook-router.js`、`stop-policy.js`、`goldband-loop/codex`、
+  `goldband-loop/review`、`usage-telemetry.js`、`utils.js` 的 git helpers。
+- 外部:`codex` CLI、`claude` CLI(headless `-p`)、`git`、Node、sha256(內建 crypto)。
+
+## Risks
+- **HIGH**:假 enforcement(marker 可被實作方偽造)。緩解:不要宣稱 hash 防偽;Stop gate
+  要求 reviewer artifact、raw output、契約欄位一致,並在文件中明確說這是 evidence gate,
+  不是抵抗同權限惡意偽造的安全邊界。
+- **HIGH**:review scope 漏掉 untracked/unstaged 新檔。緩解:canonical bundle 納入
+  untracked,或採 staged-only 並硬擋 dirty scope。
+- **HIGH**:誤傷未 arm 的一般 session。緩解:預設不介入 + fixtures 守護。
+- **MEDIUM**:審查方無限挑毛病。緩解:四道收斂機制 + 人類升級。
+- **MEDIUM**:reviewed-sha 非 deterministic。緩解:輸入正規化 + golden 測試。
+- **MEDIUM**:雙 host 不對等(只做了 Claude)。緩解:Phase 4 強制同步 + 驗證工作流。
+- **LOW**:契約殭屍檔。緩解:TTL `expiresAt` + 過期即視為未 arm。
+
+## Estimated Complexity: HIGH
+(跨 host、涉及 hook 阻擋語意、跨模型子行程、可驗證協定;但每個 phase 可獨立測試。)
+
+---
+
+## 完成準則(Definition of Done)
+- 未 arm 的 session 行為零改變(有測試證明)。
+- arm 後:無 marker 擋收工、marker 無 artifact 擋收工、artifact 欄位不一致擋收工、
+  sha 不符擋收工、真通過放行,皆有端到端證據。
+- `reviewed-sha` 測試覆蓋 tracked、staged、unstaged、untracked、新增 binary、CRLF。
+- Claude 與 Codex Stop blocking 語意都用 fixture 或實測證明;未證明前不得宣稱雙向
+  enforced gate。
+- 至少一次真實 Claude↔Codex 雙向交互審查跑通,含一次「審查方擋、實作方修正後通過」
+  與一次「反駁被接受」的紀錄,且反駁必須來自 implementer response log 而非聊天記憶。
+- 回合上限觸發時升級人類、override 可解閘,皆有證據。
+- installer / README / inventory / Codex 側同步,`/claude-config-verification` 通過。
+
+> 開始前請先用 `/goldband-plan-eng-review` 對本計畫做工程審查(本 repo 慣例:複雜、
+> 跨模組的計畫先審再做),再進 Phase 0。

--- a/docs/reports/cross-review-phase-0.md
+++ b/docs/reports/cross-review-phase-0.md
@@ -1,0 +1,61 @@
+# Cross-Review Phase 0 Report
+
+Date: 2026-07-05
+
+## Confirmed
+
+- Claude Stop blocking is wired through `hooks/scripts/hooks/hook-router.js`: a policy result with `decision: "block"` exits with status `2`.
+- The cross-review Stop gate is deterministic. It reads the session contract, plan marker, reviewer artifact, and review-scope hash; it does not spawn Claude, Codex, or any LLM.
+- Review scope is `tracked-and-untracked-vs-base`: `git -c core.autocrlf=false diff --no-ext-diff --binary <baseCommit>` plus sorted untracked file bytes.
+- The hash covers tracked unstaged changes, staged changes, untracked text, untracked binary bytes, and CRLF bytes. This is covered by `node scripts/test-cross-review.mjs`.
+- The reviewer prompt uses the same bounded review scope family as the hash: tracked diff plus sorted untracked file names, sha256 values, and text content or base64 bytes.
+- Reviewer and implementer must be different host families in the runtime contract and schema.
+- Mock reviewer mode can write a reviewer artifact and plan marker for contract tests, but Stop rejects mock artifacts as production approval evidence.
+- UserPromptSubmit trigger arming is implemented for `[[cross-review]]` and `開啟交互審查`, scoped by `session_id`.
+- The local Codex CLI can produce a parseable cross-review verdict in headless mode when run with the required local app-server permissions. A real `codex` reviewer smoke produced an `APPROVED` artifact through `goldband-cross-review run --review-mode real`.
+- The local Claude CLI is logged in when run with normal user keychain access. A real `claude` reviewer smoke produced an `APPROVED` artifact through `goldband-cross-review run --review-mode real`.
+- A real Codex reviewer E2E produced `CHANGES_REQUESTED` for a contract-violating diff, then produced `APPROVED` after the diff was fixed.
+- A real Claude reviewer accepted an implementer rebuttal from the recorded response log. Round 1 had `CR-001` open; round 2 returned `APPROVED` with `CR-001` set to `status: "rebutted-accepted"`.
+- Codex Stop hard-blocking works through hook process exit code `2` with a stderr message. A live probe showed `hook: Stop Blocked`, the turn did not complete on the blocked response, and a second Stop pass completed only after the hook returned success.
+- The repo-wired Codex cross-review gate now reaches the same `Stop Blocked` path in a live `codex exec` probe. The probe armed a contract from `[[cross-review]]`, left it `active`, and timed out after Codex re-entered the turn instead of finishing.
+- Reaching max rounds or an `ESCALATE` verdict writes an escalation summary under `${GOLDBAND_HOME:-$HOME/.goldband}/cross-review/summaries/`; Stop human-arbitration messages include that path when available.
+- Cross-review runtime telemetry records arm, round verdict, implementer response, escalation, override, and done events as v1-compatible usage events.
+- `CHANGES_REQUESTED` never rewrites to `APPROVED`; malformed or missing findings for a non-approval verdict fail closed through `ESCALATE`.
+- Round 2+ moving-goalpost protection still allows a new `HIGH` `regression.clear` blocker introduced by the implementer's latest fix.
+- Re-sending a cross-review trigger for an already active session does not reset `roundsUsed` or `baseCommit`; it only fills a missing `planFile` when the prompt supplies one.
+
+## Rejected
+
+- Running a reviewer CLI from a Stop hook is rejected. The hook remains a pure check.
+- Treating a plan marker alone as proof is rejected. The gate requires a matching artifact and current `reviewed-sha`.
+- Claiming hash-based anti-forgery is rejected. The hash catches drift, not malicious same-permission tampering.
+- Treating cross-review as a security boundary is rejected. It is an evidence gate for accidental-completion prevention and cross-model review discipline, not protection against a same-permission operator forging state or artifacts.
+- Treating Codex Stop JSON output as a hard block is rejected. Live probes showed `systemMessage`, `additionalContext`, `permissionDecision: "deny"`, `decision.behavior: "deny"`, and top-level `decision: "block"` did not prevent final output; some only made the hook show `Stop Failed`.
+
+## Fallback Decisions
+
+- `goldband-cross-review run` defaults to `real` reviewer mode. CI and local contract tests must opt into `--review-mode mock`, and mock artifacts cannot satisfy the Stop gate.
+- Codex cross-review Stop blocks use process exit `2` rather than JSON hook output. Advisory Stop checks still use `systemMessage` so they do not create completion loops.
+- A permanently failing Stop hook causes Codex to keep re-entering the turn. The cross-review gate therefore exits `2` only while the session contract remains active and invalid; `override`, expiry, or a valid marker/artifact/sha lets the hook return success.
+- The official Codex manual documents `Stop` as a turn-scope lifecycle hook and documents hook discovery/trust behavior, but the fetched manual section did not provide a Stop-specific JSON deny contract. The implementation relies on the empirical exit-code behavior above.
+- Block messages include the installed `goldband-loop/bin/goldband-cross-review` wrapper path when available. This avoids telling Codex to run `/goldband-cross-review`, which noninteractive shell execution treats as a missing absolute path.
+- Cross-review telemetry uses the existing usage-event schema with `category: "hook-decision"` and `name: "cross-review-*"`, rather than introducing a new telemetry category.
+- Claude auth checks must be run with normal user keychain access. A restricted sandbox can report a false negative and must not be treated as proof that the user is logged out.
+- Claude Stop handling short-circuits on `stop_hook_active` to avoid recursive Stop-hook storms; Codex hard-blocks by exiting the hook with status `2` and re-entering the turn. This means the two host interactions are enforced through different mechanics even though they share gate validation.
+- If a session has no contract, the gate allows immediately. This protects unrelated sessions from false interception.
+
+## Verification Commands
+
+```bash
+node scripts/test-cross-review.mjs
+npm run test:cross-review
+npm run test:hook-router -- --fixtures hooks/fixtures/router/cross-review-fixtures.json
+node scripts/test-codex-hook-router.mjs
+python3 scripts/check-json-toml-syntax.py
+codex features list
+claude auth status
+claude -p --output-format text --no-session-persistence
+goldband-loop/bin/goldband-cross-review run --review-mode real
+codex exec --ephemeral --sandbox read-only --dangerously-bypass-hook-trust -c 'hooks.Stop=[...]'
+/opt/homebrew/bin/timeout 25 codex exec --ephemeral --sandbox read-only --skip-git-repo-check -
+```

--- a/goldband-loop/bin/goldband-cross-review
+++ b/goldband-loop/bin/goldband-cross-review
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec node "$SCRIPT_DIR/../cross-review/cli.cjs" "$@"

--- a/goldband-loop/cross-review/cli.cjs
+++ b/goldband-loop/cross-review/cli.cjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+const {
+  appendResponse,
+  createContract,
+  crossReviewDir,
+  markDone,
+  overrideContract,
+  readContract,
+  runReviewRound,
+} = require('./core.cjs');
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let index = 2; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) {
+      args._.push(token);
+      continue;
+    }
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = next;
+    index += 1;
+  }
+  return args;
+}
+
+function requireValue(args, key) {
+  if (!args[key]) throw new Error(`missing --${key}`);
+  return args[key];
+}
+
+function printJson(payload) {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function usage() {
+  console.log(`Usage:
+  goldband-cross-review start --plan <path> --reviewer <codex|claude> [--implementer <claude|codex>] [--session-id <id>]
+  goldband-cross-review run [--session-id <id>] [--review-mode mock|real] [--mock-verdict APPROVED|CHANGES_REQUESTED|ESCALATE]
+  goldband-cross-review respond --session-id <id> --finding-id <id> --response fixed|rebutted|ask-human --summary <text> [--evidence <path>]
+  goldband-cross-review done --session-id <id>
+  goldband-cross-review override --session-id <id> --reason <text>
+  goldband-cross-review status --session-id <id>`);
+}
+
+function commandStart(args) {
+  const contract = createContract({
+    sessionId: args['session-id'],
+    implementer: args.implementer,
+    reviewer: requireValue(args, 'reviewer'),
+    planFile: requireValue(args, 'plan'),
+    maxRounds: args['max-rounds'],
+    ttlHours: args['ttl-hours'],
+    cwd: process.cwd(),
+  });
+  printJson({ status: 'armed', contractPath: `${crossReviewDir()}/${contract.sessionId}.json`, contract });
+}
+
+function commandRun(args) {
+  const result = runReviewRound({
+    sessionId: args['session-id'],
+    reviewMode: args['review-mode'] || 'real',
+    mockVerdict: args['mock-verdict'] || 'APPROVED',
+    cwd: process.cwd(),
+  });
+  printJson({ status: statusForReviewArtifact(result.artifact), ...result });
+}
+
+function statusForReviewArtifact(artifact) {
+  if (artifact.verdict === 'APPROVED') return 'approved-marker-written';
+  if (artifact.verdict === 'CHANGES_REQUESTED') return 'changes-requested';
+  return 'escalated';
+}
+
+function commandRespond(args) {
+  const evidence = args.evidence
+    ? String(args.evidence)
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean)
+    : [];
+  const response = appendResponse(requireValue(args, 'session-id'), {
+    findingId: requireValue(args, 'finding-id'),
+    response: requireValue(args, 'response'),
+    summary: requireValue(args, 'summary'),
+    evidence,
+  });
+  printJson({ status: 'recorded', response });
+}
+
+function commandDone(args) {
+  const contract = markDone(requireValue(args, 'session-id'), process.cwd());
+  printJson({ status: 'done', contract });
+}
+
+function commandOverride(args) {
+  const contract = overrideContract(requireValue(args, 'session-id'), requireValue(args, 'reason'));
+  printJson({ status: 'overridden', contract });
+}
+
+function commandStatus(args) {
+  const contract = readContract(requireValue(args, 'session-id'));
+  printJson({ status: contract ? contract.status : 'not-armed', contract });
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const command = args._[0];
+  if (!command || command === 'help') {
+    usage();
+    return;
+  }
+  if (command === 'start') return commandStart(args);
+  if (command === 'run') return commandRun(args);
+  if (command === 'respond') return commandRespond(args);
+  if (command === 'done') return commandDone(args);
+  if (command === 'override') return commandOverride(args);
+  if (command === 'status') return commandStatus(args);
+  throw new Error(`unknown command: ${command}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`goldband-cross-review: ${error.message}`);
+  process.exit(1);
+}

--- a/goldband-loop/cross-review/core.cjs
+++ b/goldband-loop/cross-review/core.cjs
@@ -1,0 +1,1142 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const {
+  normalizeUsageEvent,
+} = require('../../scripts/lib/telemetry-schema.cjs');
+
+const CONTRACT_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_ROUNDS = 3;
+const DEFAULT_TTL_HOURS = 24;
+const VALID_HOSTS = new Set(['claude', 'codex']);
+const VALID_STATUSES = new Set(['active', 'passed', 'overridden', 'expired']);
+const VERDICTS = new Set(['APPROVED', 'CHANGES_REQUESTED', 'ESCALATE']);
+const MARKER_PREFIX = 'GOLDBAND-CROSS-REVIEW';
+const CODE_FENCE_PATTERN = /```[\s\S]*?```/g;
+const INLINE_CODE_PATTERN = /`[^`\n]*`/g;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function stateRoot(env = process.env) {
+  const explicit = firstEnv(env, [
+    'GOLDBAND_CROSS_REVIEW_ROOT',
+    'GOLDBAND_HOME',
+  ]);
+  if (explicit) return explicit;
+  if (env.CLAUDE_PLUGIN_DATA) return env.CLAUDE_PLUGIN_DATA;
+  if (env.GOLDBAND_DATA_DIR) return env.GOLDBAND_DATA_DIR;
+  return path.join(os.homedir(), '.goldband');
+}
+
+function firstEnv(env, names) {
+  for (const name of names) {
+    const value = env[name];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function crossReviewDir(env = process.env) {
+  if (env.GOLDBAND_CROSS_REVIEW_DIR) return env.GOLDBAND_CROSS_REVIEW_DIR;
+  return path.join(stateRoot(env), 'cross-review');
+}
+
+function artifactsDir(env = process.env) {
+  return path.join(crossReviewDir(env), 'artifacts');
+}
+
+function responsesDir(env = process.env) {
+  return path.join(crossReviewDir(env), 'responses');
+}
+
+function summariesDir(env = process.env) {
+  return path.join(crossReviewDir(env), 'summaries');
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+  return dirPath;
+}
+
+function safeSegment(value) {
+  return String(value || '').replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+function sessionIdFromInput(input = {}, env = process.env) {
+  return (
+    input.session_id ||
+    input.sessionId ||
+    env.CLAUDE_SESSION_ID ||
+    env.CODEX_SESSION_ID ||
+    null
+  );
+}
+
+function detectHost(env = process.env) {
+  if (env.GOLDBAND_IMPLEMENTER) return normalizeHost(env.GOLDBAND_IMPLEMENTER);
+  if (env.CODEX_SESSION_ID) return 'codex';
+  if (env.CLAUDE_SESSION_ID) return 'claude';
+  return 'claude';
+}
+
+function oppositeHost(host) {
+  const normalized = normalizeHost(host);
+  return normalized === 'claude' ? 'codex' : 'claude';
+}
+
+function normalizeHost(value) {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!VALID_HOSTS.has(normalized)) {
+    throw new Error(`expected host to be claude or codex, got: ${value}`);
+  }
+  return normalized;
+}
+
+function contractPath(sessionId, env = process.env) {
+  return path.join(crossReviewDir(env), `${safeSegment(sessionId)}.json`);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, payload) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function readContract(sessionId, env = process.env) {
+  if (!sessionId) return null;
+  const filePath = contractPath(sessionId, env);
+  if (!fs.existsSync(filePath)) return null;
+  return readJson(filePath);
+}
+
+function writeContract(contract, env = process.env) {
+  validateContract(contract);
+  writeJson(contractPath(contract.sessionId, env), contract);
+  return contract;
+}
+
+function usageTelemetryEnabled(env = process.env) {
+  const flag = String(env.GOLDBAND_USAGE_TELEMETRY_ENABLED ?? '1').toLowerCase();
+  return flag === '1' || flag === 'true' || flag === 'yes';
+}
+
+function usageFile(env = process.env) {
+  return env.GOLDBAND_USAGE_FILE || path.join(crossReviewDir(env), 'usage-events.jsonl');
+}
+
+function appendCrossReviewUsageEvent(entry, env = process.env) {
+  if (!usageTelemetryEnabled(env) || !entry || typeof entry !== 'object') return;
+  const payload = normalizeUsageEvent({
+    category: 'hook-decision',
+    action: 'record',
+    source: 'goldband-loop/cross-review',
+    host: 'goldband',
+    ...entry,
+    recordedAt: nowIso(),
+  });
+  try {
+    const filePath = usageFile(env);
+    ensureDir(path.dirname(filePath));
+    fs.appendFileSync(filePath, `${JSON.stringify(payload)}\n`, 'utf8');
+  } catch {
+    // Cross-review telemetry must never block the gate or orchestrator.
+  }
+}
+
+function validateContract(contract) {
+  if (!contract || typeof contract !== 'object') {
+    throw new Error('cross-review contract must be an object');
+  }
+  if (contract.schemaVersion !== CONTRACT_SCHEMA_VERSION) {
+    throw new Error(`unsupported cross-review schemaVersion: ${contract.schemaVersion}`);
+  }
+  if (!contract.sessionId) throw new Error('contract.sessionId is required');
+  normalizeHost(contract.host);
+  normalizeHost(contract.implementer);
+  normalizeHost(contract.reviewer);
+  if (contract.reviewer === contract.implementer) {
+    throw new Error('cross-review requires reviewer != implementer');
+  }
+  if (!VALID_STATUSES.has(contract.status)) {
+    throw new Error(`invalid contract.status: ${contract.status}`);
+  }
+  if (!contract.baseCommit) throw new Error('contract.baseCommit is required');
+  if (contract.reviewScope !== 'tracked-and-untracked-vs-base') {
+    throw new Error(`unsupported reviewScope: ${contract.reviewScope}`);
+  }
+}
+
+function createContract(options, env = process.env) {
+  const sessionId = options.sessionId || firstEnv(env, ['CLAUDE_SESSION_ID', 'CODEX_SESSION_ID']);
+  if (!sessionId) throw new Error('session id is required to arm cross-review');
+
+  const implementer = normalizeHost(options.implementer || detectHost(env));
+  const reviewer = normalizeHost(options.reviewer || oppositeHost(implementer));
+  if (implementer === reviewer) {
+    throw new Error('cross-review requires a different reviewer model family');
+  }
+
+  const armedAt = nowIso();
+  const ttlHours = parsePositiveInt(options.ttlHours, DEFAULT_TTL_HOURS);
+  const expiresAt = new Date(Date.parse(armedAt) + ttlHours * 60 * 60 * 1000).toISOString();
+  const contract = {
+    schemaVersion: CONTRACT_SCHEMA_VERSION,
+    sessionId,
+    host: implementer,
+    implementer,
+    reviewer,
+    planFile: options.planFile || null,
+    baseCommit: options.baseCommit || gitHead(options.cwd || process.cwd()),
+    reviewScope: 'tracked-and-untracked-vs-base',
+    maxRounds: parsePositiveInt(options.maxRounds, DEFAULT_MAX_ROUNDS),
+    roundsUsed: 0,
+    status: 'active',
+    armedAt,
+    expiresAt,
+  };
+  const written = writeContract(contract, env);
+  appendCrossReviewUsageEvent(
+    {
+      name: 'cross-review-armed',
+      action: 'enable',
+      sessionId: written.sessionId,
+      run_id: written.sessionId,
+      detail: {
+        implementer: written.implementer,
+        reviewer: written.reviewer,
+        planFile: written.planFile,
+        maxRounds: written.maxRounds,
+      },
+    },
+    env,
+  );
+  return written;
+}
+
+function gitHead(cwd) {
+  const result = spawnSync('git', ['rev-parse', 'HEAD'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(`failed to read git HEAD: ${result.stderr || result.stdout}`);
+  }
+  return result.stdout.trim();
+}
+
+function gitDiffBytes(cwd, baseCommit) {
+  const result = spawnSync(
+    'git',
+    ['-c', 'core.autocrlf=false', 'diff', '--no-ext-diff', '--binary', baseCommit],
+    { cwd, encoding: 'buffer', maxBuffer: 100 * 1024 * 1024 },
+  );
+  if (result.status !== 0) {
+    throw new Error(`failed to build cross-review diff: ${result.stderr.toString('utf8')}`);
+  }
+  return result.stdout;
+}
+
+function gitUntrackedFiles(cwd) {
+  const result = spawnSync('git', ['ls-files', '--others', '--exclude-standard', '-z'], {
+    cwd,
+    encoding: 'buffer',
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(`failed to list untracked files: ${result.stderr.toString('utf8')}`);
+  }
+  return result.stdout
+    .toString('utf8')
+    .split('\0')
+    .filter(Boolean)
+    .sort();
+}
+
+function canonicalReviewBundle(cwd, baseCommit) {
+  const diffBytes = normalizeGitDiff(gitDiffBytes(cwd, baseCommit));
+  const chunks = [
+    Buffer.from(`GOLDBAND-CROSS-REVIEW-BUNDLE v1\0base=${baseCommit}\0`, 'utf8'),
+    Buffer.from('TRACKED-DIFF\0', 'utf8'),
+    diffBytes,
+    Buffer.from('\0UNTRACKED-FILES\0', 'utf8'),
+  ];
+
+  for (const relPath of gitUntrackedFiles(cwd)) {
+    const absPath = path.resolve(cwd, relPath);
+    if (!absPath.startsWith(path.resolve(cwd) + path.sep)) continue;
+    const stats = fs.statSync(absPath);
+    if (!stats.isFile()) continue;
+    const bytes = stripMarkerBlocks(fs.readFileSync(absPath));
+    const fileSha = crypto.createHash('sha256').update(bytes).digest('hex');
+    chunks.push(Buffer.from(`UNTRACKED ${relPath}\0${fileSha}\0`, 'utf8'));
+    chunks.push(bytes);
+    chunks.push(Buffer.from('\0', 'utf8'));
+  }
+
+  return Buffer.concat(chunks);
+}
+
+function reviewScopePromptText(cwd, baseCommit) {
+  const sections = [
+    'GOLDBAND-CROSS-REVIEW-BUNDLE v1',
+    `base=${baseCommit}`,
+    '',
+    '## Tracked Diff',
+    normalizeGitDiff(gitDiffBytes(cwd, baseCommit)).toString('utf8') || '(empty)',
+    '',
+    '## Untracked Files',
+  ];
+
+  const untracked = gitUntrackedFiles(cwd);
+  if (untracked.length === 0) sections.push('(none)');
+  for (const relPath of untracked) {
+    const absPath = path.resolve(cwd, relPath);
+    if (!absPath.startsWith(path.resolve(cwd) + path.sep)) continue;
+    const stats = fs.statSync(absPath);
+    if (!stats.isFile()) continue;
+    const bytes = stripMarkerBlocks(fs.readFileSync(absPath));
+    const fileSha = crypto.createHash('sha256').update(bytes).digest('hex');
+    sections.push(`### UNTRACKED ${relPath}`);
+    sections.push(`sha256=${fileSha}`);
+    sections.push(bytes.includes(0) ? bytes.toString('base64') : bytes.toString('utf8'));
+  }
+
+  return sections.join('\n');
+}
+
+function normalizeGitDiff(buffer) {
+  if (buffer.includes(0)) return buffer;
+  const text = buffer.toString('utf8');
+  if (!looksLikeGitDiff(text)) return buffer;
+  const withoutMarkers = text.includes(MARKER_PREFIX)
+    ? stripMarkerBlocksFromGitDiff(text)
+    : text;
+  return Buffer.from(withoutMarkers.replace(/^@@ .* @@.*\r?\n/gm, ''), 'utf8');
+}
+
+function stripMarkerBlocks(buffer) {
+  if (buffer.includes(0)) return buffer;
+  const text = buffer.toString('utf8');
+  if (!text.includes(MARKER_PREFIX)) return buffer;
+  const stripped = looksLikeGitDiff(text)
+    ? stripMarkerBlocksFromGitDiff(text)
+    : stripPlainMarkerBlocks(text);
+  return Buffer.from(stripped, 'utf8');
+}
+
+function stripPlainMarkerBlocks(text) {
+  return text.replace(
+    /((?:\r?\n){0,2})<!-- GOLDBAND-CROSS-REVIEW:[\s\S]*?-->\r?\n?/g,
+    (match, leading) => {
+      if (!leading) return '';
+      if (match.includes('plan-eof-newline=false')) return '';
+      return leading.includes('\n\n') || leading.includes('\r\n\r\n')
+        ? leading.slice(0, leading.indexOf('\n') + 1)
+        : leading;
+    },
+  );
+}
+
+function looksLikeGitDiff(text) {
+  return /^diff --git /m.test(text);
+}
+
+function stripMarkerBlocksFromGitDiff(text) {
+  return text
+    .split(/(?=^diff --git )/m)
+    .map(stripMarkerBlocksFromGitDiffBlock)
+    .filter(Boolean)
+    .join('');
+}
+
+function stripMarkerBlocksFromGitDiffBlock(block) {
+  const stripped = block
+    .replace(
+      /^\+?\r?\n?\+<!-- GOLDBAND-CROSS-REVIEW:[\s\S]*?^\+.*?-->\r?\n?/gm,
+      '',
+    )
+    .replace(/^@@ .* @@.*\r?\n/gm, '');
+
+  if (!hasMeaningfulDiffLine(stripped)) return '';
+  return stripped;
+}
+
+function hasMeaningfulDiffLine(diffBlock) {
+  return diffBlock
+    .split(/\r?\n/)
+    .some((line) => /^[+-]/.test(line) && !/^(?:---|\+\+\+)/.test(line));
+}
+
+function reviewedSha(cwd, baseCommit) {
+  return crypto
+    .createHash('sha256')
+    .update(canonicalReviewBundle(cwd, baseCommit))
+    .digest('hex');
+}
+
+function parseMarker(planText) {
+  const markerPattern =
+    /<!--\s*GOLDBAND-CROSS-REVIEW:\s+APPROVED\s+([\s\S]*?)-->/g;
+  let match = markerPattern.exec(planText);
+  let last = null;
+  while (match) {
+    last = match[1];
+    match = markerPattern.exec(planText);
+  }
+  if (!last) return null;
+
+  const fields = {};
+  const keyValuePattern = /([A-Za-z][A-Za-z0-9-]*)=([^\s]+)/g;
+  let pair = keyValuePattern.exec(last);
+  while (pair) {
+    fields[pair[1]] = pair[2];
+    pair = keyValuePattern.exec(last);
+  }
+  return {
+    verdict: 'APPROVED',
+    reviewer: fields.reviewer || null,
+    implementer: fields.implementer || null,
+    reviewedSha: fields['reviewed-sha'] || null,
+    rounds: parsePositiveInt(fields.rounds, 0),
+    artifact: fields.artifact || null,
+    at: fields.at || null,
+    session: fields.session || null,
+  };
+}
+
+function markerText({ artifact, contract, planHadTrailingNewline = true }) {
+  return [
+    `<!-- ${MARKER_PREFIX}: APPROVED reviewer=${artifact.reviewer} implementer=${artifact.implementer}`,
+    `     reviewed-sha=${artifact.reviewedSha} rounds=${artifact.round}`,
+    `     artifact=${artifact.artifactId} at=${artifact.createdAt} session=${contract.sessionId}`,
+    `     plan-eof-newline=${planHadTrailingNewline ? 'true' : 'false'} -->`,
+  ].join('\n');
+}
+
+function appendApprovalMarker(planFile, artifact, contract, cwd = process.cwd()) {
+  const target = resolvePlanFile(planFile, cwd);
+  const current = fs.existsSync(target) ? fs.readFileSync(target, 'utf8') : '';
+  const planHadTrailingNewline = current.endsWith('\n');
+  const separator = current.length === 0 || planHadTrailingNewline ? '' : '\n';
+  fs.writeFileSync(
+    target,
+    `${current}${separator}${markerText({ artifact, contract, planHadTrailingNewline })}\n`,
+    'utf8',
+  );
+}
+
+function resolvePlanFile(planFile, cwd) {
+  if (!planFile) return null;
+  return path.isAbsolute(planFile) ? planFile : path.resolve(cwd, planFile);
+}
+
+function artifactPath(artifactId, env = process.env) {
+  return path.join(artifactsDir(env), `${safeSegment(artifactId)}.json`);
+}
+
+function rawOutputPath(artifactId, env = process.env) {
+  return path.join(artifactsDir(env), `${safeSegment(artifactId)}.raw.txt`);
+}
+
+function escalationSummaryPath(sessionId, round, env = process.env) {
+  return path.join(
+    summariesDir(env),
+    `${safeSegment(sessionId)}-round-${round}-escalation.md`,
+  );
+}
+
+function shellQuote(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9_./:=@%+-]+$/.test(text)) return text;
+  return `'${text.replace(/'/g, "'\\''")}'`;
+}
+
+function crossReviewCommand(args = '') {
+  const wrapperPath = path.resolve(__dirname, '..', 'bin', 'goldband-cross-review');
+  const executable = fs.existsSync(wrapperPath)
+    ? shellQuote(wrapperPath)
+    : 'goldband-cross-review';
+  return [executable, args].filter(Boolean).join(' ');
+}
+
+function writeArtifact(artifact, rawOutput, env = process.env) {
+  ensureDir(artifactsDir(env));
+  if (rawOutput !== undefined) {
+    fs.writeFileSync(rawOutputPath(artifact.artifactId, env), String(rawOutput), 'utf8');
+  }
+  writeJson(artifactPath(artifact.artifactId, env), artifact);
+  return artifact;
+}
+
+function writeEscalationSummary(contract, artifact, env = process.env) {
+  ensureDir(summariesDir(env));
+  const history = readArtifactHistory(contract.sessionId, env);
+  const responses = readResponses(contract.sessionId, env);
+  const summaryPath = escalationSummaryPath(
+    contract.sessionId,
+    artifact.round,
+    env,
+  );
+  const openFindings = (artifact.findings || []).filter(
+    (finding) => finding.status === 'open',
+  );
+  const lines = [
+    '# Cross-Review Escalation Summary',
+    '',
+    `- sessionId: ${contract.sessionId}`,
+    `- implementer: ${contract.implementer}`,
+    `- reviewer: ${contract.reviewer}`,
+    `- baseCommit: ${contract.baseCommit}`,
+    `- reviewedSha: ${artifact.reviewedSha}`,
+    `- round: ${artifact.round}`,
+    `- verdict: ${artifact.verdict}`,
+    `- maxRounds: ${contract.maxRounds}`,
+    `- artifact: ${artifact.artifactId}`,
+    '',
+    '## Open Findings',
+    openFindings.length ? JSON.stringify(openFindings, null, 2) : '[]',
+    '',
+    '## Implementer Responses',
+    responses.length ? JSON.stringify(responses, null, 2) : '[]',
+    '',
+    '## Artifact History',
+    history.length ? JSON.stringify(history, null, 2) : '[]',
+    '',
+  ];
+  fs.writeFileSync(summaryPath, lines.join('\n'), 'utf8');
+  return summaryPath;
+}
+
+function readArtifact(artifactId, env = process.env) {
+  const filePath = artifactPath(artifactId, env);
+  if (!fs.existsSync(filePath)) return null;
+  return readJson(filePath);
+}
+
+function evaluateCrossReviewGate(input = {}, options = {}) {
+  const env = options.env || process.env;
+  const cwd = options.cwd || process.cwd();
+  const sessionId = sessionIdFromInput(input, env);
+  const contract = readContract(sessionId, env);
+  if (!contract) return allow();
+
+  if (contract.status === 'overridden') return allow();
+  if (contract.status !== 'active') return allow();
+  if (isExpired(contract)) {
+    writeContract({ ...contract, status: 'expired' }, env);
+    return allow();
+  }
+  if (input.stop_hook_active) return allow();
+  if (!contract.planFile) {
+    return block(
+      'cross-review-plan-missing',
+      `本工作已開啟交互審查，但尚未綁定 plan 檔。請執行 \`${crossReviewCommand('start --plan <path> --reviewer <claude|codex>')}\` 後再收工。`,
+    );
+  }
+
+  const planPath = resolvePlanFile(contract.planFile, cwd);
+  if (!planPath || !fs.existsSync(planPath)) {
+    return block('cross-review-plan-not-found', `交互審查 plan 檔不存在: ${contract.planFile}`);
+  }
+
+  const marker = parseMarker(fs.readFileSync(planPath, 'utf8'));
+  if (!marker) {
+    return blockOrEscalate(
+      contract,
+      `本工作在交互審查閘門下，請執行 \`${crossReviewCommand('run')}\`，由 ${contract.reviewer} 審查後才能收工。`,
+    );
+  }
+
+  const artifact = marker.artifact ? readArtifact(marker.artifact, env) : null;
+  if (!artifact) {
+    return block(
+      'cross-review-artifact-missing',
+      `交互審查 marker 存在，但找不到對應 reviewer artifact。請重新執行 \`${crossReviewCommand('run')}\`。`,
+    );
+  }
+
+  const artifactError = validateApprovalArtifact({ artifact, marker, contract });
+  if (artifactError) return block('cross-review-artifact-invalid', artifactError);
+
+  const currentSha = reviewedSha(cwd, contract.baseCommit);
+  if (currentSha !== artifact.reviewedSha) {
+    return block('cross-review-sha-mismatch', `交互審查通過後內容又變動，需重審。approved-sha=${artifact.reviewedSha} now-sha=${currentSha}`);
+  }
+
+  writeContract({ ...contract, status: 'passed' }, env);
+  return allow();
+}
+
+function isExpired(contract) {
+  const expiresMs = Date.parse(contract.expiresAt || '');
+  return Number.isFinite(expiresMs) && Date.now() > expiresMs;
+}
+
+function blockOrEscalate(contract, message) {
+  if (Number(contract.roundsUsed || 0) >= Number(contract.maxRounds || DEFAULT_MAX_ROUNDS)) {
+    const summaryText = contract.escalationSummaryPath
+      ? ` 摘要: ${contract.escalationSummaryPath}`
+      : '';
+    return block(
+      'cross-review-human-escalation',
+      `交互審查已達回合上限，請人類仲裁或執行 \`${crossReviewCommand('override --reason <reason>')}\`。${summaryText}`,
+    );
+  }
+  return block('cross-review-required', message);
+}
+
+function validateApprovalArtifact({ artifact, marker, contract }) {
+  if (artifact.verdict !== 'APPROVED') return 'reviewer artifact verdict 不是 APPROVED。';
+  if (artifact.reviewMode !== 'real') return 'reviewer artifact 不是 real review mode。';
+  if (artifact.sessionId !== contract.sessionId) return 'reviewer artifact sessionId 與契約不一致。';
+  if (artifact.baseCommit !== contract.baseCommit) return 'reviewer artifact baseCommit 與契約不一致。';
+  if (artifact.reviewer !== contract.reviewer) return 'reviewer artifact reviewer 與契約不一致。';
+  if (artifact.implementer !== contract.implementer) return 'reviewer artifact implementer 與契約不一致。';
+  if (artifact.reviewer === artifact.implementer) return 'reviewer artifact 顯示 reviewer 與 implementer 相同，交互審查無效。';
+  if (marker.session !== contract.sessionId) return 'plan marker session 與契約不一致。';
+  if (marker.artifact !== artifact.artifactId) return 'plan marker artifact 與 reviewer artifact 不一致。';
+  if (marker.reviewedSha !== artifact.reviewedSha) return 'plan marker reviewed-sha 與 reviewer artifact 不一致。';
+  return null;
+}
+
+function allow(logs = []) {
+  return { decision: 'allow', blockedBy: null, logs, outputJson: null, usageEvents: [] };
+}
+
+function block(blockedBy, message) {
+  return {
+    decision: 'block',
+    blockedBy,
+    logs: [`[goldband] ${message}`],
+    outputJson: null,
+    usageEvents: [
+      {
+        category: 'hook-decision',
+        name: blockedBy,
+        action: 'block',
+        source: 'cross-review-gate',
+        detail: { message },
+      },
+    ],
+  };
+}
+
+function buildPrompt({ contract, rubric, reviewerPrompt, diffText, planText, history, responses }) {
+  return [
+    reviewerPrompt,
+    '',
+    '## Rubric',
+    rubric,
+    '',
+    '## Contract',
+    JSON.stringify(contract, null, 2),
+    '',
+    '## Plan',
+    planText || '(no plan text)',
+    '',
+    '## Previous Findings',
+    history.length ? JSON.stringify(history, null, 2) : '[]',
+    '',
+    '## Implementer Responses',
+    responses.length ? JSON.stringify(responses, null, 2) : '[]',
+    '',
+    '## Review Scope Bundle',
+    diffText || '(empty diff)',
+  ].join('\n');
+}
+
+function normalizeFinding(finding, index, round) {
+  const severity = String(finding.severity || 'LOW').toUpperCase();
+  const hasBlockingFields = finding.ruleId && finding.failureScenario;
+  const blocking = ['CRITICAL', 'HIGH'].includes(severity) && hasBlockingFields;
+  return {
+    id: finding.id || `CR-${String(index + 1).padStart(3, '0')}`,
+    severity: blocking ? severity : severity === 'CRITICAL' || severity === 'HIGH' ? 'MEDIUM' : severity,
+    ruleId: finding.ruleId || null,
+    file: finding.file || null,
+    line: finding.line || null,
+    failureScenario: finding.failureScenario || null,
+    status: finding.status || 'open',
+    round,
+  };
+}
+
+function normalizeReviewResult(result, round, history = []) {
+  const verdict = String(result.verdict || '').toUpperCase();
+  if (!VERDICTS.has(verdict)) throw new Error(`invalid reviewer verdict: ${result.verdict}`);
+  const findings = Array.isArray(result.findings)
+    ? result.findings.map((finding, index) => normalizeFinding(finding, index, round))
+    : [];
+  const boundedFindings = applyRoundBoundary(findings, history, round);
+  const blockingCount = boundedFindings.filter((finding) => isBlockingFinding(finding)).length;
+  const finalVerdict = verdict === 'APPROVED' && blockingCount > 0 ? 'ESCALATE' : verdict;
+  return { verdict: finalVerdict, findings: boundedFindings, blockingCount };
+}
+
+function isBlockingFinding(finding) {
+  return (
+    finding.status === 'open' &&
+    ['CRITICAL', 'HIGH'].includes(finding.severity) &&
+    finding.ruleId &&
+    finding.failureScenario
+  );
+}
+
+function applyRoundBoundary(findings, history, round) {
+  if (round <= 1) return findings;
+
+  const previousBlockingIds = new Set(
+    history
+      .flatMap((artifact) => artifact.findings || [])
+      .filter((finding) => isBlockingFinding(finding))
+      .map((finding) => finding.id),
+  );
+  const acceptedRebuttals = new Set(
+    history
+      .flatMap((artifact) => artifact.findings || [])
+      .filter((finding) => finding.status === 'rebutted-accepted')
+      .map((finding) => finding.id),
+  );
+
+  return findings.map((finding) => {
+    if (acceptedRebuttals.has(finding.id)) {
+      return downgradeFinding(finding, 'Accepted rebuttals cannot be reopened.');
+    }
+    if (!isBlockingFinding(finding)) return finding;
+    if (previousBlockingIds.has(finding.id)) return finding;
+    if (finding.severity === 'CRITICAL') return finding;
+    if (finding.severity === 'HIGH' && finding.ruleId === 'regression.clear') return finding;
+    return downgradeFinding(
+      finding,
+      'New non-CRITICAL/non-HIGH-regression blockers after round 1 are advisory by the moving-goalpost rule.',
+    );
+  });
+}
+
+function downgradeFinding(finding, note) {
+  return {
+    ...finding,
+    severity: 'MEDIUM',
+    downgradeReason: note,
+  };
+}
+
+function runMockReviewer(verdict, round) {
+  if (verdict === 'CHANGES_REQUESTED') {
+    return {
+      rawOutput: `GOLDBAND-CROSS-REVIEW-VERDICT: CHANGES_REQUESTED reviewer=mock round=${round}`,
+      parsed: {
+        verdict: 'CHANGES_REQUESTED',
+        findings: [
+          {
+            id: 'CR-001',
+            severity: 'HIGH',
+            ruleId: 'correctness.contract',
+            file: 'mock.txt',
+            line: 1,
+            failureScenario: 'Mock reviewer requested a blocking change.',
+            status: 'open',
+          },
+        ],
+      },
+      command: 'mock-reviewer',
+      exitCode: 0,
+    };
+  }
+  return {
+    rawOutput: `GOLDBAND-CROSS-REVIEW-VERDICT: ${verdict} reviewer=mock round=${round}`,
+    parsed: { verdict, findings: [] },
+    command: 'mock-reviewer',
+    exitCode: 0,
+  };
+}
+
+function runCliReviewer(reviewer, prompt, cwd = process.cwd(), env = process.env) {
+  const command = reviewer === 'claude' ? 'claude' : 'codex';
+  const args =
+    reviewer === 'claude'
+      ? ['-p', '--output-format', 'text', '--no-session-persistence']
+      : [
+          'exec',
+          '--ephemeral',
+          '--sandbox',
+          'read-only',
+          '--skip-git-repo-check',
+          '-',
+        ];
+  const result = spawnSync(command, args, {
+    cwd,
+    input: prompt,
+    encoding: 'utf8',
+    maxBuffer: 20 * 1024 * 1024,
+    env,
+  });
+  const rawOutput = [result.stdout, result.stderr].filter(Boolean).join('\n');
+  const commandLabel = `${command} ${args.join(' ')}`;
+  let parsed;
+  try {
+    parsed = parseReviewerOutput(rawOutput);
+  } catch (error) {
+    parsed = {
+      verdict: 'ESCALATE',
+      findings: [
+        {
+          id: 'CR-REVIEWER-PARSE',
+          severity: 'HIGH',
+          ruleId: 'verification.false-claim',
+          failureScenario:
+            error && error.message
+              ? error.message
+              : 'Reviewer output did not include a parseable verdict.',
+          status: 'open',
+        },
+      ],
+    };
+  }
+  return {
+    rawOutput,
+    parsed,
+    command: commandLabel,
+    exitCode: typeof result.status === 'number' ? result.status : 1,
+  };
+}
+
+function parseReviewerOutput(output) {
+  const marker = String(output || '').match(/GOLDBAND-CROSS-REVIEW-VERDICT:\s+(APPROVED|CHANGES_REQUESTED|ESCALATE)/);
+  if (!marker) throw new Error('reviewer output did not include a parseable cross-review verdict');
+  const jsonMatch = String(output || '').match(/GOLDBAND-CROSS-REVIEW-FINDINGS:\s*(\[[\s\S]*?\])\s*(?:\n|$)/);
+  if (!jsonMatch && marker[1] !== 'APPROVED') {
+    throw new Error('reviewer requested changes or escalation without a parseable findings line');
+  }
+  return {
+    verdict: marker[1],
+    findings: jsonMatch ? JSON.parse(jsonMatch[1]) : [],
+  };
+}
+
+function runReviewRound(options, env = process.env) {
+  const cwd = options.cwd || process.cwd();
+  const sessionId = options.sessionId || firstEnv(env, ['CLAUDE_SESSION_ID', 'CODEX_SESSION_ID']);
+  const contract = readContract(sessionId, env);
+  if (!contract) throw new Error('no active cross-review contract found');
+  if (contract.status !== 'active') throw new Error(`contract is not active: ${contract.status}`);
+  if (!contract.planFile) throw new Error('contract.planFile is required before running review');
+  if (contract.reviewer === contract.implementer) throw new Error('reviewer must differ from implementer');
+
+  const currentSha = reviewedSha(cwd, contract.baseCommit);
+  const round = Number(contract.roundsUsed || 0) + 1;
+  const reviewMode = options.reviewMode || 'real';
+  if (!['real', 'mock'].includes(reviewMode)) {
+    throw new Error(`invalid reviewMode: ${reviewMode}`);
+  }
+  const reviewerResult =
+    reviewMode === 'real'
+      ? runCliReviewer(contract.reviewer, buildReviewerPrompt(contract, cwd, env), cwd, env)
+      : runMockReviewer(options.mockVerdict || 'APPROVED', round);
+  if (reviewerResult.exitCode !== 0) {
+    reviewerResult.parsed = {
+      verdict: 'ESCALATE',
+      findings: [
+        {
+          id: 'CR-REVIEWER-EXIT',
+          severity: 'HIGH',
+          ruleId: 'verification.false-claim',
+          failureScenario: `Reviewer command exited with status ${reviewerResult.exitCode}.`,
+          status: 'open',
+        },
+      ],
+    };
+  }
+  const history = readArtifactHistory(contract.sessionId, env);
+  const normalized = normalizeReviewResult(reviewerResult.parsed, round, history);
+  const artifactId = `cr-${safeSegment(contract.sessionId)}-${round}-${Date.now()}`;
+  const artifact = {
+    schemaVersion: CONTRACT_SCHEMA_VERSION,
+    artifactId,
+    sessionId: contract.sessionId,
+    reviewer: contract.reviewer,
+    implementer: contract.implementer,
+    baseCommit: contract.baseCommit,
+    reviewedSha: currentSha,
+    round,
+    verdict: normalized.verdict,
+    reviewMode,
+    findings: normalized.findings,
+    reviewerCommand: reviewerResult.command,
+    reviewerExitCode: reviewerResult.exitCode,
+    rawOutputPath: rawOutputPath(artifactId, env),
+    createdAt: nowIso(),
+  };
+  writeArtifact(artifact, reviewerResult.rawOutput, env);
+
+  const updatedContract = { ...contract, roundsUsed: round };
+  appendCrossReviewUsageEvent(
+    {
+      name: 'cross-review-round',
+      sessionId: contract.sessionId,
+      run_id: contract.sessionId,
+      detail: {
+        round,
+        verdict: normalized.verdict,
+        blockingCount: normalized.blockingCount,
+        advisoryCount: normalized.findings.length - normalized.blockingCount,
+        reviewMode,
+        reviewer: contract.reviewer,
+        implementer: contract.implementer,
+        artifactId,
+      },
+    },
+    env,
+  );
+
+  if (normalized.verdict === 'APPROVED') {
+    appendApprovalMarker(contract.planFile, artifact, contract, cwd);
+    writeContract(updatedContract, env);
+  } else {
+    if (
+      normalized.verdict === 'ESCALATE' ||
+      round >= Number(contract.maxRounds || DEFAULT_MAX_ROUNDS)
+    ) {
+      updatedContract.escalationSummaryPath = writeEscalationSummary(
+        updatedContract,
+        artifact,
+        env,
+      );
+      appendCrossReviewUsageEvent(
+        {
+          name: 'cross-review-escalation',
+          action: 'block',
+          sessionId: contract.sessionId,
+          run_id: contract.sessionId,
+          detail: {
+            round,
+            verdict: normalized.verdict,
+            maxRounds: contract.maxRounds,
+            summaryPath: updatedContract.escalationSummaryPath,
+            artifactId,
+          },
+        },
+        env,
+      );
+    }
+    writeContract(updatedContract, env);
+  }
+
+  return { contract: readContract(contract.sessionId, env), artifact };
+}
+
+function buildReviewerPrompt(contract, cwd, env) {
+  const runtimeDir = __dirname;
+  const reviewerPrompt = fs.readFileSync(path.join(runtimeDir, 'reviewer-prompt.md'), 'utf8');
+  const rubric = fs.readFileSync(path.join(runtimeDir, 'rubric.md'), 'utf8');
+  const planPath = resolvePlanFile(contract.planFile, cwd);
+  const planText = planPath && fs.existsSync(planPath) ? fs.readFileSync(planPath, 'utf8') : '';
+  const history = readArtifactHistory(contract.sessionId, env);
+  const responses = readResponses(contract.sessionId, env);
+  return buildPrompt({
+    contract,
+    rubric,
+    reviewerPrompt,
+    diffText: reviewScopePromptText(cwd, contract.baseCommit),
+    planText,
+    history,
+    responses,
+  });
+}
+
+function readArtifactHistory(sessionId, env = process.env) {
+  if (!fs.existsSync(artifactsDir(env))) return [];
+  return fs
+    .readdirSync(artifactsDir(env))
+    .filter((entry) => entry.endsWith('.json'))
+    .map((entry) => {
+      try {
+        return readJson(path.join(artifactsDir(env), entry));
+      } catch {
+        return null;
+      }
+    })
+    .filter((entry) => entry && entry.sessionId === sessionId)
+    .sort((a, b) => Number(a.round || 0) - Number(b.round || 0));
+}
+
+function readResponses(sessionId, env = process.env) {
+  const filePath = path.join(responsesDir(env), `${safeSegment(sessionId)}.jsonl`);
+  if (!fs.existsSync(filePath)) return [];
+  return fs
+    .readFileSync(filePath, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function appendResponse(sessionId, response, env = process.env) {
+  ensureDir(responsesDir(env));
+  const payload = {
+    findingId: response.findingId,
+    response: response.response,
+    summary: response.summary,
+    evidence: response.evidence || [],
+    recordedAt: nowIso(),
+  };
+  fs.appendFileSync(
+    path.join(responsesDir(env), `${safeSegment(sessionId)}.jsonl`),
+    `${JSON.stringify(payload)}\n`,
+    'utf8',
+  );
+  appendCrossReviewUsageEvent(
+    {
+      name: 'cross-review-response',
+      sessionId,
+      run_id: sessionId,
+      detail: {
+        findingId: payload.findingId,
+        response: payload.response,
+        evidenceCount: payload.evidence.length,
+      },
+    },
+    env,
+  );
+  return payload;
+}
+
+function promptRequestsCrossReview(prompt) {
+  const text = String(prompt || '')
+    .replace(CODE_FENCE_PATTERN, ' ')
+    .replace(INLINE_CODE_PATTERN, ' ');
+  return (
+    /(?:^|\s)\[\[cross-review\]\](?:$|\s)/i.test(text) ||
+    /(?:^|\s|請)開啟交互審查(?:$|\s|--)/.test(text)
+  );
+}
+
+function inferPlanFile(prompt) {
+  const match = String(prompt || '').match(/(?:--plan\s+|plan(?:File)?[:=]\s*)([^\s]+)/i);
+  return match ? match[1].replace(/^["']|["']$/g, '') : null;
+}
+
+function armFromPrompt(input = {}, options = {}) {
+  const prompt = String(input.prompt || '');
+  if (!promptRequestsCrossReview(prompt)) return null;
+  const env = options.env || process.env;
+  const implementer = options.implementer || detectHost(env);
+  const sessionId = sessionIdFromInput(input, env);
+  const existing = readContract(sessionId, env);
+  const inferredPlan = inferPlanFile(prompt);
+  if (existing && existing.status === 'active') {
+    if (!existing.planFile && inferredPlan) {
+      return writeContract({ ...existing, planFile: inferredPlan }, env);
+    }
+    return existing;
+  }
+  const contract = createContract(
+    {
+      sessionId,
+      implementer,
+      reviewer: oppositeHost(implementer),
+      planFile: inferredPlan,
+      cwd: options.cwd || process.cwd(),
+    },
+    env,
+  );
+  return contract;
+}
+
+function overrideContract(sessionId, reason, env = process.env) {
+  const contract = readContract(sessionId, env);
+  if (!contract) throw new Error('no cross-review contract found');
+  const written = writeContract(
+    {
+      ...contract,
+      status: 'overridden',
+      overrideReason: reason || 'manual override',
+      overriddenAt: nowIso(),
+    },
+    env,
+  );
+  appendCrossReviewUsageEvent(
+    {
+      name: 'cross-review-override',
+      sessionId,
+      run_id: sessionId,
+      detail: {
+        reason: written.overrideReason,
+        roundsUsed: written.roundsUsed,
+      },
+    },
+    env,
+  );
+  return written;
+}
+
+function markDone(sessionId, cwd = process.cwd(), env = process.env) {
+  const result = evaluateCrossReviewGate({ hook_event_name: 'Stop', session_id: sessionId }, { cwd, env });
+  if (result.decision === 'block') {
+    throw new Error(result.logs.join('\n'));
+  }
+  const contract = readContract(sessionId, env);
+  appendCrossReviewUsageEvent(
+    {
+      name: 'cross-review-done',
+      sessionId,
+      run_id: sessionId,
+      detail: {
+        status: contract ? contract.status : 'not-armed',
+        roundsUsed: contract ? contract.roundsUsed : null,
+      },
+    },
+    env,
+  );
+  return contract;
+}
+
+module.exports = {
+  CONTRACT_SCHEMA_VERSION,
+  appendResponse,
+  armFromPrompt,
+  artifactPath,
+  artifactsDir,
+  canonicalReviewBundle,
+  contractPath,
+  createContract,
+  crossReviewDir,
+  detectHost,
+  evaluateCrossReviewGate,
+  inferPlanFile,
+  isBlockingFinding,
+  markDone,
+  buildReviewerPrompt,
+  normalizeReviewResult,
+  oppositeHost,
+  parseMarker,
+  promptRequestsCrossReview,
+  readArtifact,
+  readContract,
+  reviewScopePromptText,
+  reviewedSha,
+  runReviewRound,
+  stateRoot,
+  validateApprovalArtifact,
+  writeArtifact,
+  writeContract,
+  overrideContract,
+};

--- a/goldband-loop/cross-review/reviewer-prompt.md
+++ b/goldband-loop/cross-review/reviewer-prompt.md
@@ -1,0 +1,38 @@
+# Goldband Cross-Review Reviewer Prompt
+
+You are the reviewer in a Claude/Codex cross-review gate. The implementer is a different model family.
+
+Review only the supplied bounded bundle: contract, plan, rubric, diff, previous findings, and implementer responses. Do not ask the implementer to read another skill. Do not change files.
+
+Your job is to decide whether the current review scope can pass the gate.
+
+Blocking findings are allowed only when they meet the rubric's blocking rules. A blocking finding must include:
+
+- `severity`: `CRITICAL` or `HIGH`
+- `ruleId`: one rule from the rubric
+- `failureScenario`: a concrete way the implementation fails
+- `status`: `open`
+
+From round 2 onward, you may only evaluate existing blockers or report a new `CRITICAL` issue, or a new `HIGH` `regression.clear` issue introduced by the implementer's latest fix. Do not move the goalposts.
+
+When an implementer response has `response: "rebutted"`, judge that rebuttal from the `Implementer Responses` log only:
+
+- If you accept the rebuttal, include the original finding id with `status: "rebutted-accepted"`, `severity: "LOW"` or `MEDIUM`, and no blocking `ruleId`.
+- If you reject the rebuttal, include the original finding id with `status: "rebutted-rejected"` plus a blocking severity, rubric `ruleId`, and concrete `failureScenario`.
+- Do not reopen a previously accepted rebuttal unless the current diff introduces a new `CRITICAL` regression.
+
+End with exactly one verdict line:
+
+```text
+GOLDBAND-CROSS-REVIEW-VERDICT: <APPROVED|CHANGES_REQUESTED|ESCALATE>
+  reviewer=<codex|claude> reviewed-sha=<sha256> round=<n>
+  blocking=<count> advisory=<count> artifact=<artifact-id>
+```
+
+Then output one JSON findings line:
+
+```text
+GOLDBAND-CROSS-REVIEW-FINDINGS: [...]
+```
+
+Use `APPROVED` when no valid blocking findings remain. Use `CHANGES_REQUESTED` only for valid open CRITICAL/HIGH findings. Use `ESCALATE` when the evidence is insufficient or human judgment is required.

--- a/goldband-loop/cross-review/rubric.md
+++ b/goldband-loop/cross-review/rubric.md
@@ -1,0 +1,20 @@
+# Goldband Cross-Review Rubric
+
+## Blocking Rules
+
+- `correctness.contract`: The implementation violates an explicit requirement, schema, gate, or source-of-truth contract.
+- `security.boundary`: The implementation weakens authorization, secret handling, sandboxing, command safety, or trust-boundary enforcement.
+- `data.loss`: The implementation can drop, corrupt, overwrite, or hide user data or required evidence.
+- `regression.clear`: The diff introduces a clear regression in existing behavior covered by current files, tests, docs, or workflow contracts.
+- `verification.false-claim`: The implementation claims enforcement, parity, or completion that current evidence does not prove.
+
+Blocking severity requires a concrete failure scenario. CRITICAL means the gate would allow unsafe, destructive, or contract-breaking work. HIGH means a real user or maintainer can hit the failure during normal use.
+
+## Advisory Rules
+
+- `style.naming`: Naming, wording, or structure could be clearer but does not change behavior.
+- `maintainability.minor`: The code could be easier to read or consolidate, but the contract still holds.
+- `performance.minor`: The implementation has small avoidable overhead that does not affect hook safety or workflow viability.
+- `docs.followup`: Documentation could be expanded, but the executable gate remains correct.
+
+MEDIUM and LOW findings are advisory. They must not block the marker.

--- a/goldband-loop/inventory.json
+++ b/goldband-loop/inventory.json
@@ -74,6 +74,7 @@
     "goldband-codex-probe",
     "goldband-community-dashboard",
     "goldband-config",
+    "goldband-cross-review",
     "goldband-developer-profile",
     "goldband-diff-scope",
     "goldband-extension",

--- a/hooks/fixtures/router/cross-review-fixtures.json
+++ b/hooks/fixtures/router/cross-review-fixtures.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "cross-review-unarmed-stop-allows",
+    "input": {
+      "hook_event_name": "Stop",
+      "session_id": "fixture-unarmed"
+    },
+    "expect": {
+      "exitCode": 0,
+      "decision": "allow"
+    }
+  },
+  {
+    "id": "cross-review-active-plan-missing-blocks",
+    "env": {
+      "GOLDBAND_CROSS_REVIEW_DIR": "hooks/fixtures/router/cross-review-state"
+    },
+    "input": {
+      "hook_event_name": "Stop",
+      "session_id": "fixture-plan-missing"
+    },
+    "expect": {
+      "exitCode": 2,
+      "decision": "block",
+      "stderrIncludes": ["尚未綁定 plan"]
+    }
+  }
+]

--- a/hooks/fixtures/router/cross-review-state/fixture-plan-missing.json
+++ b/hooks/fixtures/router/cross-review-state/fixture-plan-missing.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "sessionId": "fixture-plan-missing",
+  "host": "claude",
+  "implementer": "claude",
+  "reviewer": "codex",
+  "planFile": null,
+  "baseCommit": "0000000000000000000000000000000000000000",
+  "reviewScope": "tracked-and-untracked-vs-base",
+  "maxRounds": 3,
+  "roundsUsed": 0,
+  "status": "active",
+  "armedAt": "2026-07-05T00:00:00.000Z",
+  "expiresAt": "2099-01-01T00:00:00.000Z"
+}

--- a/hooks/scripts/hooks/skill-activation-suggestions.js
+++ b/hooks/scripts/hooks/skill-activation-suggestions.js
@@ -2,6 +2,7 @@
 
 const { readStdinJson } = require('../lib/utils');
 const { appendUsageEvent } = require('../lib/hook-router/usage-telemetry');
+const { armFromPrompt } = require('../lib/hook-router/cross-review-gate');
 const {
   buildWorkflowUsageEvents,
 } = require('../lib/hook-router/workflow-telemetry');
@@ -52,6 +53,7 @@ async function main() {
   const input = await readStdinJson();
   const prompt = String(input.prompt || '');
   const sessionId = input.session_id || process.env.CLAUDE_SESSION_ID || null;
+  const crossReviewContract = armCrossReviewIfRequested(input);
   const matches = matchPrompt(prompt);
 
   for (const event of buildWorkflowUsageEvents(
@@ -85,6 +87,9 @@ async function main() {
   }
 
   const additionalContext = [
+    crossReviewContract
+      ? `Cross-review gate armed for this session. Reviewer: ${crossReviewContract.reviewer}. Plan: ${crossReviewContract.planFile || 'not bound yet'}.`
+      : null,
     shouldEmitBaseline ? formatClaimVerificationBaseline() : null,
     shouldEmitSuggestionsForPrompt ? formatSuggestions(matches, 3) : null,
   ]
@@ -99,6 +104,18 @@ async function main() {
       },
     }),
   );
+}
+
+function armCrossReviewIfRequested(input) {
+  try {
+    return armFromPrompt(input, { implementer: 'claude' });
+  } catch (error) {
+    return {
+      reviewer: 'unknown',
+      planFile: null,
+      error: error && error.message ? error.message : String(error),
+    };
+  }
 }
 
 main().catch(() => {

--- a/hooks/scripts/lib/hook-router/cross-review-gate.js
+++ b/hooks/scripts/lib/hook-router/cross-review-gate.js
@@ -1,0 +1,20 @@
+let core = null;
+
+function loadCore() {
+  if (core) return core;
+  core = require('../../../../goldband-loop/cross-review/core.cjs');
+  return core;
+}
+
+function evaluateCrossReviewGate(input, options) {
+  return loadCore().evaluateCrossReviewGate(input, options);
+}
+
+function armFromPrompt(input, options) {
+  return loadCore().armFromPrompt(input, options);
+}
+
+module.exports = {
+  armFromPrompt,
+  evaluateCrossReviewGate,
+};

--- a/hooks/scripts/lib/hook-router/stop-policy.js
+++ b/hooks/scripts/lib/hook-router/stop-policy.js
@@ -3,6 +3,7 @@ const os = require('os');
 const path = require('path');
 const { execFileSync, spawnSync } = require('child_process');
 const { getGitModifiedFiles, isGitRepo } = require('../utils');
+const { evaluateCrossReviewGate } = require('./cross-review-gate');
 
 const NOTIFICATION_TITLE = 'Claude Code';
 const NOTIFICATION_MESSAGES = {
@@ -193,6 +194,12 @@ function getStyleGateWarningsInGitDiff() {
 }
 
 function evaluateStop(input) {
+  const crossReviewResult = evaluateCrossReviewGate(input);
+  if (crossReviewResult.decision === 'block') {
+    notifyIfNeeded(input);
+    return crossReviewResult;
+  }
+
   const warnings = getStyleGateWarningsInGitDiff();
   notifyIfNeeded(input);
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "test:hook-router": "node hooks/scripts/tools/replay-hook-router.js",
     "test:telemetry": "node scripts/test-telemetry-schema.mjs && node scripts/test-telemetry.mjs && node scripts/test-telemetry-otlp.mjs",
     "test:hook-router:coverage": "node scripts/check-hook-router-coverage.mjs",
+    "test:cross-review": "node scripts/test-cross-review.mjs && node scripts/test-cross-review-regressions.mjs",
     "test:mcp-server": "npm --prefix mcp/server test",
     "smoke:mcp-server": "npm --prefix mcp/server run smoke",
     "test:eval-budget-cap": "node scripts/test-eval-budget-cap.mjs",

--- a/schemas/cross-review-artifact.schema.json
+++ b/schemas/cross-review-artifact.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://goldband.local/schemas/cross-review-artifact.schema.json",
+  "title": "Goldband Cross Review Artifact",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "artifactId",
+    "sessionId",
+    "reviewer",
+    "implementer",
+    "baseCommit",
+    "reviewedSha",
+    "round",
+    "verdict",
+    "reviewMode",
+    "findings",
+    "reviewerCommand",
+    "reviewerExitCode",
+    "rawOutputPath",
+    "createdAt"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "artifactId": { "type": "string", "minLength": 1 },
+    "sessionId": { "type": "string", "minLength": 1 },
+    "reviewer": { "enum": ["claude", "codex"] },
+    "implementer": { "enum": ["claude", "codex"] },
+    "baseCommit": { "type": "string", "minLength": 7 },
+    "reviewedSha": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "round": { "type": "integer", "minimum": 1 },
+    "verdict": { "enum": ["APPROVED", "CHANGES_REQUESTED", "ESCALATE"] },
+    "reviewMode": { "enum": ["real", "mock"] },
+    "findings": {
+      "type": "array",
+      "items": { "$ref": "cross-review-finding.schema.json" }
+    },
+    "reviewerCommand": { "type": "string" },
+    "reviewerExitCode": { "type": "integer" },
+    "rawOutputPath": { "type": "string" },
+    "createdAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/schemas/cross-review-contract.schema.json
+++ b/schemas/cross-review-contract.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://goldband.local/schemas/cross-review-contract.schema.json",
+  "title": "Goldband Cross Review Contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "sessionId",
+    "host",
+    "implementer",
+    "reviewer",
+    "baseCommit",
+    "reviewScope",
+    "maxRounds",
+    "roundsUsed",
+    "status",
+    "armedAt",
+    "expiresAt"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "sessionId": { "type": "string", "minLength": 1 },
+    "host": { "enum": ["claude", "codex"] },
+    "implementer": { "enum": ["claude", "codex"] },
+    "reviewer": { "enum": ["claude", "codex"] },
+    "planFile": { "type": ["string", "null"] },
+    "baseCommit": { "type": "string", "minLength": 7 },
+    "reviewScope": { "const": "tracked-and-untracked-vs-base" },
+    "maxRounds": { "type": "integer", "minimum": 1 },
+    "roundsUsed": { "type": "integer", "minimum": 0 },
+    "status": { "enum": ["active", "passed", "overridden", "expired"] },
+    "armedAt": { "type": "string", "format": "date-time" },
+    "expiresAt": { "type": "string", "format": "date-time" },
+    "escalationSummaryPath": { "type": "string" },
+    "overrideReason": { "type": "string" },
+    "overriddenAt": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "not": {
+        "properties": {
+          "implementer": { "const": "claude" },
+          "reviewer": { "const": "claude" }
+        },
+        "required": ["implementer", "reviewer"]
+      }
+    },
+    {
+      "not": {
+        "properties": {
+          "implementer": { "const": "codex" },
+          "reviewer": { "const": "codex" }
+        },
+        "required": ["implementer", "reviewer"]
+      }
+    }
+  ]
+}

--- a/schemas/cross-review-finding.schema.json
+++ b/schemas/cross-review-finding.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://goldband.local/schemas/cross-review-finding.schema.json",
+  "title": "Goldband Cross Review Finding",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "severity", "status", "round"],
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "severity": { "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"] },
+    "ruleId": { "type": ["string", "null"] },
+    "file": { "type": ["string", "null"] },
+    "line": { "type": ["integer", "null"], "minimum": 1 },
+    "failureScenario": { "type": ["string", "null"] },
+    "downgradeReason": { "type": "string" },
+    "status": {
+      "enum": ["open", "resolved", "rebutted-accepted", "rebutted-rejected"]
+    },
+    "round": { "type": "integer", "minimum": 1 }
+  }
+}

--- a/schemas/cross-review-implementer-response.schema.json
+++ b/schemas/cross-review-implementer-response.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://goldband.local/schemas/cross-review-implementer-response.schema.json",
+  "title": "Goldband Cross Review Implementer Response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["findingId", "response", "summary", "evidence", "recordedAt"],
+  "properties": {
+    "findingId": { "type": "string", "minLength": 1 },
+    "response": { "enum": ["fixed", "rebutted", "ask-human"] },
+    "summary": { "type": "string", "minLength": 1 },
+    "evidence": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "recordedAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/scripts/test-cross-review-regressions.mjs
+++ b/scripts/test-cross-review-regressions.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const core = require('../goldband-loop/cross-review/core.cjs');
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { encoding: 'utf8', ...options });
+  assert.equal(
+    result.status,
+    options.expectStatus ?? 0,
+    result.stderr || result.stdout,
+  );
+  return result;
+}
+
+function makeRepo(withPlan = true) {
+  const dir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'goldband-cross-review-reg-'),
+  );
+  run('git', ['init'], { cwd: dir });
+  run('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  run('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+  fs.writeFileSync(path.join(dir, 'tracked.txt'), 'base\n');
+  if (withPlan) fs.writeFileSync(path.join(dir, 'PLAN.md'), '# Plan\n');
+  run('git', ['add', '.'], { cwd: dir });
+  run('git', ['commit', '-m', 'base'], { cwd: dir });
+  return dir;
+}
+
+function envFor(stateDir) {
+  return {
+    ...process.env,
+    GOLDBAND_CROSS_REVIEW_DIR: stateDir,
+    GOLDBAND_USAGE_FILE: path.join(stateDir, 'usage.jsonl'),
+  };
+}
+
+function head(cwd) {
+  return run('git', ['rev-parse', 'HEAD'], { cwd }).stdout.trim();
+}
+
+function createContract(dir, env, sessionId, overrides = {}) {
+  return core.createContract(
+    {
+      sessionId,
+      implementer: 'claude',
+      reviewer: 'codex',
+      planFile: 'PLAN.md',
+      baseCommit: head(dir),
+      cwd: dir,
+      ...overrides,
+    },
+    env,
+  );
+}
+
+function testChangesRequestedNeverRewritesToApproved() {
+  const normalized = core.normalizeReviewResult(
+    {
+      verdict: 'CHANGES_REQUESTED',
+      findings: [{ severity: 'HIGH', status: 'open' }],
+    },
+    1,
+  );
+  assert.equal(normalized.verdict, 'CHANGES_REQUESTED');
+  assert.equal(normalized.blockingCount, 0);
+}
+
+function testMissingFindingsLineEscalates() {
+  const dir = makeRepo();
+  const stateDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'goldband-cross-review-state-'),
+  );
+  const env = envFor(stateDir);
+  const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'goldband-fake-bin-'));
+  fs.writeFileSync(
+    path.join(fakeBin, 'codex'),
+    '#!/bin/sh\ncat >/dev/null\nprintf "%s\\n" "FAKE-CODEX-RAN"\nprintf "%s\\n" "GOLDBAND-CROSS-REVIEW-VERDICT: CHANGES_REQUESTED reviewer=codex round=1 blocking=1 advisory=0 artifact=fake"\n',
+  );
+  fs.chmodSync(path.join(fakeBin, 'codex'), 0o755);
+  createContract(dir, env, 'missing-findings-line');
+  const review = core.runReviewRound(
+    { sessionId: 'missing-findings-line', cwd: dir },
+    { ...env, PATH: `${fakeBin}${path.delimiter}${env.PATH}` },
+  );
+  assert.equal(review.artifact.verdict, 'ESCALATE');
+  assert.equal(review.artifact.findings[0].id, 'CR-REVIEWER-PARSE');
+  assert.match(
+    fs.readFileSync(review.artifact.rawOutputPath, 'utf8'),
+    /FAKE-CODEX-RAN/,
+  );
+}
+
+function testApprovedWithBlockingFindingEscalates() {
+  const normalized = core.normalizeReviewResult(
+    {
+      verdict: 'APPROVED',
+      findings: [
+        {
+          severity: 'HIGH',
+          ruleId: 'correctness.contract',
+          failureScenario: 'Reviewer found a blocking contract failure.',
+          status: 'open',
+        },
+      ],
+    },
+    1,
+  );
+  assert.equal(normalized.verdict, 'ESCALATE');
+  assert.equal(normalized.blockingCount, 1);
+}
+
+function testNonZeroReviewerExitEscalates() {
+  const dir = makeRepo();
+  const stateDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'goldband-cross-review-state-'),
+  );
+  const env = envFor(stateDir);
+  const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'goldband-fake-bin-'));
+  fs.writeFileSync(
+    path.join(fakeBin, 'codex'),
+    '#!/bin/sh\ncat >/dev/null\nprintf "%s\\n" "GOLDBAND-CROSS-REVIEW-VERDICT: APPROVED reviewer=codex round=1 blocking=0 advisory=0 artifact=fake"\nprintf "%s\\n" "GOLDBAND-CROSS-REVIEW-FINDINGS: []"\nexit 42\n',
+  );
+  fs.chmodSync(path.join(fakeBin, 'codex'), 0o755);
+  createContract(dir, env, 'nonzero-reviewer-exit');
+  const review = core.runReviewRound(
+    { sessionId: 'nonzero-reviewer-exit', cwd: dir },
+    { ...env, PATH: `${fakeBin}${path.delimiter}${env.PATH}` },
+  );
+  const planText = fs.readFileSync(path.join(dir, 'PLAN.md'), 'utf8');
+  assert.equal(review.artifact.verdict, 'ESCALATE');
+  assert.equal(review.artifact.reviewerExitCode, 42);
+  assert.equal(review.artifact.findings[0].id, 'CR-REVIEWER-EXIT');
+  assert.doesNotMatch(planText, /GOLDBAND-CROSS-REVIEW: APPROVED/);
+}
+
+function assertUntrackedPlanTextAllows(planText, suffix) {
+  const dir = makeRepo(false);
+  const stateDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'goldband-cross-review-state-'),
+  );
+  const env = envFor(stateDir);
+  const sessionId = `untracked-plan-${suffix}`;
+  fs.writeFileSync(path.join(dir, 'PLAN.md'), planText);
+  createContract(dir, env, sessionId);
+  const review = core.runReviewRound(
+    { sessionId, reviewMode: 'mock', mockVerdict: 'APPROVED', cwd: dir },
+    env,
+  );
+  const artifact = {
+    ...review.artifact,
+    reviewMode: 'real',
+  };
+  core.writeArtifact(artifact, 'real fixture output', env);
+  core.writeContract(
+    { ...core.readContract(sessionId, env), status: 'active' },
+    env,
+  );
+  const gate = core.evaluateCrossReviewGate(
+    { hook_event_name: 'Stop', session_id: sessionId },
+    { cwd: dir, env },
+  );
+  assert.equal(gate.decision, 'allow', gate.logs.join('\n'));
+}
+
+function testUntrackedPlanMarkerRoundTripAllows() {
+  assertUntrackedPlanTextAllows('# Plan\n', 'newline');
+  assertUntrackedPlanTextAllows('# Plan', 'nonewline');
+  assertUntrackedPlanTextAllows('# Plan\n\ncontent\n', 'content');
+}
+
+function testRoundTwoHighRegressionCanBlock() {
+  const normalized = core.normalizeReviewResult(
+    {
+      verdict: 'CHANGES_REQUESTED',
+      findings: [
+        {
+          id: 'CR-REG-HIGH',
+          severity: 'HIGH',
+          ruleId: 'regression.clear',
+          failureScenario: 'Latest fix introduced a high-impact regression.',
+          status: 'open',
+        },
+      ],
+    },
+    2,
+    [{ findings: [] }],
+  );
+  assert.equal(normalized.findings[0].severity, 'HIGH');
+  assert.equal(normalized.blockingCount, 1);
+}
+
+function testPromptArmDoesNotResetActiveContract() {
+  const dir = makeRepo();
+  const stateDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'goldband-cross-review-state-'),
+  );
+  const env = envFor(stateDir);
+  const sessionId = 'rearm-active';
+  const first = core.armFromPrompt(
+    { session_id: sessionId, prompt: '開啟交互審查' },
+    { cwd: dir, env, implementer: 'claude' },
+  );
+  core.writeContract({ ...first, roundsUsed: 2 }, env);
+  const second = core.armFromPrompt(
+    { session_id: sessionId, prompt: '開啟交互審查 --plan PLAN.md' },
+    { cwd: dir, env, implementer: 'claude' },
+  );
+  const third = core.armFromPrompt(
+    { session_id: sessionId, prompt: '開啟交互審查 --plan OTHER.md' },
+    { cwd: dir, env, implementer: 'claude' },
+  );
+  assert.equal(second.roundsUsed, 2);
+  assert.equal(third.roundsUsed, 2);
+  assert.equal(third.planFile, 'PLAN.md');
+  assert.equal(third.baseCommit, first.baseCommit);
+}
+
+function testQuotedTriggerTextDoesNotArm() {
+  assert.equal(
+    core.promptRequestsCrossReview('說明 `[[cross-review]]` 這個觸發詞'),
+    false,
+  );
+  assert.equal(
+    core.promptRequestsCrossReview('中文「開啟交互審查」只是文件範例'),
+    false,
+  );
+  assert.equal(
+    core.promptRequestsCrossReview(
+      '請做這件事 [[cross-review]] --plan PLAN.md',
+    ),
+    true,
+  );
+  assert.equal(
+    core.promptRequestsCrossReview('請開啟交互審查 --plan PLAN.md'),
+    true,
+  );
+}
+
+testChangesRequestedNeverRewritesToApproved();
+testMissingFindingsLineEscalates();
+testApprovedWithBlockingFindingEscalates();
+testNonZeroReviewerExitEscalates();
+testUntrackedPlanMarkerRoundTripAllows();
+testRoundTwoHighRegressionCanBlock();
+testPromptArmDoesNotResetActiveContract();
+testQuotedTriggerTextDoesNotArm();
+
+console.log('[OK] cross-review regression tests passed');

--- a/scripts/test-cross-review.mjs
+++ b/scripts/test-cross-review.mjs
@@ -1,0 +1,597 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const repoDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const core = require('../goldband-loop/cross-review/core.cjs');
+const { validateUsageEvent } = require('../scripts/lib/telemetry-schema.cjs');
+const routerPath = path.join(
+  repoDir,
+  'hooks',
+  'scripts',
+  'hooks',
+  'hook-router.js',
+);
+const codexRouterPath = path.join(repoDir, 'codex', 'hooks', 'hook-router.js');
+const crossReviewCliPath = path.join(
+  repoDir,
+  'goldband-loop',
+  'cross-review',
+  'cli.cjs',
+);
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    ...options,
+  });
+  assert.equal(
+    result.status,
+    options.expectStatus ?? 0,
+    result.stderr || result.stdout,
+  );
+  return result;
+}
+
+function makeRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'goldband-cross-review-'));
+  run('git', ['init'], { cwd: dir });
+  run('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  run('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+  fs.writeFileSync(path.join(dir, 'tracked.txt'), 'base\n');
+  fs.writeFileSync(path.join(dir, 'PLAN.md'), '# Plan\n');
+  run('git', ['add', '.'], { cwd: dir });
+  run('git', ['commit', '-m', 'base'], { cwd: dir });
+  return dir;
+}
+
+function testCanonicalHashCoversReviewScope() {
+  const dir = makeRepo();
+  const base = core.reviewedSha(
+    dir,
+    core.readContract('missing', {})?.baseCommit ||
+      run('git', ['rev-parse', 'HEAD'], { cwd: dir }).stdout.trim(),
+  );
+  const head = run('git', ['rev-parse', 'HEAD'], { cwd: dir }).stdout.trim();
+  const stableA = core.reviewedSha(dir, head);
+  const stableB = core.reviewedSha(dir, head);
+  assert.equal(stableA, stableB, 'same worktree hash should be stable');
+
+  fs.appendFileSync(path.join(dir, 'tracked.txt'), 'unstaged\n');
+  const trackedHash = core.reviewedSha(dir, head);
+  assert.notEqual(
+    trackedHash,
+    base,
+    'unstaged tracked content must affect hash',
+  );
+
+  run('git', ['add', 'tracked.txt'], { cwd: dir });
+  const stagedHash = core.reviewedSha(dir, head);
+  assert.equal(
+    stagedHash,
+    trackedHash,
+    'staging the same content must not change canonical hash',
+  );
+
+  fs.writeFileSync(path.join(dir, 'untracked.txt'), 'new\n');
+  const untrackedHash = core.reviewedSha(dir, head);
+  assert.notEqual(
+    untrackedHash,
+    stagedHash,
+    'untracked content must affect hash',
+  );
+
+  fs.writeFileSync(path.join(dir, 'binary.bin'), Buffer.from([0, 1, 2, 255]));
+  const binaryHash = core.reviewedSha(dir, head);
+  assert.notEqual(
+    binaryHash,
+    untrackedHash,
+    'untracked binary content must affect hash',
+  );
+
+  fs.writeFileSync(path.join(dir, 'crlf.txt'), 'a\r\nb\r\n');
+  const crlfHash = core.reviewedSha(dir, head);
+  assert.notEqual(crlfHash, binaryHash, 'CRLF file bytes must affect hash');
+}
+function envFor(dir, stateDir) {
+  return {
+    ...process.env,
+    GOLDBAND_CROSS_REVIEW_DIR: stateDir,
+    GOLDBAND_USAGE_FILE: path.join(stateDir, 'usage.jsonl'),
+  };
+}
+
+function readJsonl(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  return fs
+    .readFileSync(filePath, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+function runClaudeHook(input, dir, env, expectStatus = 0) {
+  return spawnSync(process.execPath, [routerPath], {
+    cwd: dir,
+    input: JSON.stringify(input),
+    encoding: 'utf8',
+    env,
+    maxBuffer: 10 * 1024 * 1024,
+    expectStatus,
+  });
+}
+
+function makeGateFixture(sessionId = 'session-a') {
+  const dir = makeRepo();
+  const stateDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'goldband-cross-review-state-'),
+  );
+  const env = envFor(dir, stateDir);
+  const head = run('git', ['rev-parse', 'HEAD'], { cwd: dir }).stdout.trim();
+  return { dir, env, head, sessionId };
+}
+
+function makeContractFixture(sessionId, overrides = {}) {
+  const fixture = makeGateFixture(sessionId);
+  core.createContract(
+    {
+      sessionId,
+      implementer: 'claude',
+      reviewer: 'codex',
+      planFile: 'PLAN.md',
+      baseCommit: fixture.head,
+      cwd: fixture.dir,
+      ...overrides,
+    },
+    fixture.env,
+  );
+  return fixture;
+}
+
+function assertUnarmedStopAllows(fixture) {
+  const result = runClaudeHook(
+    { hook_event_name: 'Stop', session_id: 'none' },
+    fixture.dir,
+    fixture.env,
+  );
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function assertPlanMissingBlocks(fixture) {
+  core.createContract(
+    {
+      sessionId: fixture.sessionId,
+      implementer: 'claude',
+      reviewer: 'codex',
+      planFile: null,
+      baseCommit: fixture.head,
+      cwd: fixture.dir,
+    },
+    fixture.env,
+  );
+  const result = runClaudeHook(
+    { hook_event_name: 'Stop', session_id: fixture.sessionId },
+    fixture.dir,
+    fixture.env,
+  );
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /尚未綁定 plan/);
+}
+
+function assertMarkerMissingBlocks(fixture) {
+  core.writeContract(
+    {
+      ...core.readContract(fixture.sessionId, fixture.env),
+      planFile: 'PLAN.md',
+    },
+    fixture.env,
+  );
+  const result = runClaudeHook(
+    { hook_event_name: 'Stop', session_id: fixture.sessionId },
+    fixture.dir,
+    fixture.env,
+  );
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /交互審查閘門/);
+  assert.match(result.stderr, /goldband-loop\/bin\/goldband-cross-review run/);
+}
+
+function assertArtifactMissingBlocks(fixture) {
+  fs.appendFileSync(
+    path.join(fixture.dir, 'PLAN.md'),
+    '\n<!-- GOLDBAND-CROSS-REVIEW: APPROVED reviewer=codex implementer=claude\n     reviewed-sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa rounds=1\n     artifact=missing at=2026-07-05T00:00:00.000Z session=session-a -->\n',
+  );
+  const result = runClaudeHook(
+    { hook_event_name: 'Stop', session_id: fixture.sessionId },
+    fixture.dir,
+    fixture.env,
+  );
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /找不到對應 reviewer artifact/);
+}
+
+function assertApprovalAllows(fixture) {
+  fs.writeFileSync(path.join(fixture.dir, 'PLAN.md'), '# Plan\n');
+  core.writeContract(
+    {
+      ...core.readContract(fixture.sessionId, fixture.env),
+      status: 'active',
+      roundsUsed: 0,
+    },
+    fixture.env,
+  );
+  const review = core.runReviewRound(
+    {
+      sessionId: fixture.sessionId,
+      reviewMode: 'mock',
+      mockVerdict: 'APPROVED',
+      cwd: fixture.dir,
+    },
+    fixture.env,
+  );
+  assert.equal(review.artifact.verdict, 'APPROVED');
+  assert.equal(review.artifact.reviewMode, 'mock');
+  let result = runClaudeHook(
+    { hook_event_name: 'Stop', session_id: fixture.sessionId },
+    fixture.dir,
+    fixture.env,
+  );
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /real review mode/);
+
+  const realArtifact = {
+    ...review.artifact,
+    artifactId: 'real-approved-fixture',
+    reviewMode: 'real',
+    reviewerCommand: 'fixture-real-reviewer',
+  };
+  core.writeArtifact(realArtifact, 'fixture raw output', fixture.env);
+  fs.appendFileSync(
+    path.join(fixture.dir, 'PLAN.md'),
+    `\n<!-- GOLDBAND-CROSS-REVIEW: APPROVED reviewer=codex implementer=claude\n     reviewed-sha=${realArtifact.reviewedSha} rounds=1\n     artifact=${realArtifact.artifactId} at=${realArtifact.createdAt} session=${fixture.sessionId} -->\n`,
+  );
+  core.writeContract(
+    { ...core.readContract(fixture.sessionId, fixture.env), status: 'active' },
+    fixture.env,
+  );
+  result = runClaudeHook(
+    { hook_event_name: 'Stop', session_id: fixture.sessionId },
+    fixture.dir,
+    fixture.env,
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    core.readContract(fixture.sessionId, fixture.env).status,
+    'passed',
+  );
+}
+
+function assertShaMismatchBlocks(fixture) {
+  core.writeContract(
+    { ...core.readContract(fixture.sessionId, fixture.env), status: 'active' },
+    fixture.env,
+  );
+  fs.appendFileSync(path.join(fixture.dir, 'tracked.txt'), 'after approval\n');
+  const result = runClaudeHook(
+    { hook_event_name: 'Stop', session_id: fixture.sessionId },
+    fixture.dir,
+    fixture.env,
+  );
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /通過後內容又變動/);
+}
+
+function assertOverrideAllows(fixture) {
+  core.overrideContract(fixture.sessionId, 'test override', fixture.env);
+  const result = runClaudeHook(
+    { hook_event_name: 'Stop', session_id: fixture.sessionId },
+    fixture.dir,
+    fixture.env,
+  );
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function testGateLifecycle() {
+  const fixture = makeGateFixture();
+  assertUnarmedStopAllows(fixture);
+  assertPlanMissingBlocks(fixture);
+  assertMarkerMissingBlocks(fixture);
+  assertArtifactMissingBlocks(fixture);
+  assertApprovalAllows(fixture);
+  assertShaMismatchBlocks(fixture);
+  assertOverrideAllows(fixture);
+}
+
+function testMaxRoundsAndRubricDowngrade() {
+  const { dir, env, sessionId } = makeContractFixture('session-b', {
+    maxRounds: 1,
+  });
+
+  const normalized = core.normalizeReviewResult(
+    {
+      verdict: 'CHANGES_REQUESTED',
+      findings: [{ severity: 'HIGH', status: 'open' }],
+    },
+    1,
+  );
+  assert.equal(
+    normalized.verdict,
+    'CHANGES_REQUESTED',
+    'reviewer CHANGES_REQUESTED must not be rewritten to APPROVED',
+  );
+  assert.equal(normalized.blockingCount, 0);
+
+  core.writeContract(
+    { ...core.readContract(sessionId, env), roundsUsed: 1 },
+    env,
+  );
+  const result = runClaudeHook(
+    { hook_event_name: 'Stop', session_id: sessionId },
+    dir,
+    env,
+  );
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /人類仲裁/);
+}
+
+function testRoundBoundaryDowngradesMovingGoalposts() {
+  const history = [
+    {
+      findings: [
+        {
+          id: 'CR-001',
+          severity: 'HIGH',
+          ruleId: 'correctness.contract',
+          failureScenario: 'Existing blocker.',
+          status: 'open',
+        },
+        {
+          id: 'CR-002',
+          severity: 'HIGH',
+          ruleId: 'correctness.contract',
+          failureScenario: 'Accepted rebuttal.',
+          status: 'rebutted-accepted',
+        },
+      ],
+    },
+  ];
+  const normalized = core.normalizeReviewResult(
+    {
+      verdict: 'CHANGES_REQUESTED',
+      findings: [
+        {
+          id: 'CR-001',
+          severity: 'HIGH',
+          ruleId: 'correctness.contract',
+          failureScenario: 'Still open.',
+          status: 'open',
+        },
+        {
+          id: 'CR-002',
+          severity: 'HIGH',
+          ruleId: 'correctness.contract',
+          failureScenario: 'Reopened accepted rebuttal.',
+          status: 'open',
+        },
+        {
+          id: 'CR-NEW',
+          severity: 'HIGH',
+          ruleId: 'correctness.contract',
+          failureScenario: 'New non-critical blocker.',
+          status: 'open',
+        },
+        {
+          id: 'CR-CRIT',
+          severity: 'CRITICAL',
+          ruleId: 'regression.clear',
+          failureScenario: 'New critical regression.',
+          status: 'open',
+        },
+      ],
+    },
+    2,
+    history,
+  );
+
+  const byId = new Map(
+    normalized.findings.map((finding) => [finding.id, finding]),
+  );
+  assert.equal(byId.get('CR-001').severity, 'HIGH');
+  assert.equal(byId.get('CR-002').severity, 'MEDIUM');
+  assert.equal(byId.get('CR-NEW').severity, 'MEDIUM');
+  assert.equal(byId.get('CR-CRIT').severity, 'CRITICAL');
+  assert.equal(normalized.blockingCount, 2);
+}
+
+function testImplementerResponsesEnterNextReviewerPrompt() {
+  const { dir, env, sessionId } = makeContractFixture('session-responses');
+
+  for (const response of ['fixed', 'rebutted', 'ask-human']) {
+    core.appendResponse(
+      sessionId,
+      {
+        findingId: `CR-${response}`,
+        response,
+        summary: `${response} summary`,
+        evidence: [`evidence-${response}`],
+      },
+      env,
+    );
+  }
+  fs.writeFileSync(
+    path.join(dir, 'new-implementation.js'),
+    'export const answer = 42;\n',
+  );
+
+  const prompt = core.buildReviewerPrompt(
+    core.readContract(sessionId, env),
+    dir,
+    env,
+  );
+  assert.match(prompt, /fixed summary/);
+  assert.match(prompt, /rebutted summary/);
+  assert.match(prompt, /ask-human summary/);
+  assert.match(prompt, /UNTRACKED new-implementation\.js/);
+  assert.match(prompt, /export const answer = 42/);
+}
+
+function testCodexStopHardBlocksWithExitCode() {
+  const { dir, env, sessionId } = makeContractFixture('codex-session', {
+    implementer: 'codex',
+    reviewer: 'claude',
+  });
+  const result = spawnSync(process.execPath, [codexRouterPath], {
+    cwd: dir,
+    input: JSON.stringify({ hook_event_name: 'Stop', session_id: sessionId }),
+    encoding: 'utf8',
+    env,
+  });
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, '');
+  assert.match(result.stderr, /交互審查閘門/);
+}
+
+function testPromptArm() {
+  const dir = makeRepo();
+  const stateDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'goldband-cross-review-state-'),
+  );
+  const env = envFor(dir, stateDir);
+  const contract = core.armFromPrompt(
+    {
+      session_id: 'prompt-session',
+      prompt: '請做這件事 [[cross-review]] --plan PLAN.md',
+    },
+    { cwd: dir, env, implementer: 'claude' },
+  );
+  assert.equal(contract.reviewer, 'codex');
+  assert.equal(contract.planFile, 'PLAN.md');
+}
+
+function testCliRunDoesNotClaimGatePassed() {
+  const { dir, env, sessionId } = makeContractFixture('cli-status');
+  const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'goldband-fake-bin-'));
+  fs.writeFileSync(
+    path.join(fakeBin, 'codex'),
+    '#!/bin/sh\ncat >/dev/null\nprintf "%s\\n" "GOLDBAND-CROSS-REVIEW-VERDICT: APPROVED reviewer=codex reviewed-sha=fake round=1 blocking=0 advisory=0 artifact=fake"\nprintf "%s\\n" "GOLDBAND-CROSS-REVIEW-FINDINGS: []"\n',
+  );
+  fs.chmodSync(path.join(fakeBin, 'codex'), 0o755);
+
+  const result = run(
+    process.execPath,
+    [crossReviewCliPath, 'run', '--session-id', sessionId],
+    {
+      cwd: dir,
+      env: { ...env, PATH: `${fakeBin}${path.delimiter}${env.PATH}` },
+    },
+  );
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.status, 'approved-marker-written');
+  assert.equal(output.artifact.reviewMode, 'real');
+  assert.match(output.artifact.reviewerCommand, /^codex exec/);
+  assert.equal(core.readContract(sessionId, env).status, 'active');
+}
+function makeEscalationFixture() {
+  const dir = makeRepo();
+  const stateDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'goldband-cross-review-state-'),
+  );
+  const env = envFor(dir, stateDir);
+  const sessionId = 'session-telemetry';
+  const head = run('git', ['rev-parse', 'HEAD'], { cwd: dir }).stdout.trim();
+  core.createContract(
+    {
+      sessionId,
+      implementer: 'claude',
+      reviewer: 'codex',
+      planFile: 'PLAN.md',
+      baseCommit: head,
+      maxRounds: 1,
+      cwd: dir,
+    },
+    env,
+  );
+  return { dir, env, sessionId };
+}
+function appendRebuttalResponse(sessionId, env) {
+  core.appendResponse(
+    sessionId,
+    {
+      findingId: 'CR-001',
+      response: 'rebutted',
+      summary: 'Evidence shows the contract is still valid.',
+      evidence: ['PLAN.md'],
+    },
+    env,
+  );
+}
+function assertEscalationStopBlocksWithSummary(dir, env, sessionId) {
+  const stopResult = runClaudeHook(
+    { hook_event_name: 'Stop', session_id: sessionId },
+    dir,
+    env,
+  );
+  assert.equal(stopResult.status, 2);
+  assert.match(stopResult.stderr, /人類仲裁/);
+  assert.match(stopResult.stderr, /session-telemetry-round-1-escalation\.md/);
+}
+
+function assertCrossReviewTelemetryEvents(env) {
+  const events = readJsonl(env.GOLDBAND_USAGE_FILE);
+  assert.ok(events.length > 0);
+  for (const event of events) {
+    assert.deepEqual(validateUsageEvent(event), { valid: true, errors: [] });
+  }
+  const eventNames = events.map((event) => event.name);
+  assert.ok(eventNames.includes('cross-review-armed'));
+  assert.ok(eventNames.includes('cross-review-response'));
+  assert.ok(eventNames.includes('cross-review-round'));
+  assert.ok(eventNames.includes('cross-review-escalation'));
+  assert.ok(eventNames.includes('cross-review-override'));
+}
+
+function testEscalationSummaryAndTelemetry() {
+  const { dir, env, sessionId } = makeEscalationFixture();
+  appendRebuttalResponse(sessionId, env);
+  const review = core.runReviewRound(
+    {
+      sessionId,
+      reviewMode: 'mock',
+      mockVerdict: 'CHANGES_REQUESTED',
+      cwd: dir,
+    },
+    env,
+  );
+  const contract = core.readContract(sessionId, env);
+  assert.equal(review.artifact.verdict, 'CHANGES_REQUESTED');
+  assert.ok(contract.escalationSummaryPath);
+  assert.ok(fs.existsSync(contract.escalationSummaryPath));
+  assert.match(
+    fs.readFileSync(contract.escalationSummaryPath, 'utf8'),
+    /Implementer Responses/,
+  );
+
+  assertEscalationStopBlocksWithSummary(dir, env, sessionId);
+  core.overrideContract(sessionId, 'human accepted risk', env);
+  assertCrossReviewTelemetryEvents(env);
+}
+
+testCanonicalHashCoversReviewScope();
+testGateLifecycle();
+testMaxRoundsAndRubricDowngrade();
+testRoundBoundaryDowngradesMovingGoalposts();
+testImplementerResponsesEnterNextReviewerPrompt();
+testCodexStopHardBlocksWithExitCode();
+testPromptArm();
+testCliRunDoesNotClaimGatePassed();
+testEscalationSummaryAndTelemetry();
+
+console.log('[OK] cross-review gate tests passed');

--- a/shell/install/profiles.sh
+++ b/shell/install/profiles.sh
@@ -124,7 +124,7 @@ install_all_with_workflow() {
 }
 
 install_commands() {
-    link_component "$REPO_DIR/commands" "$CLAUDE_DIR/commands" "Commands (5 個)"
+    link_component "$REPO_DIR/commands" "$CLAUDE_DIR/commands" "Commands"
 }
 
 install_rules() {


### PR DESCRIPTION
## Summary
- Adds the Claude/Codex cross-review gate CLI, runtime, schemas, reviewer prompts, Stop hook integration, and docs.
- Makes real review the production path and keeps mock review out of formal approvals.
- Adds regression coverage for fail-closed reviewer parsing, blocking findings, nonzero reviewer exits, untracked scope, marker hashing, and hook routing.

## Verification
- [x] npm run test:cross-review
- [x] npm run test:style-gate
- [x] node scripts/test-codex-hook-router.mjs
- [x] npm run test:hook-router -- --fixtures hooks/fixtures/router/cross-review-fixtures.json
- [x] git diff --cached --check

## Flow
- Commit was pushed to dev first: 2a214e6 feat: add cross-review gate
- This PR is dev -> main, matching the repository flow.

## Notes
- A mistaken feature -> main PR (#5) was closed.
- Untracked prompt drafts 01/02/03/05 were intentionally left out.