### PR TITLE
fix: harden installer setup and hook output contracts

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -165,12 +165,13 @@ On Windows, use Git Bash or WSL. Native PowerShell install, status, uninstall,
 and self-update wrappers are retired. If an older install left
 `~/.claude/bin/goldband-self-update.ps1`,
 `~/.claude/shell/goldband-launchers.ps1`, or
-`~/.claude/.goldband-windows-state.json`, remove those stale files manually.
+`~/.claude/.goldband-windows-state.json`, rerun `./install.sh launchers` from
+Git Bash to back up the stale files and remove the old PowerShell profile block.
 
-`./install.sh codex-requirements` manages the POSIX system path
-`/etc/codex/requirements.toml`. Native Windows managed requirements must be
-installed by an administrator or managed policy at
-`%ProgramData%\OpenAI\Codex\requirements.toml`; goldband does not stage
+`./install.sh codex-requirements` manages `/etc/codex/requirements.toml` on
+POSIX hosts and `%ProgramData%\OpenAI\Codex\requirements.toml` when run from
+Git Bash on Windows. Native Windows managed requirements may still require an
+administrator or managed policy. goldband does not stage
 `~/.codex/requirements.toml` as a Windows enforcement path.
 
 ## Goldband Telemetry

--- a/goldband-loop/setup
+++ b/goldband-loop/setup
@@ -779,6 +779,22 @@ symlink_target_under_dir() {
   esac
 }
 
+skill_file_matches_under_dir() {
+  local target="$1"
+  local root="$2"
+  local source_skill
+
+  [ -f "$target/SKILL.md" ] || return 1
+  [ -d "$root" ] || return 1
+
+  for source_skill in "$root"/*/SKILL.md; do
+    [ -f "$source_skill" ] || continue
+    cmp -s "$target/SKILL.md" "$source_skill" && return 0
+  done
+
+  return 1
+}
+
 goldband_managed_skill_entry() {
   local target="$1"
   local source_root="$2"
@@ -796,6 +812,8 @@ goldband_managed_skill_entry() {
 
   if [ -d "$target" ]; then
     goldband_managed_skill_marker_matches "$target" "$source_root" "$generated_root" && return 0
+    skill_file_matches_under_dir "$target" "$source_root" && return 0
+    [ -n "$generated_root" ] && skill_file_matches_under_dir "$target" "$generated_root" && return 0
   fi
 
   return 1

--- a/hooks/fixtures/router/replay-fixtures.json
+++ b/hooks/fixtures/router/replay-fixtures.json
@@ -56,6 +56,35 @@
     }
   },
   {
+    "id": "lifecycle-session-start-context-restore",
+    "coverage": {
+      "category": "lifecycle-policy",
+      "policy": "session-start-context-restore",
+      "expectedDecision": "allow",
+      "variant": "positive",
+      "regressionSource": "session-start-output-json"
+    },
+    "env": {
+      "GOLDBAND_DATA_DIR": "__RUN_TMP__/lifecycle-data"
+    },
+    "input": {
+      "hook_event_name": "SessionStart",
+      "session_id": "lifecycle-session-start-context-restore-__ITERATION__"
+    },
+    "expect": {
+      "exitCode": 0,
+      "decision": "allow",
+      "stdoutIncludes": [
+        "hookSpecificOutput",
+        "SessionStart",
+        "context-restore"
+      ],
+      "stderrIncludes": [
+        "SessionStart"
+      ]
+    }
+  },
+  {
     "id": "pretool-allow-normal-edit",
     "coverage": {
       "category": "router-smoke",

--- a/hooks/scripts/hooks/hook-router.js
+++ b/hooks/scripts/hooks/hook-router.js
@@ -96,12 +96,20 @@ function writeLogs(lines) {
   }
 }
 
-function writeOutput(rawInput, outputJson) {
-  if (outputJson && typeof outputJson === 'object') {
-    process.stdout.write(JSON.stringify(outputJson));
+function writeOutput(outputJson) {
+  if (outputJson === null) {
     return;
   }
-  process.stdout.write(rawInput);
+
+  if (
+    !outputJson ||
+    typeof outputJson !== 'object' ||
+    Array.isArray(outputJson)
+  ) {
+    throw new TypeError('Hook router outputJson must be a JSON object or null');
+  }
+
+  process.stdout.write(JSON.stringify(outputJson));
 }
 
 function buildMetric(input, outcome, durationMs) {
@@ -157,7 +165,7 @@ async function main() {
     console.error(`[HookRouterMetrics] ${JSON.stringify(metric)}`);
   }
 
-  writeOutput(rawInput, outcome.outputJson);
+  writeOutput(outcome.outputJson);
 
   if (outcome.decision === 'block') {
     process.exit(2);
@@ -167,11 +175,17 @@ async function main() {
   process.exit(0);
 }
 
-main().catch((error) => {
-  const message =
-    error && error.stack
-      ? error.stack
-      : String(error || 'Unknown hook router error');
-  console.error(`[HookRouterError] ${message}`);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    const message =
+      error && error.stack
+        ? error.stack
+        : String(error || 'Unknown hook router error');
+    console.error(`[HookRouterError] ${message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  writeOutput,
+};

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,27 @@ SHELL_LAUNCHERS_FILE="$CLAUDE_SHELL_DIR/goldband-launchers.sh"
 ZSHRC_FILE="${ZDOTDIR:-$HOME}/.zshrc"
 CODEX_DIR="$HOME/.codex"
 CODEX_CONFIG_FILE="$CODEX_DIR/config.toml"
-CODEX_REQUIREMENTS_FILE="${CODEX_REQUIREMENTS_FILE:-/etc/codex/requirements.toml}"
+if [ -z "${CODEX_REQUIREMENTS_FILE+x}" ]; then
+    _goldband_uname="$(uname -s 2>/dev/null || true)"
+    if [ "${GOLDBAND_TEST_WINDOWS_HOST:-0}" = "1" ]; then
+        _goldband_uname="MINGW64_NT-test"
+    fi
+    case "$_goldband_uname" in
+        MINGW*|MSYS*|CYGWIN*)
+            _goldband_program_data="${ProgramData:-${PROGRAMDATA:-C:\\ProgramData}}"
+            if command -v cygpath >/dev/null 2>&1; then
+                CODEX_REQUIREMENTS_FILE="$(cygpath -u "$_goldband_program_data")/OpenAI/Codex/requirements.toml"
+            else
+                CODEX_REQUIREMENTS_FILE="/c/ProgramData/OpenAI/Codex/requirements.toml"
+            fi
+            unset _goldband_program_data
+            ;;
+        *)
+            CODEX_REQUIREMENTS_FILE="/etc/codex/requirements.toml"
+            ;;
+    esac
+    unset _goldband_uname
+fi
 CODEX_AGENTS_FILE="$CODEX_DIR/AGENTS.md"
 CODEX_CUSTOM_AGENTS_DIR="$CODEX_DIR/agents"
 CODEX_PROMPTS_DIR="$CODEX_DIR/prompts"
@@ -126,6 +146,7 @@ load_install_modules() {
         "$REPO_DIR/shell/install/profiles.sh" \
         "$REPO_DIR/shell/install/app-support-status.sh" \
         "$REPO_DIR/shell/install/knowledge-status.sh" \
+        "$REPO_DIR/shell/install/workflow-status.sh" \
         "$REPO_DIR/shell/install/status.sh" \
         "$REPO_DIR/shell/install/uninstall.sh"
     do

--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,8 @@ if [ -z "${CODEX_REQUIREMENTS_FILE+x}" ]; then
             _goldband_program_data="${ProgramData:-${PROGRAMDATA:-C:\\ProgramData}}"
             if command -v cygpath >/dev/null 2>&1; then
                 CODEX_REQUIREMENTS_FILE="$(cygpath -u "$_goldband_program_data")/OpenAI/Codex/requirements.toml"
+            elif [ "${_goldband_program_data#/}" != "$_goldband_program_data" ]; then
+                CODEX_REQUIREMENTS_FILE="${_goldband_program_data%/}/OpenAI/Codex/requirements.toml"
             else
                 CODEX_REQUIREMENTS_FILE="/c/ProgramData/OpenAI/Codex/requirements.toml"
             fi

--- a/plugin-assets/claude-code-plugin/hooks/scripts/hooks/hook-router.js
+++ b/plugin-assets/claude-code-plugin/hooks/scripts/hooks/hook-router.js
@@ -96,12 +96,20 @@ function writeLogs(lines) {
   }
 }
 
-function writeOutput(rawInput, outputJson) {
-  if (outputJson && typeof outputJson === 'object') {
-    process.stdout.write(JSON.stringify(outputJson));
+function writeOutput(outputJson) {
+  if (outputJson === null) {
     return;
   }
-  process.stdout.write(rawInput);
+
+  if (
+    !outputJson ||
+    typeof outputJson !== 'object' ||
+    Array.isArray(outputJson)
+  ) {
+    throw new TypeError('Hook router outputJson must be a JSON object or null');
+  }
+
+  process.stdout.write(JSON.stringify(outputJson));
 }
 
 function buildMetric(input, outcome, durationMs) {
@@ -157,7 +165,7 @@ async function main() {
     console.error(`[HookRouterMetrics] ${JSON.stringify(metric)}`);
   }
 
-  writeOutput(rawInput, outcome.outputJson);
+  writeOutput(outcome.outputJson);
 
   if (outcome.decision === 'block') {
     process.exit(2);
@@ -167,11 +175,17 @@ async function main() {
   process.exit(0);
 }
 
-main().catch((error) => {
-  const message =
-    error && error.stack
-      ? error.stack
-      : String(error || 'Unknown hook router error');
-  console.error(`[HookRouterError] ${message}`);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    const message =
+      error && error.stack
+        ? error.stack
+        : String(error || 'Unknown hook router error');
+    console.error(`[HookRouterError] ${message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  writeOutput,
+};

--- a/scripts/test-auto-update.mjs
+++ b/scripts/test-auto-update.mjs
@@ -5,14 +5,15 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const root = path.resolve(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   '..',
 );
 
 function run(command, args, options = {}) {
-  const result = spawnSync(command, args, {
+  const result = spawnSync(resolveCommand(command), args, {
     cwd: options.cwd || root,
     env: { ...process.env, ...(options.env || {}) },
     encoding: 'utf8',
@@ -25,6 +26,18 @@ function run(command, args, options = {}) {
     [command, ...args, result.stdout, result.stderr].join('\n'),
   );
   return result;
+}
+
+function resolveCommand(command) {
+  if (process.platform !== 'win32' || command !== 'bash') {
+    return command;
+  }
+  const candidates = [
+    process.env.GOLDBAND_TEST_BASH,
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+    'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
+  ].filter(Boolean);
+  return candidates.find((candidate) => fs.existsSync(candidate)) || command;
 }
 
 function makeTempDir(name) {
@@ -54,7 +67,7 @@ function testSkillLinkStopsAfterSymlinkRemoveFailure() {
     path.join(source, 'SKILL.md'),
     'name: evidence-based-coding\n',
   );
-  fs.symlinkSync(source, dest);
+  fs.symlinkSync(source, dest, process.platform === 'win32' ? 'junction' : 'dir');
 
   const script = `
 set -euo pipefail
@@ -134,6 +147,86 @@ function testInstallStateAndAutoRefresh() {
     /auto-update tracked targets: codex-prompts, hooks, rules, codex-hooks, codex-rules, codex-requirements/,
   );
   assert.match(status.stdout, /last auto-refresh: success/);
+}
+
+function testWindowsRequirementsDefaultPath() {
+  const home = makeTempDir('goldband-windows-requirements-home');
+  const programData = path.join(home, 'ProgramData');
+  const env = {
+    HOME: home,
+    ProgramData: programData,
+    GOLDBAND_TEST_WINDOWS_HOST: '1',
+  };
+
+  run('bash', ['./install.sh', 'codex-requirements'], { env });
+
+  const requirements = path.join(
+    programData,
+    'OpenAI',
+    'Codex',
+    'requirements.toml',
+  );
+  assert.equal(fs.existsSync(requirements), true);
+  assert.equal(
+    fs.readFileSync(requirements, 'utf8'),
+    fs.readFileSync(path.join(root, 'codex', 'requirements.toml'), 'utf8'),
+  );
+
+  const status = run('bash', ['./install.sh', 'status'], { env });
+  assert.match(status.stdout, /codex requirements -> .*ProgramData.*requirements\.toml/);
+}
+
+function testRetiredWindowsLauncherCleanup() {
+  const home = makeTempDir('goldband-windows-launchers-home');
+  const env = {
+    HOME: home,
+    GOLDBAND_TEST_WINDOWS_HOST: '1',
+  };
+  const claude = path.join(home, '.claude');
+  const staleUpdate = path.join(claude, 'bin', 'goldband-self-update.ps1');
+  const staleLaunchers = path.join(claude, 'shell', 'goldband-launchers.ps1');
+  const staleState = path.join(claude, '.goldband-windows-state.json');
+  const psProfile = path.join(
+    home,
+    'Documents',
+    'PowerShell',
+    'Microsoft.PowerShell_profile.ps1',
+  );
+  const windowsPsProfile = path.join(
+    home,
+    'Documents',
+    'WindowsPowerShell',
+    'Microsoft.PowerShell_profile.ps1',
+  );
+  const profileBlock = [
+    '# >>> goldband powershell launchers >>>',
+    'if (Test-Path "$HOME/.claude/shell/goldband-launchers.ps1") {',
+    '    . "$HOME/.claude/shell/goldband-launchers.ps1"',
+    '}',
+    '# <<< goldband powershell launchers <<<',
+    '',
+  ].join('\n');
+
+  fs.mkdirSync(path.dirname(staleUpdate), { recursive: true });
+  fs.mkdirSync(path.dirname(staleLaunchers), { recursive: true });
+  fs.mkdirSync(path.dirname(psProfile), { recursive: true });
+  fs.mkdirSync(path.dirname(windowsPsProfile), { recursive: true });
+  fs.writeFileSync(staleUpdate, 'old update\n');
+  fs.writeFileSync(staleLaunchers, 'old launchers\n');
+  fs.writeFileSync(staleState, '{}\n');
+  fs.writeFileSync(psProfile, `${profileBlock}Write-Output keep\n`);
+  fs.writeFileSync(windowsPsProfile, `${profileBlock}Write-Output keep\n`);
+
+  run('bash', ['./install.sh', 'launchers'], { env });
+
+  assert.equal(fs.existsSync(staleUpdate), false);
+  assert.equal(fs.existsSync(staleLaunchers), false);
+  assert.equal(fs.existsSync(staleState), false);
+  assert.equal(fs.readdirSync(path.dirname(staleUpdate)).some((name) => name.startsWith('goldband-self-update.ps1.bak.')), true);
+  assert.equal(fs.readdirSync(path.dirname(staleLaunchers)).some((name) => name.startsWith('goldband-launchers.ps1.bak.')), true);
+  assert.equal(fs.readdirSync(claude).some((name) => name.startsWith('.goldband-windows-state.json.bak.')), true);
+  assert.equal(fs.readFileSync(psProfile, 'utf8').includes('goldband-launchers.ps1'), false);
+  assert.equal(fs.readFileSync(windowsPsProfile, 'utf8').includes('goldband-launchers.ps1'), false);
 }
 
 function writeAutoRefreshTargets(stateFile, state) {
@@ -269,6 +362,8 @@ function testSelfUpdateDirtyTrackedConflictSkipsRefresh() {
 
 testSkillLinkStopsAfterSymlinkRemoveFailure();
 testInstallStateAndAutoRefresh();
+testWindowsRequirementsDefaultPath();
+testRetiredWindowsLauncherCleanup();
 testSelfUpdateDirtyFastForward();
 testSelfUpdateDirtyTrackedConflictSkipsRefresh();
 console.log('[OK] auto-update installer refresh tests passed');

--- a/scripts/test-auto-update.mjs
+++ b/scripts/test-auto-update.mjs
@@ -7,10 +7,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const root = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  '..',
-);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 function run(command, args, options = {}) {
   const result = spawnSync(resolveCommand(command), args, {
@@ -67,7 +64,11 @@ function testSkillLinkStopsAfterSymlinkRemoveFailure() {
     path.join(source, 'SKILL.md'),
     'name: evidence-based-coding\n',
   );
-  fs.symlinkSync(source, dest, process.platform === 'win32' ? 'junction' : 'dir');
+  fs.symlinkSync(
+    source,
+    dest,
+    process.platform === 'win32' ? 'junction' : 'dir',
+  );
 
   const script = `
 set -euo pipefail
@@ -173,7 +174,10 @@ function testWindowsRequirementsDefaultPath() {
   );
 
   const status = run('bash', ['./install.sh', 'status'], { env });
-  assert.match(status.stdout, /codex requirements -> .*ProgramData.*requirements\.toml/);
+  assert.match(
+    status.stdout,
+    /codex requirements -> .*ProgramData.*requirements\.toml/,
+  );
 }
 
 function testRetiredWindowsLauncherCleanup() {
@@ -219,14 +223,56 @@ function testRetiredWindowsLauncherCleanup() {
 
   run('bash', ['./install.sh', 'launchers'], { env });
 
+  assertRetiredWindowsLaunchersRemoved({
+    claude,
+    psProfile,
+    staleLaunchers,
+    staleState,
+    staleUpdate,
+    windowsPsProfile,
+  });
+}
+
+function assertRetiredWindowsLaunchersRemoved(paths) {
+  const {
+    claude,
+    psProfile,
+    staleLaunchers,
+    staleState,
+    staleUpdate,
+    windowsPsProfile,
+  } = paths;
   assert.equal(fs.existsSync(staleUpdate), false);
   assert.equal(fs.existsSync(staleLaunchers), false);
   assert.equal(fs.existsSync(staleState), false);
-  assert.equal(fs.readdirSync(path.dirname(staleUpdate)).some((name) => name.startsWith('goldband-self-update.ps1.bak.')), true);
-  assert.equal(fs.readdirSync(path.dirname(staleLaunchers)).some((name) => name.startsWith('goldband-launchers.ps1.bak.')), true);
-  assert.equal(fs.readdirSync(claude).some((name) => name.startsWith('.goldband-windows-state.json.bak.')), true);
-  assert.equal(fs.readFileSync(psProfile, 'utf8').includes('goldband-launchers.ps1'), false);
-  assert.equal(fs.readFileSync(windowsPsProfile, 'utf8').includes('goldband-launchers.ps1'), false);
+  assert.equal(
+    fs
+      .readdirSync(path.dirname(staleUpdate))
+      .some((name) => name.startsWith('goldband-self-update.ps1.bak.')),
+    true,
+  );
+  assert.equal(
+    fs
+      .readdirSync(path.dirname(staleLaunchers))
+      .some((name) => name.startsWith('goldband-launchers.ps1.bak.')),
+    true,
+  );
+  assert.equal(
+    fs
+      .readdirSync(claude)
+      .some((name) => name.startsWith('.goldband-windows-state.json.bak.')),
+    true,
+  );
+  assert.equal(
+    fs.readFileSync(psProfile, 'utf8').includes('goldband-launchers.ps1'),
+    false,
+  );
+  assert.equal(
+    fs
+      .readFileSync(windowsPsProfile, 'utf8')
+      .includes('goldband-launchers.ps1'),
+    false,
+  );
 }
 
 function writeAutoRefreshTargets(stateFile, state) {

--- a/scripts/test-claude-hook-router-review-readonly.mjs
+++ b/scripts/test-claude-hook-router-review-readonly.mjs
@@ -3,6 +3,7 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -18,6 +19,8 @@ const routerPath = path.join(
   'hooks',
   'hook-router.js',
 );
+const require = createRequire(import.meta.url);
+const { writeOutput } = require(routerPath);
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'goldband-review-hook-'));
 
 process.on('exit', () => {
@@ -130,6 +133,55 @@ function assertStopClearsReviewReadOnly(sessionId) {
   assert.equal(editAfterStop.status, 0, editAfterStop.stderr);
 }
 
+function assertAllowedWriteHasNoHookOutput() {
+  const allowedWrite = runHook('allow-output-regression', {
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Write',
+    tool_input: {
+      file_path: 'src/allow-output-regression.ts',
+      content: 'export {};\n',
+    },
+  });
+
+  assert.equal(allowedWrite.status, 0, allowedWrite.stderr);
+  assert.equal(
+    allowedWrite.stdout,
+    '',
+    'An allow hook must not echo its input as Claude hook output',
+  );
+}
+
+function assertRepeatedSessionStartHasNoHookOutput() {
+  const sessionId = 'session-start-output-regression';
+  const firstSessionStart = runHook(sessionId, {
+    hook_event_name: 'SessionStart',
+  });
+  assert.equal(firstSessionStart.status, 0, firstSessionStart.stderr);
+  assert.equal(
+    JSON.parse(firstSessionStart.stdout).hookSpecificOutput.hookEventName,
+    'SessionStart',
+  );
+
+  const repeatedSessionStart = runHook(sessionId, {
+    hook_event_name: 'SessionStart',
+  });
+  assert.equal(repeatedSessionStart.status, 0, repeatedSessionStart.stderr);
+  assert.equal(
+    repeatedSessionStart.stdout,
+    '',
+    'A deduplicated SessionStart with outputJson: null must emit no hook output',
+  );
+}
+
+function assertInvalidHookOutputFailsLoudly() {
+  for (const invalidOutput of [undefined, false, '', 1, []]) {
+    assert.throws(
+      () => writeOutput(invalidOutput),
+      /outputJson must be a JSON object or null/,
+    );
+  }
+}
+
 assertReviewReadOnlyActivation('goldband-name', { name: 'goldband-review' });
 assertReviewReadOnlyActivation('short-name', { name: 'review' });
 assertReviewReadOnlyActivation('skill-name-field', { skill_name: '/review' });
@@ -152,5 +204,9 @@ const editAfterShip = runHook(nonReviewSession, {
   },
 });
 assert.equal(editAfterShip.status, 0, editAfterShip.stderr);
+
+assertAllowedWriteHasNoHookOutput();
+assertRepeatedSessionStartHasNoHookOutput();
+assertInvalidHookOutputFailsLoudly();
 
 console.log('[OK] Claude /review hook read-only enforcement verified');

--- a/scripts/test-code-style-gate.mjs
+++ b/scripts/test-code-style-gate.mjs
@@ -139,6 +139,10 @@ function testPreCommitProjectHookSkippedOnGoldbandFailure() {
 }
 
 function testPreCommitWarnsWhenProjectHookNotExecutable() {
+  if (process.platform === 'win32') {
+    return;
+  }
+
   const dir = createRepo();
   const log = path.join(dir, 'hook-order.log');
   const gate = path.join(dir, 'goldband-gate.mjs');
@@ -245,16 +249,24 @@ function testPreCommitMissingChecker() {
 function testPreCommitMissingNode() {
   const dir = createRepo();
   const binDir = path.join(dir, 'bin');
-  fs.mkdirSync(binDir);
-  fs.symlinkSync(resolveCommand('git'), path.join(binDir, 'git'));
-  fs.symlinkSync(resolveCommand('dirname'), path.join(binDir, 'dirname'));
+  let pathWithoutNode = binDir;
+  if (process.platform === 'win32') {
+    pathWithoutNode = [
+      path.dirname(resolveCommand('git')),
+      path.dirname(resolveCommand('dirname')),
+    ].join(path.delimiter);
+  } else {
+    fs.mkdirSync(binDir);
+    fs.symlinkSync(resolveCommand('git'), path.join(binDir, 'git'));
+    fs.symlinkSync(resolveCommand('dirname'), path.join(binDir, 'dirname'));
+  }
 
   const result = run('/bin/bash', [preCommitHook], {
     cwd: dir,
     env: {
       ...process.env,
       GOLDBAND_STYLE_GATE_SCRIPT: checker,
-      PATH: binDir,
+      PATH: pathWithoutNode,
     },
   });
 
@@ -294,11 +306,26 @@ function hookEnv(overrides = {}) {
 }
 
 function run(command, args, options = {}) {
-  return spawnSync(command, args, {
+  return spawnSync(resolveSpawnCommand(command), args, {
     cwd: options.cwd ?? repoRoot,
     encoding: 'utf8',
     env: options.env ?? process.env,
   });
+}
+
+function resolveSpawnCommand(command) {
+  if (process.platform !== 'win32') {
+    return command;
+  }
+  if (command !== 'bash' && command !== '/bin/bash' && command !== '/bin/sh') {
+    return command;
+  }
+  const candidates = [
+    process.env.GOLDBAND_TEST_BASH,
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+    'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
+  ].filter(Boolean);
+  return candidates.find((candidate) => fs.existsSync(candidate)) || command;
 }
 
 function resolveCommand(command) {

--- a/scripts/test-telemetry.mjs
+++ b/scripts/test-telemetry.mjs
@@ -385,9 +385,12 @@ function testClaudeSessionStartContextIsDedupedBySession() {
   });
 
   const firstOutput = JSON.parse(first.stdout);
-  const secondOutput = JSON.parse(second.stdout);
   assert.equal(firstOutput.hookSpecificOutput.hookEventName, 'SessionStart');
-  assert.equal(secondOutput.hookSpecificOutput, undefined);
+  assert.equal(
+    second.stdout,
+    '',
+    'A deduplicated SessionStart must emit no hook output',
+  );
 
   const sessionStartEvents = readJsonl(usageFile).filter(
     (event) =>

--- a/shell/install/codex.sh
+++ b/shell/install/codex.sh
@@ -127,6 +127,10 @@ install_codex_requirements_file() {
         fi
         cp "$src" "$dest"
         chmod 0644 "$dest"
+    elif is_windows_host; then
+        echo -e "  ${RED}[錯誤] Codex requirements 需要可寫入的 Windows managed path:${NC} $dest" >&2
+        echo -e "  ${CYAN}  請用系統管理員權限建立此目錄並複製 codex/requirements.toml，或用 CODEX_REQUIREMENTS_FILE 指到可寫入的測試路徑。${NC}" >&2
+        return 1
     else
         sudo mkdir -p "$dest_dir"
         if sudo test -e "$dest" && ! sudo cmp -s "$src" "$dest"; then

--- a/shell/install/common.sh
+++ b/shell/install/common.sh
@@ -140,6 +140,14 @@ join_by_comma() {
     echo "$*"
 }
 
+is_windows_host() {
+    [ "${GOLDBAND_TEST_WINDOWS_HOST:-0}" = "1" ] && return 0
+    case "$(uname -s 2>/dev/null || true)" in
+        MINGW*|MSYS*|CYGWIN*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 dedupe_skill_list() {
     local seen=" "
     local output=()
@@ -354,6 +362,12 @@ backup_existing_path() {
     local backup_path="${path}.bak.$(timestamp_suffix)"
     mv "$path" "$backup_path"
     echo -e "  ${YELLOW}[備份] $(basename "$path") -> $backup_path${NC}"
+}
+
+backup_or_remove_existing_path() {
+    local path="$1"
+    [ -e "$path" ] || [ -L "$path" ] || return 0
+    backup_existing_path "$path"
 }
 
 prepare_skills_directory() {

--- a/shell/install/install-state.sh
+++ b/shell/install/install-state.sh
@@ -9,6 +9,16 @@ install_state_dir() {
     dirname "$(install_state_file)"
 }
 
+install_state_python_available() {
+    command -v python3 >/dev/null 2>&1 || return 1
+    python3 -c 'import json' >/dev/null 2>&1
+}
+
+install_state_node_available() {
+    command -v node >/dev/null 2>&1 || return 1
+    node -e 'JSON.parse("{}")' >/dev/null 2>&1
+}
+
 normalize_install_target() {
     case "$1" in
         help|-h|--help|status|auto-refresh)
@@ -65,7 +75,7 @@ install_state_targets() {
     state_file="$(install_state_file)"
     [ -f "$state_file" ] || return 0
 
-    if command -v python3 >/dev/null 2>&1; then
+    if install_state_python_available; then
         python3 - "$state_file" <<'PY'
 import json
 import sys
@@ -80,6 +90,18 @@ for target in data.get("targets", []):
     if isinstance(target, str) and target:
         print(target)
 PY
+        return 0
+    fi
+
+    if install_state_node_available; then
+        node -e '
+const fs = require("fs");
+let data = {};
+try { data = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); } catch {}
+for (const target of data.targets || []) {
+  if (typeof target === "string" && target) console.log(target);
+}
+' "$state_file"
         return 0
     fi
 
@@ -101,12 +123,12 @@ install_state_write() {
     state_dir="$(dirname "$state_file")"
     mkdir -p "$state_dir"
 
-    if command -v python3 >/dev/null 2>&1; then
+    if install_state_python_available; then
         install_state_write_python "$state_file" "$refresh_status" "$refresh_old" "$refresh_new" "$refresh_message" "${targets[@]}"
         return 0
     fi
 
-    install_state_write_fallback "$state_file" "${targets[@]}"
+    install_state_write_fallback "$state_file" "$refresh_status" "$refresh_old" "$refresh_new" "$refresh_message" "${targets[@]}"
 }
 
 install_state_write_python() {
@@ -158,12 +180,18 @@ PY
 
 install_state_write_fallback() {
     local state_file="$1"
+    local refresh_status="$2"
+    local refresh_old="$3"
+    local refresh_new="$4"
+    local refresh_message="$5"
     local tmp_file="${state_file}.tmp.$$"
-    shift
+    shift 5
+    local updated_at
+    updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     {
         printf '{\n'
         printf '  "version": 1,\n'
-        printf '  "updatedAt": "%s",\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        printf '  "updatedAt": "%s",\n' "$updated_at"
         printf '  "repo": "%s",\n' "$(printf '%s' "$REPO_DIR" | sed 's/\\/\\\\/g; s/"/\\"/g')"
         printf '  "targets": ['
         local first=true target
@@ -176,10 +204,46 @@ install_state_write_fallback() {
             fi
             printf '"%s"' "$target"
         done
-        printf ']\n'
+        printf ']'
+        if [ -n "$refresh_status" ]; then
+            printf ',\n'
+            printf '  "lastAutoRefresh": {\n'
+            printf '    "status": "%s",\n' "$(json_escape_string "$refresh_status")"
+            printf '    "updatedAt": "%s",\n' "$updated_at"
+            printf '    "oldHead": %s,\n' "$(json_nullable_string "$refresh_old")"
+            printf '    "newHead": %s,\n' "$(json_nullable_string "$refresh_new")"
+            printf '    "message": %s,\n' "$(json_nullable_string "$refresh_message")"
+            printf '    "targets": ['
+            first=true
+            for target in "$@"; do
+                [ -n "$target" ] || continue
+                if $first; then
+                    first=false
+                else
+                    printf ', '
+                fi
+                printf '"%s"' "$(json_escape_string "$target")"
+            done
+            printf ']\n'
+            printf '  }\n'
+        else
+            printf '\n'
+        fi
         printf '}\n'
     } > "$tmp_file"
     mv "$tmp_file" "$state_file"
+}
+
+json_escape_string() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+json_nullable_string() {
+    if [ -z "$1" ]; then
+        printf 'null'
+    else
+        printf '"%s"' "$(json_escape_string "$1")"
+    fi
 }
 
 record_installed_target() {
@@ -344,7 +408,7 @@ show_auto_update_status() {
         return 0
     fi
 
-    if command -v python3 >/dev/null 2>&1; then
+    if install_state_python_available; then
         python3 - "$state_file" <<'PY'
 import json
 import sys
@@ -367,6 +431,25 @@ if isinstance(last, dict):
     if message:
         print(f"    {message}")
 PY
+        return 0
+    fi
+
+    if install_state_node_available; then
+        node -e '
+const fs = require("fs");
+let data = {};
+try { data = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); } catch (error) {
+  console.log(`  [警告] auto-update install-state 無法讀取: ${error.message}`);
+  process.exit(0);
+}
+const targets = (data.targets || []).join(", ") || "none";
+console.log(`  [OK] auto-update tracked targets: ${targets}`);
+const last = data.lastAutoRefresh;
+if (last && typeof last === "object") {
+  console.log(`  [OK] last auto-refresh: ${last.status || "unknown"} at ${last.updatedAt || "unknown time"}`);
+  if (last.message) console.log(`    ${last.message}`);
+}
+' "$state_file"
         return 0
     fi
 

--- a/shell/install/launchers.sh
+++ b/shell/install/launchers.sh
@@ -63,7 +63,67 @@ remove_shell_launcher_block() {
     mv "$temp_file" "$rc_file"
 }
 
+strip_powershell_launcher_block() {
+    local profile_file="$1"
+    local begin_marker="# >>> goldband powershell launchers >>>"
+    local end_marker="# <<< goldband powershell launchers <<<"
+    local temp_file
+
+    [ -f "$profile_file" ] || return 1
+    temp_file="$(mktemp)"
+
+    awk -v begin="$begin_marker" -v end="$end_marker" '
+        BEGIN { skipping = 0 }
+        $0 == begin { skipping = 1; next }
+        skipping == 1 && $0 == end { skipping = 0; next }
+        skipping == 0 { print }
+    ' "$profile_file" > "$temp_file" || {
+        rm -f "$temp_file"
+        return 1
+    }
+
+    printf '%s\n' "$temp_file"
+}
+
+remove_powershell_launcher_block() {
+    local profile_file="$1"
+    local temp_file
+
+    [ -f "$profile_file" ] || return 0
+    grep -q '^# >>> goldband powershell launchers >>>$' "$profile_file" 2>/dev/null || return 0
+    temp_file="$(strip_powershell_launcher_block "$profile_file")" || return 1
+    mv "$temp_file" "$profile_file"
+    echo -e "  ${GREEN}[移除] retired PowerShell launcher profile block -> $profile_file${NC}"
+}
+
+cleanup_retired_windows_launchers() {
+    is_windows_host || return 0
+
+    local stale_update="$CLAUDE_DIR/bin/goldband-self-update.ps1"
+    local stale_launchers="$CLAUDE_DIR/shell/goldband-launchers.ps1"
+    local stale_state="$CLAUDE_DIR/.goldband-windows-state.json"
+    local powershell_profile="$HOME/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"
+    local windows_powershell_profile="$HOME/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1"
+
+    if [ -e "$stale_update" ] || [ -L "$stale_update" ]; then
+        backup_or_remove_existing_path "$stale_update"
+        echo -e "  ${GREEN}[清理] retired PowerShell self-update wrapper${NC}"
+    fi
+    if [ -e "$stale_launchers" ] || [ -L "$stale_launchers" ]; then
+        backup_or_remove_existing_path "$stale_launchers"
+        echo -e "  ${GREEN}[清理] retired PowerShell launcher wrappers${NC}"
+    fi
+    if [ -e "$stale_state" ] || [ -L "$stale_state" ]; then
+        backup_or_remove_existing_path "$stale_state"
+        echo -e "  ${GREEN}[清理] retired PowerShell launcher state${NC}"
+    fi
+
+    remove_powershell_launcher_block "$powershell_profile"
+    remove_powershell_launcher_block "$windows_powershell_profile"
+}
+
 install_shell_launchers() {
+    cleanup_retired_windows_launchers
     link_component "$REPO_DIR/shell/goldband-self-update.sh" "$SHELL_UPDATE_BIN" "Shell self-update script"
     link_component "$REPO_DIR/shell/goldband-launchers.sh" "$SHELL_LAUNCHERS_FILE" "Shell launcher wrappers"
     upsert_shell_launcher_block "$ZSHRC_FILE"

--- a/shell/install/status.sh
+++ b/shell/install/status.sh
@@ -51,7 +51,9 @@ show_claude_goldband_entrypoint_status() {
     local alias="$SKILLS_DIR/_goldband-command" runtime_dir="$SKILLS_DIR/goldband"
     [ -e "$alias" ] || [ -L "$alias" ] || return 0
 
-    if [ -f "$alias/.goldband-managed-skill" ] || { [ -d "$alias" ] && [ -L "$alias/SKILL.md" ] && workflow_status_symlink_target_under_dir "$alias/SKILL.md" "$runtime_dir"; }; then
+    if [ -f "$alias/.goldband-managed-skill" ] ||
+        { [ -d "$alias" ] && [ -L "$alias/SKILL.md" ] && workflow_status_symlink_target_under_dir "$alias/SKILL.md" "$runtime_dir"; } ||
+        { [ -d "$alias" ] && [ -f "$runtime_dir/SKILL.md" ] && cmp -s "$alias/SKILL.md" "$runtime_dir/SKILL.md" 2>/dev/null; }; then
         echo -e "  ${RED}[重複]${NC} legacy /goldband skill alias -> $alias"
         echo "    active selector should be: $CLAUDE_DIR/commands/goldband.md"
         echo "    建議: 重跑 ./install.sh workflow，或刪除 goldband-managed 的 _goldband-command alias。"
@@ -108,6 +110,22 @@ show_shell_launcher_status() {
         echo -e "  ${YELLOW}[部分安裝]${NC} shell launchers — 建議重跑 ./install.sh launchers"
     else
         echo -e "  ${YELLOW}[未安裝]${NC} shell launchers (zsh)"
+    fi
+    show_retired_windows_launcher_status
+}
+
+show_retired_windows_launcher_status() {
+    is_windows_host || return 0
+
+    local stale=()
+    { [ -e "$CLAUDE_DIR/bin/goldband-self-update.ps1" ] || [ -L "$CLAUDE_DIR/bin/goldband-self-update.ps1" ]; } && stale+=("~/.claude/bin/goldband-self-update.ps1")
+    { [ -e "$CLAUDE_DIR/shell/goldband-launchers.ps1" ] || [ -L "$CLAUDE_DIR/shell/goldband-launchers.ps1" ]; } && stale+=("~/.claude/shell/goldband-launchers.ps1")
+    { [ -e "$CLAUDE_DIR/.goldband-windows-state.json" ] || [ -L "$CLAUDE_DIR/.goldband-windows-state.json" ]; } && stale+=("~/.claude/.goldband-windows-state.json")
+
+    if [ "${#stale[@]}" -gt 0 ]; then
+        echo -e "  ${RED}[stale]${NC} retired PowerShell launchers: $(join_by_comma "${stale[@]}")"
+        echo "    建議: 重跑 ./install.sh launchers 清理舊 Windows wrapper。"
+        GOLDBAND_STATUS_EXIT_CODE=2
     fi
 }
 
@@ -414,149 +432,6 @@ show_workflow_runtime_status() {
     else
         echo -e "  ${YELLOW}[未安裝]${NC} Goldband Loop $label"
     fi
-}
-
-workflow_status_path_under_dir() {
-    local candidate="$1"
-    local base="$2"
-    local candidate_real base_real
-    candidate_real="$(cd "$candidate" 2>/dev/null && pwd -P)" || return 1
-    base_real="$(cd "$base" 2>/dev/null && pwd -P)" || return 1
-    case "$candidate_real" in
-        "$base_real"|"$base_real"/*) return 0 ;;
-        *) return 1 ;;
-    esac
-}
-
-workflow_status_symlink_target_under_dir() {
-    local candidate="$1"
-    local base="$2"
-    local link_dest candidate_dir resolved_dir resolved_path base_real
-    link_dest="$(readlink "$candidate" 2>/dev/null || true)"
-    [ -n "$link_dest" ] || return 1
-    case "$link_dest" in
-        /*) resolved_path="$link_dest" ;;
-        *)
-            candidate_dir="$(dirname "$candidate")"
-            resolved_path="$candidate_dir/$link_dest"
-            ;;
-    esac
-    resolved_dir="$(dirname "$resolved_path")"
-    resolved_path="$(cd "$resolved_dir" 2>/dev/null && pwd -P)/$(basename "$resolved_path")" || return 1
-    base_real="$(cd "$base" 2>/dev/null && pwd -P)" || return 1
-    case "$resolved_path" in
-        "$base_real"|"$base_real"/*) return 0 ;;
-        *) return 1 ;;
-    esac
-}
-
-workflow_generated_root_for_runtime() {
-    local runtime_dir="$1"
-    local skill_link="$runtime_dir/SKILL.md"
-    local link_dest link_dir resolved_path skill_dir
-
-    [ -L "$skill_link" ] || return 1
-    link_dest="$(readlink "$skill_link" 2>/dev/null || true)"
-    [ -n "$link_dest" ] || return 1
-    case "$link_dest" in
-        /*) resolved_path="$link_dest" ;;
-        *)
-            link_dir="$(dirname "$skill_link")"
-            resolved_path="$link_dir/$link_dest"
-            ;;
-    esac
-    link_dir="$(dirname "$resolved_path")"
-    resolved_path="$(cd "$link_dir" 2>/dev/null && pwd -P)/$(basename "$resolved_path")" || return 1
-    skill_dir="$(dirname "$resolved_path")"
-    if [ -f "$skill_dir/setup" ] && [ -d "$skill_dir/goldband-upgrade" ]; then
-        printf '%s\n' "$skill_dir"
-        return 0
-    fi
-    [ "$(basename "$skill_dir")" = "goldband" ] || return 1
-    dirname "$skill_dir"
-}
-
-workflow_marker_points_to_root() {
-    local entry="$1"
-    local runtime_root="$2"
-    local generated_root="$3"
-    local marker="$entry/.goldband-managed-skill"
-    local source_path source_dir
-
-    [ -f "$marker" ] || return 1
-    source_path="$(sed -n 's/^source=//p' "$marker" | head -1)"
-    [ -n "$source_path" ] || return 1
-    if [ -d "$source_path" ]; then
-        source_dir="$source_path"
-    else
-        source_dir="$(dirname "$source_path")"
-    fi
-    workflow_status_path_under_dir "$source_dir" "$runtime_root" && return 0
-    [ -n "$generated_root" ] && workflow_status_path_under_dir "$source_dir" "$generated_root" && return 0
-    return 1
-}
-
-workflow_entry_managed_by_goldband() {
-    local entry="$1"
-    local runtime_dir="$2"
-    local generated_root="$3"
-    local runtime_root
-
-    [ -f "$entry/SKILL.md" ] || return 1
-    runtime_root="$(cd "$runtime_dir" 2>/dev/null && pwd -P)" || return 1
-
-    if [ -L "$entry" ]; then
-        workflow_status_path_under_dir "$entry" "$runtime_root" && return 0
-        [ -n "$generated_root" ] && workflow_status_path_under_dir "$entry" "$generated_root" && return 0
-    fi
-
-    if [ -L "$entry/SKILL.md" ]; then
-        workflow_status_symlink_target_under_dir "$entry/SKILL.md" "$runtime_root" && return 0
-        [ -n "$generated_root" ] && workflow_status_symlink_target_under_dir "$entry/SKILL.md" "$generated_root" && return 0
-    fi
-
-    workflow_marker_points_to_root "$entry" "$runtime_root" "$generated_root" && return 0
-    return 1
-}
-
-workflow_exposed_skill_count() {
-    local skills_dir="$1"
-    local runtime_dir="$2"
-    local generated_root="$3"
-    local count=0
-    local entry
-    [ -d "$skills_dir" ] || {
-        printf '0\n'
-        return 0
-    }
-    for entry in "$skills_dir"/*; do
-        [ -e "$entry" ] || [ -L "$entry" ] || continue
-        workflow_entry_managed_by_goldband "$entry" "$runtime_dir" "$generated_root" || continue
-        count=$((count + 1))
-    done
-    printf '%s\n' "$count"
-}
-
-workflow_goldband_top_level_count() {
-    local skills_dir="$1"
-    local runtime_dir="$2"
-    local generated_root="$3"
-    local count=0
-    local entry name
-    [ -d "$skills_dir" ] || {
-        printf '0\n'
-        return 0
-    }
-    for entry in "$skills_dir"/*; do
-        [ -e "$entry" ] || [ -L "$entry" ] || continue
-        workflow_entry_managed_by_goldband "$entry" "$runtime_dir" "$generated_root" || continue
-        name="$(basename "$entry")"
-        case "$name" in
-            goldband|_goldband-command|goldband-upgrade) continue ;;
-        esac
-        count=$((count + 1))
-    done
-    printf '%s\n' "$count"
 }
 
 workflow_profile_value() {

--- a/shell/install/workflow-status.sh
+++ b/shell/install/workflow-status.sh
@@ -1,0 +1,164 @@
+# This file must be sourced by bash, not executed directly.
+
+workflow_status_path_under_dir() {
+    local candidate="$1"
+    local base="$2"
+    local candidate_real base_real
+    candidate_real="$(cd "$candidate" 2>/dev/null && pwd -P)" || return 1
+    base_real="$(cd "$base" 2>/dev/null && pwd -P)" || return 1
+    case "$candidate_real" in
+        "$base_real"|"$base_real"/*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+workflow_status_symlink_target_under_dir() {
+    local candidate="$1"
+    local base="$2"
+    local link_dest candidate_dir resolved_dir resolved_path base_real
+    link_dest="$(readlink "$candidate" 2>/dev/null || true)"
+    [ -n "$link_dest" ] || return 1
+    case "$link_dest" in
+        /*) resolved_path="$link_dest" ;;
+        *)
+            candidate_dir="$(dirname "$candidate")"
+            resolved_path="$candidate_dir/$link_dest"
+            ;;
+    esac
+    resolved_dir="$(dirname "$resolved_path")"
+    resolved_path="$(cd "$resolved_dir" 2>/dev/null && pwd -P)/$(basename "$resolved_path")" || return 1
+    base_real="$(cd "$base" 2>/dev/null && pwd -P)" || return 1
+    case "$resolved_path" in
+        "$base_real"|"$base_real"/*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+workflow_generated_root_for_runtime() {
+    local runtime_dir="$1"
+    local skill_link="$runtime_dir/SKILL.md"
+    local link_dest link_dir resolved_path skill_dir
+
+    [ -L "$skill_link" ] || return 1
+    link_dest="$(readlink "$skill_link" 2>/dev/null || true)"
+    [ -n "$link_dest" ] || return 1
+    case "$link_dest" in
+        /*) resolved_path="$link_dest" ;;
+        *)
+            link_dir="$(dirname "$skill_link")"
+            resolved_path="$link_dir/$link_dest"
+            ;;
+    esac
+    link_dir="$(dirname "$resolved_path")"
+    resolved_path="$(cd "$link_dir" 2>/dev/null && pwd -P)/$(basename "$resolved_path")" || return 1
+    skill_dir="$(dirname "$resolved_path")"
+    if [ -f "$skill_dir/setup" ] && [ -d "$skill_dir/goldband-upgrade" ]; then
+        printf '%s\n' "$skill_dir"
+        return 0
+    fi
+    [ "$(basename "$skill_dir")" = "goldband" ] || return 1
+    dirname "$skill_dir"
+}
+
+workflow_marker_points_to_root() {
+    local entry="$1"
+    local runtime_root="$2"
+    local generated_root="$3"
+    local marker="$entry/.goldband-managed-skill"
+    local source_path source_dir
+
+    [ -f "$marker" ] || return 1
+    source_path="$(sed -n 's/^source=//p' "$marker" | head -1)"
+    [ -n "$source_path" ] || return 1
+    if [ -d "$source_path" ]; then
+        source_dir="$source_path"
+    else
+        source_dir="$(dirname "$source_path")"
+    fi
+    workflow_status_path_under_dir "$source_dir" "$runtime_root" && return 0
+    [ -n "$generated_root" ] && workflow_status_path_under_dir "$source_dir" "$generated_root" && return 0
+    return 1
+}
+
+workflow_skill_file_matches_under_dir() {
+    local entry="$1"
+    local root="$2"
+    local source_skill
+
+    [ -f "$entry/SKILL.md" ] || return 1
+    [ -d "$root" ] || return 1
+
+    for source_skill in "$root"/*/SKILL.md; do
+        [ -f "$source_skill" ] || continue
+        cmp -s "$entry/SKILL.md" "$source_skill" && return 0
+    done
+
+    return 1
+}
+
+workflow_entry_managed_by_goldband() {
+    local entry="$1"
+    local runtime_dir="$2"
+    local generated_root="$3"
+    local runtime_root
+
+    [ -f "$entry/SKILL.md" ] || return 1
+    runtime_root="$(cd "$runtime_dir" 2>/dev/null && pwd -P)" || return 1
+
+    workflow_status_path_under_dir "$entry" "$runtime_root" && return 0
+
+    if [ -L "$entry" ]; then
+        workflow_status_path_under_dir "$entry" "$runtime_root" && return 0
+        [ -n "$generated_root" ] && workflow_status_path_under_dir "$entry" "$generated_root" && return 0
+    fi
+
+    if [ -L "$entry/SKILL.md" ]; then
+        workflow_status_symlink_target_under_dir "$entry/SKILL.md" "$runtime_root" && return 0
+        [ -n "$generated_root" ] && workflow_status_symlink_target_under_dir "$entry/SKILL.md" "$generated_root" && return 0
+    fi
+
+    workflow_marker_points_to_root "$entry" "$runtime_root" "$generated_root" && return 0
+    workflow_skill_file_matches_under_dir "$entry" "$runtime_root" && return 0
+    [ -n "$generated_root" ] && workflow_skill_file_matches_under_dir "$entry" "$generated_root" && return 0
+    return 1
+}
+
+workflow_exposed_skill_count() {
+    local skills_dir="$1"
+    local runtime_dir="$2"
+    local generated_root="$3"
+    local count=0
+    local entry
+    [ -d "$skills_dir" ] || {
+        printf '0\n'
+        return 0
+    }
+    for entry in "$skills_dir"/*; do
+        [ -e "$entry" ] || [ -L "$entry" ] || continue
+        workflow_entry_managed_by_goldband "$entry" "$runtime_dir" "$generated_root" || continue
+        count=$((count + 1))
+    done
+    printf '%s\n' "$count"
+}
+
+workflow_goldband_top_level_count() {
+    local skills_dir="$1"
+    local runtime_dir="$2"
+    local generated_root="$3"
+    local count=0
+    local entry name
+    [ -d "$skills_dir" ] || {
+        printf '0\n'
+        return 0
+    }
+    for entry in "$skills_dir"/*; do
+        [ -e "$entry" ] || [ -L "$entry" ] || continue
+        workflow_entry_managed_by_goldband "$entry" "$runtime_dir" "$generated_root" || continue
+        name="$(basename "$entry")"
+        case "$name" in
+            goldband|_goldband-command|goldband-upgrade) continue ;;
+        esac
+        count=$((count + 1))
+    done
+    printf '%s\n' "$count"
+}


### PR DESCRIPTION
## Summary

- harden Goldband Loop setup against sandboxed Playwright and macOS temp-path failures
- restore Windows installer managed-path, launcher cleanup, and status behavior
- validate Claude hook outputJson as object-or-null and cover SessionStart deduplication
- repair formatting and Windows path simulation failures that kept Validate Config red

## Verification

- Validate Config run 29111392815: success
- Linux validate job: success, including free suite and sandbox container
- macOS workflow installer job: success
- local style, auto-update, hook router, telemetry, plugin distribution, MCP, workflow runtime, and free suite checks: pass