### PR TITLE
Fix sandbox Playwright setup and skill linking

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -158,8 +158,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
       - name: Show Bash version
         run: bash --version
+
+      - name: Install Goldband Loop dependencies
+        run: cd goldband-loop && bun install --frozen-lockfile
+
+      - name: Test Goldband Loop Playwright setup behavior on macOS
+        run: bash scripts/test-goldband-loop-playwright-setup.sh
 
       - name: Test workflow installer integration on macOS Bash
         run: bash scripts/test-workflow-integration.sh

--- a/goldband-loop/setup
+++ b/goldband-loop/setup
@@ -302,20 +302,90 @@ if [ "$INSTALL_CODEX" -eq 1 ]; then
   migrate_direct_codex_install "$SOURCE_GOLDBAND_DIR" "$CODEX_GOLDBAND"
 fi
 
+PLAYWRIGHT_LAST_ERROR_LOG=""
+
 ensure_playwright_browser() {
+  local log_file
+  log_file="$(mktemp "${TMPDIR:-/tmp}/goldband-playwright-check.XXXXXX")"
+
   if [ "$IS_WINDOWS" -eq 1 ]; then
     # On Windows, Bun can't launch Chromium due to broken pipe handling
     # (oven-sh/bun#4253). Use Node.js to verify Chromium works instead.
-    (
+    if (
       cd "$SOURCE_GOLDBAND_DIR"
       node -e "const { chromium } = require('playwright'); (async () => { const executablePath = process.env.GOLDBAND_CHROMIUM_PATH || undefined; const b = await chromium.launch(executablePath ? { executablePath } : {}); await b.close(); })()" 2>/dev/null
-    )
+    ) >"$log_file" 2>&1; then
+      rm -f "$log_file"
+      PLAYWRIGHT_LAST_ERROR_LOG=""
+      return 0
+    fi
   else
-    (
+    if (
       cd "$SOURCE_GOLDBAND_DIR"
       bun --eval 'import { chromium } from "playwright"; const executablePath = process.env.GOLDBAND_CHROMIUM_PATH || undefined; const browser = await chromium.launch(executablePath ? { executablePath } : {}); await browser.close();'
-    ) >/dev/null 2>&1
+    ) >"$log_file" 2>&1; then
+      rm -f "$log_file"
+      PLAYWRIGHT_LAST_ERROR_LOG=""
+      return 0
+    fi
   fi
+
+  PLAYWRIGHT_LAST_ERROR_LOG="$log_file"
+  return 1
+}
+
+playwright_error_matches() {
+  local pattern="$1"
+  [ -n "$PLAYWRIGHT_LAST_ERROR_LOG" ] || return 1
+  [ -f "$PLAYWRIGHT_LAST_ERROR_LOG" ] || return 1
+  grep -Eiq "$pattern" "$PLAYWRIGHT_LAST_ERROR_LOG"
+}
+
+playwright_failure_indicates_environment_block() {
+  playwright_error_matches 'Permission denied|Operation not permitted|MachPortRendezvousServer|bootstrap_check_in|EPERM|EACCES'
+}
+
+playwright_browser_cache_dir() {
+  if [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ]; then
+    printf '%s\n' "$PLAYWRIGHT_BROWSERS_PATH"
+    return 0
+  fi
+
+  case "$(uname -s)" in
+    Darwin) printf '%s\n' "$HOME/Library/Caches/ms-playwright" ;;
+    *) printf '%s\n' "${XDG_CACHE_HOME:-$HOME/.cache}/ms-playwright" ;;
+  esac
+}
+
+playwright_browser_cache_writable() {
+  local cache_dir
+  local probe
+  cache_dir="$(playwright_browser_cache_dir)"
+  probe="$cache_dir/.goldband-write-test.$$"
+
+  mkdir -p "$cache_dir" 2>/dev/null || return 1
+  if : >"$probe" 2>/dev/null; then
+    rm -f "$probe" 2>/dev/null || true
+    return 0
+  fi
+  return 1
+}
+
+handle_playwright_unavailable_without_install() {
+  local reason="$1"
+
+  PLAYWRIGHT_READY=0
+  if playwright_required; then
+    echo "goldband setup failed: $reason" >&2
+    echo "  Playwright Chromium install was not attempted because this environment cannot run or update the browser runtime safely." >&2
+    echo "  To install without browser workflows: GOLDBAND_SKIP_PLAYWRIGHT=1 ./setup --host $HOST --prefix" >&2
+    echo "  To make browser workflows optional in this environment: GOLDBAND_REQUIRE_PLAYWRIGHT=0 ./setup --host $HOST --prefix" >&2
+    return 1
+  fi
+
+  echo "warning: $reason" >&2
+  echo "warning: continuing without browser runtime because GOLDBAND_REQUIRE_PLAYWRIGHT=0" >&2
+  return 0
 }
 
 prepare_bun_for_windows_compile() {
@@ -492,23 +562,29 @@ if [ "${GOLDBAND_SKIP_PLAYWRIGHT:-0}" = "1" ]; then
   PLAYWRIGHT_READY=0
   log "Skipping Playwright Chromium install (GOLDBAND_SKIP_PLAYWRIGHT=1). Browser workflows will be unavailable until Chromium is installed."
 elif ! ensure_playwright_browser; then
-  echo "Installing Playwright Chromium..."
-  PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS="${GOLDBAND_PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS:-300}"
-  (
-    cd "$SOURCE_GOLDBAND_DIR"
-    run_with_timeout "$PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS" bunx playwright install chromium
-  ) || {
-    if playwright_required; then
-      echo "goldband setup failed: Playwright Chromium install did not finish successfully within ${PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS}s" >&2
+  if playwright_failure_indicates_environment_block; then
+    handle_playwright_unavailable_without_install "Playwright Chromium launch was blocked by the current environment or sandbox" || exit 1
+  elif ! playwright_browser_cache_writable; then
+    handle_playwright_unavailable_without_install "Playwright browser cache is not writable: $(playwright_browser_cache_dir)" || exit 1
+  else
+    echo "Installing Playwright Chromium..."
+    PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS="${GOLDBAND_PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS:-300}"
+    (
+      cd "$SOURCE_GOLDBAND_DIR"
+      run_with_timeout "$PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS" bunx playwright install chromium
+    ) || {
+      if playwright_required; then
+        echo "goldband setup failed: Playwright Chromium install did not finish successfully within ${PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS}s" >&2
+        echo "  Re-run manually for details: cd $SOURCE_GOLDBAND_DIR && bunx playwright install chromium" >&2
+        echo "  Or increase the timeout: GOLDBAND_PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS=600 ./setup --host $HOST --prefix" >&2
+        echo "  To install without browser workflows: GOLDBAND_SKIP_PLAYWRIGHT=1 ./setup --host $HOST --prefix" >&2
+        exit 1
+      fi
+      PLAYWRIGHT_READY=0
+      echo "warning: Playwright Chromium install did not finish successfully within ${PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS}s; continuing without browser runtime" >&2
       echo "  Re-run manually for details: cd $SOURCE_GOLDBAND_DIR && bunx playwright install chromium" >&2
-      echo "  Or increase the timeout: GOLDBAND_PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS=600 ./setup --host $HOST --prefix" >&2
-      echo "  To install without browser workflows: GOLDBAND_SKIP_PLAYWRIGHT=1 ./setup --host $HOST --prefix" >&2
-      exit 1
-    fi
-    PLAYWRIGHT_READY=0
-    echo "warning: Playwright Chromium install did not finish successfully within ${PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS}s; continuing without browser runtime" >&2
-    echo "  Re-run manually for details: cd $SOURCE_GOLDBAND_DIR && bunx playwright install chromium" >&2
-  }
+    }
+  fi
 
   if [ "$PLAYWRIGHT_READY" -eq 1 ] && [ "$IS_WINDOWS" -eq 1 ]; then
     # On Windows, Node.js launches Chromium (not Bun — see oven-sh/bun#4253).

--- a/scripts/test-auto-update.mjs
+++ b/scripts/test-auto-update.mjs
@@ -35,6 +35,50 @@ function readJson(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
 
+function testSkillLinkStopsAfterSymlinkRemoveFailure() {
+  const work = makeTempDir('goldband-skill-link-denied');
+  const source = path.join(
+    work,
+    'repo',
+    'skills',
+    'global',
+    'evidence-based-coding',
+  );
+  const targetDir = path.join(work, 'home', '.claude', 'skills');
+  const dest = path.join(targetDir, 'evidence-based-coding');
+  const polluted = path.join(source, 'evidence-based-coding');
+
+  fs.mkdirSync(source, { recursive: true });
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(source, 'SKILL.md'),
+    'name: evidence-based-coding\n',
+  );
+  fs.symlinkSync(source, dest);
+
+  const script = `
+set -euo pipefail
+source ${JSON.stringify(path.join(root, 'shell', 'install', 'common.sh'))}
+rm() {
+  if [ "$#" -eq 1 ] && [ "$1" = ${JSON.stringify(dest)} ]; then
+    echo "rm denied for $1" >&2
+    return 1
+  fi
+  command rm "$@"
+}
+if link_skill_entry ${JSON.stringify(source)} ${JSON.stringify(dest)}; then
+  echo "link_skill_entry unexpectedly succeeded" >&2
+  exit 1
+fi
+if [ -e ${JSON.stringify(polluted)} ] || [ -L ${JSON.stringify(polluted)} ]; then
+  echo "source skill directory was polluted by a nested symlink" >&2
+  exit 1
+fi
+`;
+
+  run('bash', ['-lc', script]);
+}
+
 function testInstallStateAndAutoRefresh() {
   const home = makeTempDir('goldband-auto-update-home');
   const env = {
@@ -223,6 +267,7 @@ function testSelfUpdateDirtyTrackedConflictSkipsRefresh() {
   );
 }
 
+testSkillLinkStopsAfterSymlinkRemoveFailure();
 testInstallStateAndAutoRefresh();
 testSelfUpdateDirtyFastForward();
 testSelfUpdateDirtyTrackedConflictSkipsRefresh();

--- a/scripts/test-goldband-loop-playwright-setup.sh
+++ b/scripts/test-goldband-loop-playwright-setup.sh
@@ -13,13 +13,23 @@ ensure_setup_preconditions() {
   fi
 
   echo "Building Goldband Loop browser binary for setup smoke precondition..."
-  build_log="$(mktemp "${TMPDIR:-/tmp}/goldband-pw-build.XXXXXX.log")"
+  build_log="$(mktemp "${TMPDIR:-/tmp}/goldband-pw-build.XXXXXX")"
   if ! (
     cd "$ROOT_DIR/goldband-loop"
     bun run build
   ) > "$build_log" 2>&1; then
     echo "failed to build Goldband Loop browser binary" >&2
     cat "$build_log" >&2
+    exit 1
+  fi
+}
+
+assert_portable_mktemp_templates() {
+  local matches
+  matches="$(grep -En 'mktemp .*[X][X][X][X][X][X][.]' "$SETUP_SCRIPT" "$0" || true)"
+  if [ -n "$matches" ]; then
+    echo "mktemp templates must keep XXXXXX at the end for macOS/BSD compatibility" >&2
+    echo "$matches" >&2
     exit 1
   fi
 }
@@ -54,6 +64,108 @@ run_required_missing_browser_fails() {
   fi
 }
 
+write_fake_playwright_tools() {
+  local fake_bin="$1"
+  local bun_mode="$2"
+  local bunx_marker="$3"
+  mkdir -p "$fake_bin"
+  cat > "$fake_bin/bun" <<EOF_BUN
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "--eval" ]; then
+  case "$bun_mode" in
+    sandbox)
+      echo "bootstrap_check_in com.microsoft.crashpad.child_port_handshake: Permission denied (1100)" >&2
+      ;;
+    missing)
+      echo "browserType.launch: Executable doesn't exist at /missing/chromium" >&2
+      ;;
+    *)
+      echo "unexpected fake bun mode: $bun_mode" >&2
+      ;;
+  esac
+  exit 1
+fi
+echo "unexpected fake bun invocation: \$*" >&2
+exit 99
+EOF_BUN
+  cat > "$fake_bin/bunx" <<EOF_BUNX
+#!/usr/bin/env bash
+set -euo pipefail
+touch "$bunx_marker"
+echo "bunx should not have been called" >&2
+exit 99
+EOF_BUNX
+  chmod +x "$fake_bin/bun" "$fake_bin/bunx"
+}
+
+run_sandbox_launch_block_skips_install() {
+  local tmp_home fake_bin log_file bunx_marker rc
+  tmp_home="$(mktemp -d "${TMPDIR:-/tmp}/goldband-pw-sandbox.XXXXXX")"
+  fake_bin="$tmp_home/bin"
+  log_file="$tmp_home/setup.log"
+  bunx_marker="$tmp_home/bunx-called"
+  write_fake_playwright_tools "$fake_bin" "sandbox" "$bunx_marker"
+
+  set +e
+  PATH="$fake_bin:$PATH" \
+    HOME="$tmp_home" \
+    GOLDBAND_SKIP_BUILD=1 \
+    GOLDBAND_SKIP_GENERATE=1 \
+    GOLDBAND_SKIP_COREUTILS=1 \
+    "$SETUP_SCRIPT" --host claude --prefix > "$log_file" 2>&1
+  rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ]; then
+    echo "expected setup to fail clearly when sandbox blocks Chromium launch" >&2
+    cat "$log_file" >&2
+    exit 1
+  fi
+  grep -q "Playwright Chromium launch was blocked" "$log_file"
+  grep -q "Playwright Chromium install was not attempted" "$log_file"
+  if [ -e "$bunx_marker" ]; then
+    echo "setup tried to install Chromium after a sandbox launch denial" >&2
+    cat "$log_file" >&2
+    exit 1
+  fi
+}
+
+run_unwritable_cache_skips_install() {
+  local tmp_home fake_bin log_file bunx_marker cache_path rc
+  tmp_home="$(mktemp -d "${TMPDIR:-/tmp}/goldband-pw-cache.XXXXXX")"
+  fake_bin="$tmp_home/bin"
+  log_file="$tmp_home/setup.log"
+  bunx_marker="$tmp_home/bunx-called"
+  cache_path="$tmp_home/not-a-directory"
+  printf 'not a directory\n' > "$cache_path"
+  write_fake_playwright_tools "$fake_bin" "missing" "$bunx_marker"
+
+  set +e
+  PATH="$fake_bin:$PATH" \
+    HOME="$tmp_home" \
+    PLAYWRIGHT_BROWSERS_PATH="$cache_path" \
+    GOLDBAND_SKIP_BUILD=1 \
+    GOLDBAND_SKIP_GENERATE=1 \
+    GOLDBAND_SKIP_COREUTILS=1 \
+    "$SETUP_SCRIPT" --host claude --prefix > "$log_file" 2>&1
+  rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ]; then
+    echo "expected setup to fail clearly when Playwright cache is not writable" >&2
+    cat "$log_file" >&2
+    exit 1
+  fi
+  grep -q "Playwright browser cache is not writable" "$log_file"
+  grep -q "Playwright Chromium install was not attempted" "$log_file"
+  if [ -e "$bunx_marker" ]; then
+    echo "setup tried to install Chromium with an unwritable cache" >&2
+    cat "$log_file" >&2
+    exit 1
+  fi
+}
+
 run_explicit_skip_succeeds() {
   local tmp_home log_file
   tmp_home="$(mktemp -d "${TMPDIR:-/tmp}/goldband-pw-skip.XXXXXX")"
@@ -72,7 +184,10 @@ run_explicit_skip_succeeds() {
   grep -q "goldband ready (claude, standard profile)." "$log_file"
 }
 
+assert_portable_mktemp_templates
 ensure_setup_preconditions
+run_sandbox_launch_block_skips_install
+run_unwritable_cache_skips_install
 run_required_missing_browser_fails
 run_explicit_skip_succeeds
 

--- a/shell/install/codex.sh
+++ b/shell/install/codex.sh
@@ -184,7 +184,7 @@ link_codex_rule_file() {
         return
     fi
 
-    create_repo_link "$src" "$dest"
+    create_repo_link "$src" "$dest" || return 1
     if [ "$CREATE_REPO_LINK_MODE" = "copy" ]; then
         echo -e "  ${YELLOW}[安裝 (copy fallback)] $label — 此環境無法建立檔案 symlink${NC}"
     else

--- a/shell/install/common.sh
+++ b/shell/install/common.sh
@@ -27,7 +27,7 @@ link_component() {
     fi
 
     mkdir -p "$(dirname "$dest")"
-    create_repo_link "$src" "$dest"
+    create_repo_link "$src" "$dest" || return 1
     if [ "$CREATE_REPO_LINK_MODE" = "copy" ]; then
         echo -e "  ${YELLOW}[安裝 (copy fallback)] $name — 此環境無法建立檔案 symlink${NC}"
     else
@@ -40,6 +40,10 @@ create_repo_link() {
     local dest="$2"
     CREATE_REPO_LINK_MODE=""
 
+    if [ -e "$dest" ] || [ -L "$dest" ]; then
+        rm -rf "$dest" || return 1
+    fi
+
     ln -s "$src" "$dest" 2>/dev/null || true
     if repo_link_points_to "$dest" "$src"; then
         CREATE_REPO_LINK_MODE="link"
@@ -47,7 +51,7 @@ create_repo_link() {
     fi
 
     if [ -e "$dest" ] || [ -L "$dest" ]; then
-        rm -rf "$dest"
+        rm -rf "$dest" || return 1
     fi
 
     if [ -d "$src" ] && create_windows_directory_junction "$src" "$dest"; then
@@ -55,13 +59,13 @@ create_repo_link() {
             CREATE_REPO_LINK_MODE="link"
             return 0
         fi
-        rm -rf "$dest"
+        rm -rf "$dest" || return 1
     fi
 
     if [ -d "$src" ]; then
-        cp -R "$src" "$dest"
+        cp -R "$src" "$dest" || return 1
     else
-        cp "$src" "$dest"
+        cp "$src" "$dest" || return 1
     fi
     CREATE_REPO_LINK_MODE="copy"
 }
@@ -377,12 +381,12 @@ link_skill_entry() {
     local dest="$2"
 
     if [ -L "$dest" ]; then
-        rm "$dest"
+        rm "$dest" || return 1
     elif [ -e "$dest" ]; then
-        backup_existing_path "$dest"
+        backup_existing_path "$dest" || return 1
     fi
 
-    create_repo_link "$source" "$dest"
+    create_repo_link "$source" "$dest" || return 1
 }
 
 write_skill_profile_file() {

--- a/shell/install/managed-profiles.sh
+++ b/shell/install/managed-profiles.sh
@@ -171,7 +171,7 @@ install_selected_profile_skills() {
             echo -e "  ${YELLOW}[跳過] ${missing_label} 不存在: $skill${NC}" >&2
             continue
         fi
-        link_skill_entry "$src" "$dest"
+        link_skill_entry "$src" "$dest" || return 1
         installed=$((installed + 1))
     done
     SELECTED_PROFILE_SKILLS_INSTALLED="$installed"
@@ -184,7 +184,7 @@ install_profile_extra_links() {
     for link_spec in "$@"; do
         local extra_src="${link_spec%%:*}"
         local extra_dest_name="${link_spec##*:}"
-        link_skill_entry "$extra_src" "$target_dir/$extra_dest_name"
+        link_skill_entry "$extra_src" "$target_dir/$extra_dest_name" || return 1
     done
 }
 


### PR DESCRIPTION
## Summary
- fail fast when Playwright Chromium launch/cache access is blocked by sandbox permissions instead of entering browser install retry
- prevent skill linking from continuing after failed symlink removal, avoiding nested symlinks in source skill directories
- add macOS CI coverage for the Playwright setup behavior test

## Verification
- bash -n goldband-loop/setup scripts/test-goldband-loop-playwright-setup.sh shell/install/common.sh shell/install/managed-profiles.sh shell/install/codex.sh
- bash scripts/test-goldband-loop-playwright-setup.sh
- npm run test:auto-update
- npm run lint:style
- npm run test:project-style-gate
- bash scripts/test-workflow-integration.sh
- git diff --check