### PR TITLE
fix(review): enforce single-owner cost controls

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -244,8 +244,8 @@ Implementation contract:
 Decision: `rules/*.md` remains the policy-content source of truth. A
 metadata-only `rules/manifest.json` selects applicable Rules for programmatic
 code review. Each review reads the current Rule text once into an immutable
-snapshot shared by its core prompt, specialist prompts, and prompt telemetry.
-The next review creates a fresh snapshot.
+snapshot shared by its single core prompt and prompt telemetry. The next review
+creates a fresh snapshot.
 
 Implementation contract:
 
@@ -833,24 +833,19 @@ Implementation contract:
 - The launcher resolves `workflows/run.ts` from the active source root or the
   installed runtime's `.installed-source`; missing runtime ownership fails
   explicitly.
-- User-supplied prompt text never proves runtime ownership. Runtime-owned child
-  prompts use the dedicated non-router `GOLDBAND_RUNTIME_TASK=review/code`
-  header, perform the supplied review inline, and never invoke `$goldband`
-  again.
+- User-supplied prompt text never proves runtime ownership. The launcher marks
+  the child environment with `GOLDBAND_REVIEW_ACTIVE`, and nested launchers fail
+  before starting another runtime or host.
 - The launcher probes the evidence root before starting. If the default
   `~/.goldband` root is blocked by the caller's filesystem sandbox, it uses a
   private temporary state root and reports the evidence as ephemeral. An
   explicitly configured state root remains fail-closed when it is not writable.
-- A Codex parent session requests host-native sandbox escalation for the
-  launcher command before execution. Codex applies its command sandbox to all
-  descendants, while the nested `codex exec` CLI must initialize Codex state
-  and app-server resources. This one parent-session admission is separate from
-  child reviewer command approval; the child remains read-only with approval
-  set to `never`.
+- The installed Codex launcher has an exact machine-local allow rule. Missing
+  launcher, runtime, or rule is an install failure rather than a request for
+  ad-hoc escalation. The child remains read-only with approval set to `never`.
 - Codex subprocesses use `--ask-for-approval never` with the read-only sandbox.
-  Core and specialist prompts prohibit `require_escalated`; blocked dynamic
-  verification is reported as unavailable instead of attempting an approval
-  flow that non-interactive `codex exec` cannot service.
+  Command approval and mutating capability are removed by the host adapter, not
+  by child prompt prose.
 - Codex reviewers also use `--ignore-user-config`, an explicit empty
   `mcp_servers` override, and `--ephemeral`. Authentication still comes from
   `CODEX_HOME`, but user/project customization cannot expose external MCP tools
@@ -873,9 +868,9 @@ Implementation contract:
 - Untracked paths are collected with `git ls-files -z` and parsed on NUL
   boundaries. Legal filenames containing newlines, tabs, quotes, or backslashes
   therefore reach the same containment and content checks as ordinary paths.
-- Core and specialist prompts are delivered over child stdin, never as command
-  arguments. The full 2 MiB input contract therefore does not depend on the
-  host operating system's smaller `ARG_MAX` limit.
+- The single core prompt is delivered over child stdin, never as a command
+  argument. The full 2 MiB input contract therefore does not depend on the host
+  operating system's smaller `ARG_MAX` limit.
 - `--diff-file` and untracked-file collection accept only stable regular files.
   They reject symbolic links and special files, validate the opened inode, and
   read through that same no-follow file descriptor. Descriptor metadata is
@@ -1030,7 +1025,7 @@ Revisit triggers:
 
 Decision: Goldband owns a bounded, persistent file dependency-impact graph in
 the typed `review/code` parent runtime. It is built only when at least two files
-changed, before host dispatch, and is passed to core and specialist prompts as
+changed, before host dispatch, and is passed to the single core prompt as
 advisory inspection context. It is not an MCP server, child-reviewer plugin, or
 independent source of findings.
 
@@ -1050,12 +1045,12 @@ Implementation contract:
 - Graph status is `analyzed`, `degraded`, or `skipped`. Limits and unreadable or
   unstable inputs become diagnostics rather than silently implying complete
   coverage.
-- Core and specialist prompts state that graph output is structural hinting
-  only. The diff remains complete review scope, and a blocking finding still
-  requires current source evidence and a reachable failure path.
-- Automatic specialist selection may add `testing` when a changed source file
-  has no observed reverse test dependency, and `maintainability` when the
-  bounded impact set is wide or truncated.
+- The core prompt treats graph output as structural hinting only. The diff
+  remains complete review scope, and a blocking finding still requires current
+  source evidence and a reachable failure path.
+- Missing observed test dependencies and wide or truncated impact remain
+  deterministic signals in the core review context; they do not dispatch
+  independent specialists.
 - Each pass emits an impact JSON artifact and telemetry for skip reason, parsed
   and reused files, edges, affected files, tests, truncation, and diagnostics.
 
@@ -1277,3 +1272,122 @@ Revisit triggers:
   host call or resending the full diff.
 - A separate user-visible cross-review capability gains an enforceable quota
   authorization contract and bounded inputs.
+
+## 2026-07-22: Review Launches Are Single-Owner and Non-Recursive
+
+Decision: make the typed runtime the owner of every deterministic review
+execution rule. A public `review/code` launch owns one active child runtime.
+That child cannot launch another review, and another session cannot concurrently
+review the same canonical repository and scope. Prompts contain only launcher
+routing that the outer host must perform and semantic judgment that code cannot
+perform.
+
+Context:
+
+- A live Codex review launched a second complete `review/code` process from
+  inside the core reviewer. Both runs received the same 310 KB prompt and same
+  diff digest, so the second run duplicated cost without adding a distinct
+  review contract.
+- Workflow and child prompts repeated launch count, polling, read-only,
+  approval, schema, specialist, timeout, and recursion rules even after the
+  runtime owned those constraints. The duplicate prose increased input tokens
+  and overstated what the outer interactive host could enforce.
+- Prompt text is not an execution boundary.
+
+Implementation contract:
+
+- The launcher fails before runtime or host startup when
+  `GOLDBAND_REVIEW_ACTIVE` is present. The marker is injected only into the
+  launched runtime environment and is inherited by its model process.
+- Before spawning the runtime, the launcher atomically acquires an owner-only
+  lease keyed by canonical repository plus normalized review scope. A live
+  matching lease rejects duplicate sessions. Stale replacement first acquires
+  a separate exclusive recovery lock, re-reads the current owner, writes a
+  same-directory replacement, and atomically renames it over the stale lease.
+  Contenders never unlink a lease they merely observed earlier. The owner
+  releases its token-matched lease in a `finally` block.
+- Durable and ephemeral evidence both use a separate stable, owner-only
+  coordination root under the canonical OS temp directory, so evidence-root
+  aliases and independent fallback roots still contend on the same lease.
+- Relative `--diff-file` scopes are canonicalized from the invocation directory,
+  matching the runtime's actual diff-file resolution.
+- Scope flags are parsed into the runtime's effective structured options and
+  serialized in a fixed field order, so equivalent `--base` plus `--worktree`
+  invocations contend on one lease regardless of CLI argument order.
+- Different explicit scopes may run concurrently. Host choice, timeout values,
+  and polling behavior do not create a second scope for the same diff.
+- The launcher and host adapter own real mode, the single host call, nested and
+  duplicate rejection, read-only capability, approval policy, timeout, output
+  schema, aggregation, validation, telemetry, and report rendering.
+- `review/code --loop` is rejected by the public launcher and unsupported by the
+  typed workflow definition. Repeated full-diff passes require a separate,
+  explicit capability and cost contract.
+- The generated workflow contract contains only installed-launcher routing,
+  scope forwarding, failure reporting, and report handoff. The child prompt
+  contains only semantic rubric, applicable Rules, impact context, repository
+  instruction discovery and the scoped diff.
+- The full scoped diff remains in the prompt and fails explicitly above 256 KiB.
+  Runtime-selected Rules use manifest-owned compact review criteria and expose
+  their full policy source for on-demand inspection. Path-only groups cannot be
+  activated by incidental prose inside the diff. Impact context is bounded to
+  8 KiB and total non-diff prompt overhead is bounded to 20 KiB.
+- Prompt telemetry records diff, Rules, impact, static criteria, total, and
+  overhead bytes. Host adapters separately persist numeric input, cache,
+  output, total-token, model, and cost fields when exposed by the CLI; raw host
+  JSONL and prompt content are not retained as usage telemetry.
+- Review strictness remains owned by the shared rubric, checklist, applicable
+  Rules snapshot, impact context, full scoped diff, and concrete failure-path
+  requirement. This decision removes duplicate execution, not review criteria.
+
+Assumptions:
+
+- Public review execution goes through the installed Goldband launcher.
+- The durable state root and fallback coordination root are private to the local
+  user, and process liveness is a sufficient stale-lease signal for local
+  duplicate suppression.
+- A user who explicitly selects different scopes intends separate reviews.
+
+Consequences:
+
+- A reviewer that tries to invoke Goldband again receives an immediate error
+  before another model process starts.
+- Two sessions cannot silently spend quota on the same repository and scope at
+  the same time, including when each uses a different ephemeral evidence root.
+- A killed launcher can leave a lease file, but the next launch recovers it when
+  the recorded process is no longer alive. A crashed recovery attempt fails
+  closed instead of allowing another paid reviewer to race through cleanup.
+- Runtime-owned instructions and the duplicate Markdown finding schema no
+  longer consume model input. Full diff, applicable Rules, and semantic criteria
+  remain because they affect review quality.
+- Outer-host polling and post-report behavior cannot be constrained by the child
+  process. The prompt only tells the outer host how to launch and return the
+  runtime result; native host lifecycle controls would be required for a hard
+  outer-session boundary.
+
+Alternatives considered:
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| Add only stronger prompt wording | The observed reviewer ignored equivalent guidance and started another runtime. |
+| Block every concurrent review in a repository | Prevents intentional staged and base-scope reviews that do not duplicate the same input contract. |
+| Keep runtime rules duplicated in prompts | Adds tokens without adding enforcement and makes runtime drift harder to see. |
+| Remove the full diff, applicable Rules, or semantic checklist | Changes review coverage before recall quality has been benchmarked. |
+
+Failure signals:
+
+- A model process carrying `GOLDBAND_REVIEW_ACTIVE` starts another public review
+  runtime or host model.
+- Two live leases exist for the same canonical repository and normalized scope.
+- The review workflow contract exceeds its 1 KiB routing budget or contains
+  specialist, lease, polling, or second-pass execution prose.
+- The child prompt contains runtime task markers, read-only, approval, launcher,
+  recursion, or output-schema instructions.
+- Token use remains approximately doubled for a single launch with no nested or
+  duplicate process evidence.
+
+Revisit triggers:
+
+- The host provides a native, non-bypassable child capability allowlist that can
+  replace the environment marker.
+- Review inputs gain a measured chunking or context-cache design with defect
+  recall parity against the current full-scope prompt.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,27 +1,24 @@
 # TODO
 
-## P0 - 補完 workflow convergence loop real-mode 驗證
+## P0 - 補完 QA convergence loop real-mode 驗證
 
-目前狀態：runtime-owned convergence loop 的 deterministic 基礎已完成；剩餘 P0
-是把 mock coverage 推進到真實 host 的 live evidence。不可再把 controller、stop
-predicate 或逐輪 evidence 列為尚未實作，也不可用 fixture 冒充 real-mode E2E。
+目前狀態：`review/code` 已改為強制 single-pass，避免完整 diff 被多輪重送；
+convergence loop 只保留給 `qa/app`。剩餘 P0 是把 QA mock coverage 推進到真實
+browser evidence，不可用 fixture 冒充 real-mode E2E。
 
 ### 已完成
 
 - [x] runtime 自主驅動多輪，不需要 caller 手動提供 iteration 或 blocker 狀態。
 - [x] `target-met`、`iteration-cap`、`same-blocker-repeated`、
   `no-improvement` stop predicates 與 regression tests。
-- [x] `review/code` 把前輪 findings 帶入下一輪，並輸出 signal trail、stop reason
-  與 machine-readable `loop-summary`。
 - [x] `qa/app` typed mock adapter 只重跑 failed checks，並驗證 check schema。
-- [x] CLI 保留 single-pass 預設，且 `--max-iterations` 不可超過 registry cap。
+- [x] `review/code` launcher 與 typed workflow 都拒絕 `--loop`。
+- [x] QA 的 `--max-iterations` 不可超過 registry cap。
 - [x] 每輪 JSONL evidence 包含 `iteration` 與 `signalSnapshot`。
 - [x] `goldband-loop/workflows/README.md` 已描述目前實際 loop 行為。
 
 ### 待辦
 
-- [ ] 執行 `review/code` real LLM convergence E2E，保存真實 host、命令、退出狀態、
-  JSONL evidence 與 artifacts；host、授權、網路或 budget 不足時明確標記 blocked。
 - [ ] 執行 `qa/app` real browser E2E；把 checks 接到已 typed 的
   `browser/session` evidence contract。在完成前維持 unsupported，不可把 mock
   check 或 Playwright setup 當成 runtime 支援。
@@ -31,7 +28,7 @@ predicate 或逐輪 evidence 列為尚未實作，也不可用 fixture 冒充 re
 ### 驗收標準
 
 - [x] runtime 能在無 caller 介入下自主多輪執行並停在正確 stop condition。
-- [x] `review/code` 與 `qa/app` mock 多輪整合測試都有逐輪 evidence。
+- [x] `qa/app` mock 多輪整合測試有逐輪 evidence。
 - [ ] real-mode 驗證結果有可重跑的 pass、blocked 或 unsupported evidence。
 - [ ] live evidence、registry 狀態、runtime 行為與文件一致。
 

--- a/goldband-loop/bin/goldband.ts
+++ b/goldband-loop/bin/goldband.ts
@@ -1,8 +1,11 @@
 #!/usr/bin/env bun
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
+	chmodSync,
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
@@ -26,12 +29,18 @@ import {
 } from "../lib/managed-worktree-boundary";
 import {
 	assertValidReviewScopeFlags,
+	assertReviewNotNested,
 	INDEPENDENT_REVIEWER_ERROR,
+	REVIEW_ACTIVE_ENV,
 	REVIEW_SCOPE_FLAGS,
 	REVIEW_EVIDENCE_DURABILITY_ENV,
 	REVIEW_EVIDENCE_DURABILITY_EPHEMERAL,
 	type ReviewScopeFlag,
 } from "../lib/review-runtime-contract";
+import {
+	acquireReviewExecutionLease,
+	releaseReviewExecutionLease,
+} from "../lib/review-execution-lease";
 import { resolveGoldbandStateRoot } from "../lib/state-root";
 
 type ReviewHost = "claude" | "codex";
@@ -55,23 +64,24 @@ type ReviewRuntimeResolutionOptions = {
 type ReviewProcessEnvironment = {
 	env: NodeJS.ProcessEnv;
 	evidenceRoot: string;
+	coordinationRoot: string;
 	durability: "durable" | "ephemeral";
 };
 
 type ReviewProcessEnvironmentOptions = {
 	home?: string;
+	coordinationRoot?: string;
 	createTemporaryRoot?: () => string;
 	probeStateRoot?: (root: string) => void;
 };
 
 const TRUSTED_CODEX_EXECUTABLE_ENV = "GOLDBAND_TRUSTED_CODEX_EXECUTABLE";
-const TRUSTED_BROWSER_EXECUTABLE_ENV =
-	"GOLDBAND_TRUSTED_BROWSER_EXECUTABLE";
+const TRUSTED_BROWSER_EXECUTABLE_ENV = "GOLDBAND_TRUSTED_BROWSER_EXECUTABLE";
 
 function printUsage(stream: Pick<Console, "log">): void {
 	stream.log("Usage:");
 	stream.log(
-		"  goldband review code --host <claude|codex> [--staged|--worktree|--base <ref>|--diff-file <file>] [--include-untracked] [--review-host-timeout-seconds <60-1800>] [--review-pass-timeout-seconds <60-1800>] [--loop]",
+		"  goldband review code --host <claude|codex> [--staged|--worktree|--base <ref>|--diff-file <file>] [--include-untracked] [--review-host-timeout-seconds <60-1800>] [--review-pass-timeout-seconds <60-1800>]",
 	);
 	stream.log(
 		"  goldband browser session --host <claude|codex> [command] [args...]",
@@ -172,6 +182,11 @@ export function buildReviewRuntimeArgs(args: string[]): string[] {
 				"review code always uses real mode; --mode is not accepted",
 			);
 		}
+		if (arg === "--loop") {
+			throw new Error(
+				"review code is single-pass; --loop is disabled to prevent repeated full-diff model calls",
+			);
+		}
 		if (arg === "--specialists") {
 			const value = args[index + 1];
 			if (!value) throw new Error("--specialists requires a value");
@@ -235,6 +250,7 @@ function installedSourceRoot(runtimeRoot: string): string | undefined {
 }
 
 function reviewCode(args: string[]): number {
+	assertReviewNotNested(process.env);
 	const runtimeFile = resolveWorkflowRuntimeFile();
 	const runtimeArgs = buildReviewRuntimeArgs(args);
 	const reviewEnvironment = prepareReviewProcessEnvironment(process.env);
@@ -249,27 +265,34 @@ function reviewCode(args: string[]): number {
 			`Goldband review: durable state root is not writable in this sandbox; evidence will use sandbox-safe temporary root ${reviewEnvironment.evidenceRoot}.`,
 		);
 	}
-	const result = spawnSync(process.execPath, [runtimeFile, ...runtimeArgs], {
-		cwd: process.cwd(),
-		env: reviewEnvironment.env,
-		stdio: "inherit",
-	});
-	if (result.error) throw result.error;
-	if (result.status === null) {
-		throw new Error(
-			`review runtime terminated without an exit status (${result.signal ?? "unknown signal"})`,
-		);
+	const lease = acquireReviewExecutionLease(
+		reviewEnvironment.coordinationRoot,
+		process.cwd(),
+		runtimeArgs,
+	);
+	reviewEnvironment.env[REVIEW_ACTIVE_ENV] = lease.token;
+	try {
+		const result = spawnSync(process.execPath, [runtimeFile, ...runtimeArgs], {
+			cwd: process.cwd(),
+			env: reviewEnvironment.env,
+			stdio: "inherit",
+		});
+		if (result.error) throw result.error;
+		if (result.status === null) {
+			throw new Error(
+				`review runtime terminated without an exit status (${result.signal ?? "unknown signal"})`,
+			);
+		}
+		return result.status;
+	} finally {
+		releaseReviewExecutionLease(lease);
 	}
-	return result.status;
 }
 
 function browserSession(args: string[]): number {
 	const hostFlag = args[0];
 	const host = args[1];
-	if (
-		hostFlag !== "--host" ||
-		(host !== "claude" && host !== "codex")
-	) {
+	if (hostFlag !== "--host" || (host !== "claude" && host !== "codex")) {
 		throw new Error(
 			"browser session requires --host claude or --host codex before the browser command",
 		);
@@ -356,7 +379,14 @@ export function prepareReviewProcessEnvironment(
 	const probe = options.probeStateRoot ?? probeWritableStateRoot;
 	try {
 		probe(evidenceRoot);
-		return { env: cleanEnv, evidenceRoot, durability: "durable" };
+		return {
+			env: cleanEnv,
+			evidenceRoot,
+			coordinationRoot: prepareTemporaryReviewCoordinationRoot(
+				options.coordinationRoot ?? defaultReviewCoordinationRoot(options.home),
+			),
+			durability: "durable",
+		};
 	} catch (error) {
 		if (explicitRoot || !isStateRootPermissionError(error)) throw error;
 	}
@@ -365,16 +395,51 @@ export function prepareReviewProcessEnvironment(
 		? options.createTemporaryRoot()
 		: mkdtempSync(join(tmpdir(), "goldband-review-state-"));
 	probe(temporaryRoot);
+	const coordinationRoot = prepareTemporaryReviewCoordinationRoot(
+		options.coordinationRoot ?? defaultReviewCoordinationRoot(options.home),
+	);
 	return {
 		env: {
 			...cleanEnv,
 			GOLDBAND_HOME: temporaryRoot,
-			[REVIEW_EVIDENCE_DURABILITY_ENV]:
-				REVIEW_EVIDENCE_DURABILITY_EPHEMERAL,
+			[REVIEW_EVIDENCE_DURABILITY_ENV]: REVIEW_EVIDENCE_DURABILITY_EPHEMERAL,
 		},
 		evidenceRoot: temporaryRoot,
+		coordinationRoot,
 		durability: "ephemeral",
 	};
+}
+
+function defaultReviewCoordinationRoot(home = homedir()): string {
+	const identity =
+		typeof process.getuid === "function"
+			? String(process.getuid())
+			: createHash("sha256").update(home).digest("hex").slice(0, 12);
+	return join(
+		realpathSync(tmpdir()),
+		`goldband-review-coordination-${identity}`,
+	);
+}
+
+function prepareTemporaryReviewCoordinationRoot(root: string): string {
+	mkdirSync(root, { recursive: true, mode: 0o700 });
+	const metadata = lstatSync(root);
+	if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+		throw new Error(
+			`review coordination root must be a real directory: ${root}`,
+		);
+	}
+	if (
+		typeof process.getuid === "function" &&
+		metadata.uid !== process.getuid()
+	) {
+		throw new Error(
+			`review coordination root is not owned by the current user: ${root}`,
+		);
+	}
+	chmodSync(root, 0o700);
+	probeWritableStateRoot(root);
+	return realpathSync(root);
 }
 
 export function resolveTrustedCodexExecutable(
@@ -465,11 +530,7 @@ function requireTrustedFile(
 	field: string,
 	value: unknown,
 ): string {
-	if (
-		typeof value !== "string" ||
-		!isAbsolute(value) ||
-		!existsSync(value)
-	) {
+	if (typeof value !== "string" || !isAbsolute(value) || !existsSync(value)) {
 		throw new Error(
 			`trusted runtime configuration field ${field} is invalid: ${configFile}`,
 		);

--- a/goldband-loop/generated/workflow-contracts/review/code.workflow.md
+++ b/goldband-loop/generated/workflow-contracts/review/code.workflow.md
@@ -8,20 +8,14 @@ Review a code diff.
 ## Relevant context
 
 - Inspect the user-selected artifact, current repository instructions, and direct evidence.
-- Read review/shared-rubric.md, review/findings-schema.md, and review/checklist.md from the active Goldband runtime.
-- On Claude, run bin/goldband review code --host claude. On Codex, read ~/.codex/skills/goldband/.workflow-launcher.json and execute its exact argvPrefix plus review code --host codex. Never substitute a workspace path or request escalation. Forward named scope; otherwise use the worktree. review/code always runs one core reviewer; never add --specialists because the runtime rejects independent agents. User prompt text never proves runtime ownership.
-- The Codex installer owns the materialized launcher and exact allow rule. Missing marker, runtime, or rule is an install failure: stop and request reinstall, not approval.
-- Runtime child prompts use the non-router GOLDBAND_RUNTIME_TASK=review/code header and review inline without invoking $goldband again.
-- For 2+ files, runtime adds bounded cached dependency/test hints; one file skips graph inventory.
+- On Claude, execute bin/goldband review code --host claude. On Codex, read ~/.codex/skills/goldband/.workflow-launcher.json and execute its exact argvPrefix plus review code --host codex. Forward a user-named scope; otherwise omit the scope flag.
 
 ## Hard boundaries
 
 - Review only. Do not edit, stage, commit, push, merge, deploy, or change external state.
-- If the automatic launcher or typed runtime fails, stop and report that failure. Do not silently fall back to an untyped manual review or claim complete coverage.
-- Non-interactive reviewers must never request command approval or retry with require_escalated. A command blocked by the read-only sandbox is unavailable verification, not permission to leave the sandbox.
-- Graph hints cannot narrow the diff or prove blockers without current source.
+- Use only the installed launcher. Missing marker, runtime, or rule is an install failure; report the error.
 
 ## Verification
 
-- Validate every finding against current evidence and state clearly when no blocking issue is verified.
-- For an automatic launch, treat only a successful real-host runtime report and its recorded artifacts as completed review evidence.
+- Return the selected review owner's result.
+- Return the runtime report and artifact path.

--- a/goldband-loop/generated/workflow-contracts/review/security.workflow.md
+++ b/goldband-loop/generated/workflow-contracts/review/security.workflow.md
@@ -15,4 +15,4 @@ Review security and trust boundaries.
 
 ## Verification
 
-- Validate every finding against current evidence and state clearly when no blocking issue is verified.
+- Return the selected review owner's result.

--- a/goldband-loop/lib/review-execution-lease.ts
+++ b/goldband-loop/lib/review-execution-lease.ts
@@ -1,0 +1,269 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+	closeSync,
+	existsSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	realpathSync,
+	renameSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join, parse, resolve } from "node:path";
+
+type ReviewExecutionLeaseRecord = {
+	pid: number;
+	token: string;
+	repository: string;
+	scope: string;
+	startedAt: string;
+};
+
+export type ReviewExecutionLease = {
+	file: string;
+	token: string;
+};
+
+type ReviewExecutionLeaseOptions = {
+	pid?: number;
+	isProcessAlive?: (pid: number) => boolean;
+	afterStaleLeaseRead?: () => void;
+};
+
+export function acquireReviewExecutionLease(
+	stateRoot: string,
+	cwd: string,
+	runtimeArgs: string[],
+	options: ReviewExecutionLeaseOptions = {},
+): ReviewExecutionLease {
+	const repository = canonicalRepositoryRoot(cwd);
+	const invocationDirectory = realpathSync(cwd);
+	const scope = normalizedReviewScope(invocationDirectory, runtimeArgs);
+	const file = reviewExecutionLeasePath(stateRoot, repository, scope);
+	const record: ReviewExecutionLeaseRecord = {
+		pid: options.pid ?? process.pid,
+		token: randomUUID(),
+		repository,
+		scope,
+		startedAt: new Date().toISOString(),
+	};
+	const isProcessAlive = options.isProcessAlive ?? processIsAlive;
+	mkdirSync(dirname(file), { recursive: true });
+
+	try {
+		writeNewLease(file, record);
+		return { file, token: record.token };
+	} catch (error) {
+		if (!isAlreadyExists(error)) throw error;
+	}
+
+	const existing = readLeaseRecord(file);
+	if (isProcessAlive(existing.pid)) throw activeLeaseError(existing);
+	options.afterStaleLeaseRead?.();
+	return replaceStaleLease(file, record, isProcessAlive);
+}
+
+export function releaseReviewExecutionLease(lease: ReviewExecutionLease): void {
+	let existing: ReviewExecutionLeaseRecord;
+	try {
+		existing = readLeaseRecord(lease.file);
+	} catch (error) {
+		if (isMissing(error)) return;
+		throw error;
+	}
+	if (existing.token !== lease.token) return;
+	unlinkSync(lease.file);
+}
+
+function reviewExecutionLeasePath(
+	stateRoot: string,
+	repository: string,
+	scope: string,
+): string {
+	const digest = createHash("sha256")
+		.update(JSON.stringify({ repository, scope }))
+		.digest("hex");
+	return join(stateRoot, "workflow-runs", "active-review", `${digest}.json`);
+}
+
+function replaceStaleLease(
+	file: string,
+	replacement: ReviewExecutionLeaseRecord,
+	isProcessAlive: (pid: number) => boolean,
+): ReviewExecutionLease {
+	const recoveryFile = `${file}.recovery`;
+	const recoveryToken = randomUUID();
+	try {
+		writeExclusiveJson(recoveryFile, {
+			pid: replacement.pid,
+			token: recoveryToken,
+			startedAt: new Date().toISOString(),
+		});
+	} catch (error) {
+		if (!isAlreadyExists(error)) throw error;
+		throw new Error(
+			"review/code stale lease recovery is already in progress; wait for that launcher instead of starting another paid review",
+		);
+	}
+
+	const replacementFile = `${file}.${replacement.token}.replacement`;
+	try {
+		const current = readLeaseRecord(file);
+		if (isProcessAlive(current.pid)) throw activeLeaseError(current);
+		writeNewLease(replacementFile, replacement);
+		renameSync(replacementFile, file);
+		return { file, token: replacement.token };
+	} finally {
+		unlinkIfOwned(replacementFile, replacement.token);
+		unlinkIfOwned(recoveryFile, recoveryToken);
+	}
+}
+
+function writeNewLease(file: string, record: ReviewExecutionLeaseRecord): void {
+	writeExclusiveJson(file, record);
+}
+
+function writeExclusiveJson(file: string, value: unknown): void {
+	const fd = openSync(file, "wx", 0o600);
+	try {
+		writeFileSync(fd, `${JSON.stringify(value, null, 2)}\n`);
+	} finally {
+		closeSync(fd);
+	}
+}
+
+function unlinkIfOwned(file: string, token: string): void {
+	let value: unknown;
+	try {
+		value = JSON.parse(readFileSync(file, "utf8"));
+	} catch (error) {
+		if (isMissing(error)) return;
+		throw error;
+	}
+	if (
+		value &&
+		typeof value === "object" &&
+		"token" in value &&
+		value.token === token
+	) {
+		unlinkSync(file);
+	}
+}
+
+function activeLeaseError(existing: ReviewExecutionLeaseRecord): Error {
+	return new Error(
+		`review/code is already running for this repository and scope (pid ${existing.pid}, started ${existing.startedAt}); wait for that report instead of launching a duplicate`,
+	);
+}
+
+function normalizedReviewScope(
+	invocationDirectory: string,
+	runtimeArgs: string[],
+): string {
+	let staged = false;
+	let worktree = false;
+	let base: string | undefined;
+	let diffFile: string | undefined;
+	let includeUntracked = false;
+	for (let index = 0; index < runtimeArgs.length; index += 1) {
+		const arg = runtimeArgs[index];
+		if (arg === "--staged") {
+			staged = true;
+			continue;
+		}
+		if (arg === "--worktree") {
+			worktree = true;
+			continue;
+		}
+		if (arg === "--include-untracked") {
+			includeUntracked = true;
+			continue;
+		}
+		if (arg === "--base") {
+			base = runtimeArgs[index + 1] ?? "";
+			index += 1;
+			continue;
+		}
+		if (arg === "--diff-file") {
+			const value = runtimeArgs[index + 1] ?? "";
+			diffFile = resolve(invocationDirectory, value);
+			index += 1;
+		}
+	}
+	return JSON.stringify({
+		staged,
+		worktree,
+		base,
+		diffFile,
+		includeUntracked,
+	});
+}
+
+function readLeaseRecord(file: string): ReviewExecutionLeaseRecord {
+	let value: unknown;
+	try {
+		value = JSON.parse(readFileSync(file, "utf8"));
+	} catch (error) {
+		if (isMissing(error)) throw error;
+		throw new Error(
+			`review/code execution lease is unreadable; inspect or remove the stale lease manually: ${file}`,
+		);
+	}
+	if (
+		!value ||
+		typeof value !== "object" ||
+		!("pid" in value) ||
+		!Number.isSafeInteger(value.pid) ||
+		!("token" in value) ||
+		typeof value.token !== "string" ||
+		!("repository" in value) ||
+		typeof value.repository !== "string" ||
+		!("scope" in value) ||
+		typeof value.scope !== "string" ||
+		!("startedAt" in value) ||
+		typeof value.startedAt !== "string"
+	) {
+		throw new Error(
+			`review/code execution lease is invalid; inspect or remove the stale lease manually: ${file}`,
+		);
+	}
+	return value as ReviewExecutionLeaseRecord;
+}
+
+function processIsAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return !isNoSuchProcess(error);
+	}
+}
+
+function isAlreadyExists(error: unknown): boolean {
+	return errorCode(error) === "EEXIST";
+}
+
+function isMissing(error: unknown): boolean {
+	return errorCode(error) === "ENOENT";
+}
+
+function isNoSuchProcess(error: unknown): boolean {
+	return errorCode(error) === "ESRCH";
+}
+
+function errorCode(error: unknown): string | undefined {
+	if (!error || typeof error !== "object" || !("code" in error))
+		return undefined;
+	return String(error.code);
+}
+
+function canonicalRepositoryRoot(cwd: string): string {
+	let current = realpathSync(cwd);
+	const filesystemRoot = parse(current).root;
+	while (true) {
+		if (existsSync(join(current, ".git"))) return current;
+		if (current === filesystemRoot) return realpathSync(cwd);
+		current = dirname(current);
+	}
+}

--- a/goldband-loop/lib/review-runtime-contract.ts
+++ b/goldband-loop/lib/review-runtime-contract.ts
@@ -1,10 +1,9 @@
-export const REVIEW_RUNTIME_TASK_HEADER = "GOLDBAND_RUNTIME_TASK=review/code";
+export const REVIEW_ACTIVE_ENV = "GOLDBAND_REVIEW_ACTIVE";
+const NESTED_REVIEW_ERROR =
+	"review/code cannot start inside an active review; reuse the current runtime report instead of launching another reviewer";
 export const REVIEW_EVIDENCE_DURABILITY_ENV =
 	"GOLDBAND_REVIEW_EVIDENCE_DURABILITY";
 export const REVIEW_EVIDENCE_DURABILITY_EPHEMERAL = "ephemeral";
-export const REVIEW_NON_INTERACTIVE_COMMAND_POLICY =
-	"Non-interactive review: never request command approval or use require_escalated. If a command cannot run inside the read-only sandbox, do not retry it outside the sandbox; record that verification as unavailable and continue the review from available read-only evidence.";
-
 export const REVIEW_SCOPE_FLAGS = [
 	"--staged",
 	"--worktree",
@@ -30,6 +29,12 @@ type ReviewExecutionOptions = ReviewScopeOptions & {
 export const INDEPENDENT_REVIEWER_ERROR =
 	"review/code uses exactly one core reviewer; independent specialist agents are disabled";
 
+export function assertReviewNotNested(
+	env: NodeJS.ProcessEnv = process.env,
+): void {
+	if (env[REVIEW_ACTIVE_ENV]) throw new Error(NESTED_REVIEW_ERROR);
+}
+
 export function assertValidReviewScopeFlags(flags: ReviewScopeFlag[]): void {
 	const selected = new Set(flags);
 	const primary = REVIEW_SCOPE_FLAGS.filter(
@@ -41,7 +46,7 @@ export function assertValidReviewScopeFlags(flags: ReviewScopeFlag[]): void {
 		primary.includes("--worktree");
 	const diffFileWithUntracked =
 		selected.has("--diff-file") && selected.has("--include-untracked");
-	if (primary.length > 1 && !allowedBaseWorktree || diffFileWithUntracked) {
+	if ((primary.length > 1 && !allowedBaseWorktree) || diffFileWithUntracked) {
 		throw new Error(
 			`conflicting review scope flags: ${REVIEW_SCOPE_FLAGS.filter((flag) => selected.has(flag)).join(", ")}; use one scope, with --base --worktree as the only combined scope`,
 		);

--- a/goldband-loop/review/checklist.md
+++ b/goldband-loop/review/checklist.md
@@ -1,48 +1,6 @@
-# Read-Only Review Checklist
+# Semantic Review Checklist
 
-## Instructions
-
-Review the diff for concrete issues. Cite `file:line` when available. Flag only
-real problems with evidence. Do not edit files, apply patches, commit, push,
-or run repair workflows.
-
-Use `shared-rubric.md` as the canonical taxonomy, severity standard, finding
-shape, and merge rule source. The one core reviewer owns every category below
-inside the same repository-reading context; it must not delegate categories to
-independent agents.
-
-## Finding validity gate
-
-Only report a finding when all three are present:
-
-- an exact `file:line`;
-- a concrete input or runtime state and a reachable execution path;
-- the incorrect result, expected result, and practical impact.
-
-A suspicious pattern, style preference, generic best practice, or unsupported
-test gap is not a finding.
-
-## Output Format
-
-```
-[P1] Short problem title — path/to/file.ts:42
-
-When <input/state>, execution reaches <path> and produces <actual> instead of
-<expected>, causing <impact>.
-
-Evidence: <specific diff/code/test/config evidence>
-Fix: <one-sentence healthy fix>
-Verify: <command, test, readback, or manual check>
-```
-
-If no issues survive the validity gate, output `No findings.` and briefly name
-the high-risk paths that were actually traced.
-
-Always include:
-
-`Read-only review: no files were modified.`
-
-## Core Review Categories
+Apply the shared rubric's evidence gate while tracing the relevant categories.
 
 ### Problem-Fix Correctness
 

--- a/goldband-loop/review/shared-rubric.md
+++ b/goldband-loop/review/shared-rubric.md
@@ -1,12 +1,8 @@
 # Shared Review Rubric
 
-This is the canonical review standard for normal `/review` and the review
-content consumed by `cross-review`. Execution semantics differ:
-
-- `/review` is read-only findings review. It never edits source files and never
-  signs a gate.
-- `cross-review` uses this standard inside its own gate contract, verdict
-  marker, reviewed-sha, rounds, implementer responses, and escalation flow.
+This is the canonical semantic judgment standard for normal `/review` and
+`cross-review`. Execution, permissions, output shape, aggregation, and gate
+behavior belong to their runtimes.
 
 ## Taxonomy
 
@@ -42,10 +38,6 @@ Use the lowest severity supported by concrete evidence.
 - `info`: skipped/degraded coverage, useful context, or an unverified issue that
   is not supported enough to stay high severity.
 
-`review/code` has one core reviewer. Category and specialist metadata may remain
-in findings for compatibility, but the runtime must not dispatch independent
-specialist agents.
-
 High or critical findings without concrete evidence must be downgraded to
 `info`. Findings that need human judgment because the supplied evidence is
 insufficient should be reported as `info` in normal `/review` and as `ESCALATE`
@@ -67,11 +59,3 @@ scores.
 `blocking` means "must be fixed before landing" in normal `/review`. It does
 not sign or block the session by itself. `cross-review` maps blocking findings
 into its own verdict rules.
-
-## Merge Rules
-
-- Deduplicate by file, line, category, and failure scenario.
-- Merge duplicate findings by preserving the strongest severity and most
-  specific evidence.
-- Record every contributing specialist.
-- Sort findings by severity, then file, line, and category.

--- a/goldband-loop/test/goldband-review-cli.test.ts
+++ b/goldband-loop/test/goldband-review-cli.test.ts
@@ -7,6 +7,7 @@ import {
 	mkdtempSync,
 	readFileSync,
 	readdirSync,
+	realpathSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
@@ -17,6 +18,11 @@ import {
 	prepareReviewProcessEnvironment,
 	resolveReviewRuntimeFile,
 } from "../bin/goldband.ts";
+import {
+	acquireReviewExecutionLease,
+	releaseReviewExecutionLease,
+} from "../lib/review-execution-lease";
+import { REVIEW_ACTIVE_ENV } from "../lib/review-runtime-contract";
 
 describe("goldband review code launcher", () => {
 	test("runs the real typed pipeline through the Codex host adapter", () => {
@@ -47,6 +53,8 @@ describe("goldband review code launcher", () => {
 					'test -n "$output"',
 					'test "$approval" = "never"',
 					'test "$sandbox" = "read-only"',
+					`test -n "\${${REVIEW_ACTIVE_ENV}:-}"`,
+					'printf \'%s\\n\' \'{"type":"turn.completed","usage":{"input_tokens":1200,"cached_input_tokens":800,"output_tokens":75,"total_tokens":1275}}\'',
 					'printf \'%s\\n\' \'{"findings":[]}\' > "$output"',
 				].join("\n"),
 			);
@@ -94,7 +102,224 @@ describe("goldband review code launcher", () => {
 			expect(telemetry.passTimeoutMs).toBe(600_000);
 			expect(telemetry.specialistMode).toBe("off");
 			expect(telemetry.selectedSpecialists).toEqual([]);
+			expect(telemetry.diffBytes).toBeGreaterThan(0);
+			expect(telemetry.promptOverheadBytes).toBeLessThanOrEqual(20 * 1024);
+			const usageFile = readdirSync(telemetryDir).find((file) =>
+				file.endsWith("-review-host-usage.json"),
+			);
+			const usage = JSON.parse(
+				readFileSync(join(telemetryDir, usageFile as string), "utf8"),
+			);
+			expect(usage).toMatchObject({
+				host: "codex",
+				available: true,
+				inputTokens: 1200,
+				cachedInputTokens: 800,
+				outputTokens: 75,
+				totalTokens: 1275,
+			});
 			expect(readFileSync(callLog, "utf8").trim().split("\n")).toHaveLength(1);
+		} finally {
+			rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+
+	test("nested review is rejected before launching any runtime or host", () => {
+		const fixture = mkdtempSync(join(tmpdir(), "goldband-review-nested-"));
+		try {
+			const fakeBin = join(fixture, "bin");
+			const fakeCodex = join(fakeBin, "codex");
+			const callLog = join(fixture, "codex-calls.log");
+			mkdirSync(fakeBin, { recursive: true });
+			writeFileSync(
+				fakeCodex,
+				`#!/usr/bin/env bash\nprintf '%s\\n' call >> "${callLog}"\n`,
+			);
+			chmodSync(fakeCodex, 0o755);
+
+			const result = spawnSync(
+				resolve(import.meta.dir, "../bin/goldband"),
+				["review", "code", "--host", "codex"],
+				{
+					cwd: fixture,
+					encoding: "utf8",
+					env: {
+						...process.env,
+						[REVIEW_ACTIVE_ENV]: "parent-review-token",
+						PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+					},
+				},
+			);
+
+			expect(result.status).toBe(1);
+			expect(result.stderr).toContain("cannot start inside an active review");
+			expect(existsSync(callLog)).toBe(false);
+		} finally {
+			rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+
+	test("same repository and scope cannot hold two active review leases", () => {
+		const fixture = mkdtempSync(join(tmpdir(), "goldband-review-lease-"));
+		try {
+			const stateRoot = join(fixture, "state");
+			const nestedDirectory = join(fixture, "packages", "app");
+			mkdirSync(join(fixture, ".git"));
+			mkdirSync(nestedDirectory, { recursive: true });
+			const first = acquireReviewExecutionLease(
+				stateRoot,
+				fixture,
+				["review", "code", "--worktree"],
+			);
+			try {
+				expect(() =>
+					acquireReviewExecutionLease(
+						stateRoot,
+						nestedDirectory,
+						["review", "code", "--worktree"],
+					),
+				).toThrow("already running for this repository and scope");
+			} finally {
+				releaseReviewExecutionLease(first);
+			}
+		} finally {
+			rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+
+	test("equivalent base plus worktree scopes share one lease regardless of flag order", () => {
+		const fixture = mkdtempSync(join(tmpdir(), "goldband-review-lease-order-"));
+		try {
+			const stateRoot = join(fixture, "state");
+			mkdirSync(join(fixture, ".git"));
+			const first = acquireReviewExecutionLease(
+				stateRoot,
+				fixture,
+				["review", "code", "--base", "origin/main", "--worktree"],
+			);
+			try {
+				expect(() =>
+					acquireReviewExecutionLease(
+						stateRoot,
+						fixture,
+						["review", "code", "--worktree", "--base", "origin/main"],
+					),
+				).toThrow("already running for this repository and scope");
+			} finally {
+				releaseReviewExecutionLease(first);
+			}
+		} finally {
+			rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+
+	test("equivalent diff-file scopes use the invocation directory", () => {
+		const fixture = mkdtempSync(join(tmpdir(), "goldband-review-diff-lease-"));
+		try {
+			const stateRoot = join(fixture, "state");
+			const packageDirectory = join(fixture, "packages", "app");
+			mkdirSync(join(fixture, ".git"));
+			mkdirSync(packageDirectory, { recursive: true });
+			writeFileSync(join(packageDirectory, "change.diff"), "diff fixture\n");
+			const first = acquireReviewExecutionLease(
+				stateRoot,
+				packageDirectory,
+				["review", "code", "--diff-file", "change.diff"],
+			);
+			try {
+				expect(() =>
+					acquireReviewExecutionLease(
+						stateRoot,
+						fixture,
+						["review", "code", "--diff-file", "packages/app/change.diff"],
+					),
+				).toThrow("already running for this repository and scope");
+			} finally {
+				releaseReviewExecutionLease(first);
+			}
+		} finally {
+			rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+
+	test("different scopes may run concurrently and stale leases recover", () => {
+		const fixture = mkdtempSync(join(tmpdir(), "goldband-review-lease-scope-"));
+		try {
+			const stateRoot = join(fixture, "state");
+			const worktree = acquireReviewExecutionLease(
+				stateRoot,
+				fixture,
+				["review", "code", "--worktree"],
+			);
+			const staged = acquireReviewExecutionLease(
+				stateRoot,
+				fixture,
+				["review", "code", "--staged"],
+			);
+			releaseReviewExecutionLease(worktree);
+			releaseReviewExecutionLease(staged);
+
+			const stale = acquireReviewExecutionLease(
+				stateRoot,
+				fixture,
+				["review", "code", "--base", "origin/main"],
+				{ pid: 999_999, isProcessAlive: () => false },
+			);
+			const replacement = acquireReviewExecutionLease(
+				stateRoot,
+				fixture,
+				["review", "code", "--base", "origin/main"],
+				{ isProcessAlive: () => false },
+			);
+			releaseReviewExecutionLease(stale);
+			expect(existsSync(replacement.file)).toBe(true);
+			releaseReviewExecutionLease(replacement);
+			expect(existsSync(replacement.file)).toBe(false);
+		} finally {
+			rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+
+	test("stale recovery cannot delete a concurrently replaced live lease", () => {
+		const fixture = mkdtempSync(join(tmpdir(), "goldband-review-lease-race-"));
+		try {
+			const stateRoot = join(fixture, "state");
+			mkdirSync(join(fixture, ".git"));
+			const stale = acquireReviewExecutionLease(
+				stateRoot,
+				fixture,
+				["review", "code", "--worktree"],
+				{ pid: 999_999, isProcessAlive: () => false },
+			);
+
+			let winner: ReturnType<typeof acquireReviewExecutionLease> | undefined;
+			expect(() =>
+				acquireReviewExecutionLease(
+					stateRoot,
+					fixture,
+					["review", "code", "--worktree"],
+					{
+						isProcessAlive: (pid) => pid !== 999_999,
+						afterStaleLeaseRead: () => {
+							winner = acquireReviewExecutionLease(
+								stateRoot,
+								fixture,
+								["review", "code", "--worktree"],
+								{ isProcessAlive: () => false },
+							);
+						},
+					},
+				),
+			).toThrow("already running for this repository and scope");
+
+			expect(winner).toBeDefined();
+			expect(JSON.parse(readFileSync(stale.file, "utf8")).token).toBe(
+				winner?.token,
+			);
+			releaseReviewExecutionLease(stale);
+			expect(existsSync(stale.file)).toBe(true);
+			releaseReviewExecutionLease(winner as NonNullable<typeof winner>);
+			expect(existsSync(stale.file)).toBe(false);
 		} finally {
 			rmSync(fixture, { recursive: true, force: true });
 		}
@@ -112,14 +337,13 @@ describe("goldband review code launcher", () => {
 		]);
 	});
 
-	test("preserves explicit scope and loop options", () => {
+	test("preserves explicit scope", () => {
 		expect(
 			buildReviewRuntimeArgs([
 				"--host",
 				"codex",
 				"--base",
 				"origin/main",
-				"--loop",
 			]),
 		).toEqual([
 			"review",
@@ -130,8 +354,13 @@ describe("goldband review code launcher", () => {
 			"codex",
 			"--base",
 			"origin/main",
-			"--loop",
 		]);
+	});
+
+	test("rejects repeated review loops before launching the runtime", () => {
+		expect(() =>
+			buildReviewRuntimeArgs(["--host", "codex", "--loop"]),
+		).toThrow("--loop is disabled to prevent repeated full-diff model calls");
 	});
 
 	test("rejects independent specialist agents before launching the runtime", () => {
@@ -240,6 +469,7 @@ describe("goldband review code launcher", () => {
 				{},
 				{
 					home: join(fixture, "blocked-home"),
+					coordinationRoot: join(fixture, "review-coordination"),
 					createTemporaryRoot: () => temporaryRoot,
 					probeStateRoot: (root) => {
 						probed.push(root);
@@ -254,6 +484,9 @@ describe("goldband review code launcher", () => {
 
 			expect(result.durability).toBe("ephemeral");
 			expect(result.evidenceRoot).toBe(temporaryRoot);
+			expect(result.coordinationRoot).toBe(
+				realpathSync(join(fixture, "review-coordination")),
+			);
 			expect(result.env.GOLDBAND_HOME).toBe(temporaryRoot);
 			expect(result.env.GOLDBAND_REVIEW_EVIDENCE_DURABILITY).toBe(
 				"ephemeral",
@@ -262,6 +495,80 @@ describe("goldband review code launcher", () => {
 				join(fixture, "blocked-home", ".goldband"),
 				temporaryRoot,
 			]);
+		} finally {
+			rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+
+	test("durable evidence and review coordination use separate roots", () => {
+		const fixture = mkdtempSync(join(tmpdir(), "goldband-review-durable-"));
+		try {
+			const evidenceRoot = join(fixture, "evidence");
+			const coordinationRoot = join(fixture, "coordination");
+			const result = prepareReviewProcessEnvironment(
+				{ GOLDBAND_HOME: evidenceRoot },
+				{ coordinationRoot },
+			);
+
+			expect(result.durability).toBe("durable");
+			expect(result.evidenceRoot).toBe(evidenceRoot);
+			expect(result.coordinationRoot).toBe(realpathSync(coordinationRoot));
+			expect(result.coordinationRoot).not.toBe(result.evidenceRoot);
+		} finally {
+			rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+
+	test("ephemeral evidence roots share one stable review coordination root", () => {
+		const fixture = mkdtempSync(join(tmpdir(), "goldband-review-coordination-"));
+		try {
+			const coordinationRoot = join(fixture, "coordination");
+			const blockedHome = join(fixture, "blocked-home");
+			const prepare = (temporaryRoot: string) =>
+				prepareReviewProcessEnvironment(
+					{},
+					{
+						home: blockedHome,
+						coordinationRoot,
+						createTemporaryRoot: () => temporaryRoot,
+						probeStateRoot: (root) => {
+							if (root === join(blockedHome, ".goldband")) {
+								throw Object.assign(new Error("sandbox blocked"), {
+									code: "EPERM",
+								});
+							}
+							mkdirSync(root, { recursive: true });
+						},
+					},
+				);
+			const firstEnvironment = prepare(join(fixture, "evidence-one"));
+			const secondEnvironment = prepare(join(fixture, "evidence-two"));
+			expect(firstEnvironment.evidenceRoot).not.toBe(
+				secondEnvironment.evidenceRoot,
+			);
+			expect(firstEnvironment.coordinationRoot).toBe(
+				realpathSync(coordinationRoot),
+			);
+			expect(secondEnvironment.coordinationRoot).toBe(
+				realpathSync(coordinationRoot),
+			);
+
+			const first = acquireReviewExecutionLease(
+				firstEnvironment.coordinationRoot,
+				fixture,
+				["review", "code", "--worktree"],
+			);
+			try {
+				expect(() =>
+					acquireReviewExecutionLease(
+						secondEnvironment.coordinationRoot,
+						fixture,
+						["review", "code", "--worktree"],
+					),
+				).toThrow("already running for this repository and scope");
+			} finally {
+				releaseReviewExecutionLease(first);
+			}
 		} finally {
 			rmSync(fixture, { recursive: true, force: true });
 		}

--- a/goldband-loop/test/review-impact.test.ts
+++ b/goldband-loop/test/review-impact.test.ts
@@ -144,7 +144,7 @@ describe('review impact graph', () => {
     }));
     const formatted = formatReviewImpactContext(impactFixture({ impactedFiles }));
 
-    expect(Buffer.byteLength(formatted)).toBeLessThan(50 * 1024);
+    expect(Buffer.byteLength(formatted)).toBeLessThan(9 * 1024);
     expect(formatted).toContain('"bounded":true');
     expect(() => reviewInputSchema.validate({
       source: 'fixture',

--- a/goldband-loop/test/workflows-runtime.test.ts
+++ b/goldband-loop/test/workflows-runtime.test.ts
@@ -32,6 +32,7 @@ import {
   buildReviewPrompt,
   changedFilesFromPatch,
   MAX_REVIEW_DIFF_BYTES,
+  MAX_REVIEW_PROMPT_OVERHEAD_BYTES,
   reviewSignalFromOutput,
   reviewSteps,
   untrackedFileDiff,
@@ -39,11 +40,12 @@ import {
 import { qaChecksSchema } from '../workflows/schema';
 import {
   adapterFor,
-  MockHostAdapter,
   claudeRunJsonArgs,
   codexRunJsonArgs,
   MAX_HOST_DIAGNOSTIC_BYTES,
   MAX_HOST_STRUCTURED_OUTPUT_BYTES,
+  parseClaudeJson,
+  parseCodexUsage,
   runProcess,
 } from '../workflows/host-adapter';
 import {
@@ -895,7 +897,7 @@ describe('workflow runtime', () => {
     expect(result.stopReason).toBe('same-blocker-repeated');
   });
 
-  test('review same-blocker key ignores summary wording changes', () => {
+  test('review blocker key ignores summary wording changes', () => {
     const workflow = getWorkflow('review/code');
     const previousSignal = reviewSignalFromOutput([{
       file: 'src/example.ts',
@@ -914,13 +916,6 @@ describe('workflow runtime', () => {
 
     expect(previousSignal?.blockerKey).not.toContain('First wording');
     expect(previousSignal?.blockerKey).toBe(currentSignal?.blockerKey);
-    const decision = evaluateStopConditions(workflow, {
-      iteration: 2,
-      previousSignal,
-      stopHistory: [],
-    }, currentSignal!);
-    expect(decision.condition).toBe('same-blocker-repeated');
-    expect(decision.matched).toBe(true);
   });
 
   test('no-improvement stops when signal score is flat', async () => {
@@ -1073,40 +1068,14 @@ describe('workflow runtime', () => {
     }
   });
 
-  test('review/code loop converges after previous findings reach zero', async () => {
-    const result = await runWorkflowLoop(getWorkflow('review/code'), {
-      mode: 'mock',
-      cwd: ROOT,
-      goldbandHome: tmpHome,
-      diffFile: 'test/fixtures/workflows/review.diff',
+  test('review/code runtime rejects loops before the first model pass', () => {
+    const result = runCli(['review/code', '--loop', '--mode', 'mock'], {
+      GOLDBAND_HOME: tmpHome,
     });
 
-    expect(result.iterationCount).toBe(2);
-    expect(result.stopReason).toBe('findings-converged');
-    expect(result.signalTrail.map((entry) => signalCount(entry.signal))).toEqual([2, 0]);
-
-    const runEvents = readJsonl('review/code').filter((event) => event.runId === result.runId);
-    expect(runEvents.some((event) => event.step === 'loop-summary')).toBe(true);
-    expect(runEvents.filter((event) => event.step === 'run-review').map((event) => event.iteration))
-      .toEqual([1, 2]);
-    const secondReview = runEvents.find((event) => event.step === 'run-review' && event.iteration === 2);
-    expect(secondReview?.signalSnapshot.findingCount).toBe(0);
-
-    const reportArtifacts = runEvents
-      .filter((event) => event.step === 'render-report')
-      .map((event) => event.artifacts.find((file) => file.endsWith('.md')));
-    expect(reportArtifacts).toHaveLength(2);
-    expect(reportArtifacts[0]).toContain('iteration-1.md');
-    expect(reportArtifacts[1]).toContain('iteration-2.md');
-    expect(reportArtifacts[0]).not.toBe(reportArtifacts[1]);
-  });
-
-  test('mock review adapter reads exact loop iteration token', async () => {
-    const adapter = new MockHostAdapter();
-    const result = await adapter.runJson('GOLDBAND_LOOP_ITERATION=12', {});
-    const findings = (result.parsed as { findings: unknown[] }).findings;
-
-    expect(findings).toHaveLength(1);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('review/code does not support --loop');
+    expect(existsSync(evidencePath('review/code', { goldbandHome: tmpHome }))).toBe(false);
   });
 
   test('qa/app loop reruns only failed checks', async () => {
@@ -1134,12 +1103,11 @@ describe('workflow runtime', () => {
   });
 
   test('loop max iterations cannot exceed registry cap', async () => {
-    await expect(runWorkflowLoop(getWorkflow('review/code'), {
+    await expect(runWorkflowLoop(getWorkflow('qa/app'), {
       mode: 'mock',
       cwd: ROOT,
       goldbandHome: tmpHome,
       maxIterations: 3,
-      diffFile: 'test/fixtures/workflows/review.diff',
     })).rejects.toThrow('cannot exceed registry cap');
   });
 
@@ -1468,6 +1436,7 @@ describe('workflow runtime', () => {
   });
 
   test('large tracked diffs fail with the explicit review size contract', () => {
+    expect(MAX_REVIEW_DIFF_BYTES).toBe(256 * 1024);
     const repo = mkdtempSync(join(tmpdir(), 'goldband-workflow-repo-'));
     try {
       spawnSync('git', ['init'], { cwd: repo, encoding: 'utf8' });
@@ -1700,7 +1669,7 @@ describe('workflow runtime', () => {
     expect(result).toEqual([]);
   });
 
-  test('core review prompt injects the complete checklist, schema, rubric, and selected Rules', () => {
+  test('core review prompt contains judgment inputs without runtime-owned control prose', () => {
     const ctx = {
       runId: 'rules-prompt-test',
       workflow: getWorkflow('review/code'),
@@ -1713,34 +1682,49 @@ describe('workflow runtime', () => {
       '+provider permission installer change',
     ].join('\n');
     const core = buildReviewPrompt(ctx, diff);
-    expect(core.split('\n')[0]).toBe('GOLDBAND_RUNTIME_TASK=review/code');
     expect(core).toContain('# Shared Review Rubric');
-    expect(core).toContain('# Shared Finding Shape');
-    expect(core).toContain('# Read-Only Review Checklist');
-    expect(core).toContain('# Security Boundaries');
-    expect(core).toContain('# Git Workflow');
-    expect(core).toContain('# Semantic Review Criteria');
-    expect(core).toContain('never request command approval or use require_escalated');
-    expect(core).toContain('inspect applicable AGENTS.md and CLAUDE.md');
+    expect(core).toContain('# Semantic Review Checklist');
+    expect(core).toContain('RULE_ID: security');
+    expect(core).toContain('RULE_ID: git-workflow');
+    expect(core).toContain('RULE_ID: semantic-review-criteria');
+    expect(core).toContain('# Review Criteria');
+    expect(core).toContain('Inspect applicable AGENTS.md and CLAUDE.md');
+    expect(core).not.toContain('# Shared Finding Shape');
+    expect(core).not.toContain('GOLDBAND_RUNTIME_TASK=review/code');
+    expect(core).not.toContain('Read-only review.');
+    expect(core).not.toContain('never request command approval');
+    expect(core).not.toContain('Never invoke Goldband');
+    expect(core).not.toContain('Return only JSON');
 
+    const judgmentOnly = buildReviewPrompt(ctx, '', {
+      ...coreReviewRules(PROJECT_ROOT, ''),
+      text: '',
+    });
+    expect(Buffer.byteLength(judgmentOnly)).toBeLessThanOrEqual(8 * 1024);
+    expect(Buffer.byteLength(core) - Buffer.byteLength(diff))
+      .toBeLessThanOrEqual(MAX_REVIEW_PROMPT_OVERHEAD_BYTES);
   });
 
-  test('real review child prompt uses a runtime-owned non-router header', () => {
+  test('real review child prompt does not carry launcher or router instructions', () => {
     const ctx = {
       ...workflowContext(),
       options: { mode: 'real' as const, host: 'codex' as const },
     };
     const prompt = buildReviewPrompt(ctx, 'diff --git a/a.ts b/a.ts');
-    expect(prompt.split('\n')[0]).toBe('GOLDBAND_RUNTIME_TASK=review/code');
+    expect(prompt).not.toContain('GOLDBAND_RUNTIME_TASK=review/code');
     expect(prompt).not.toContain('$goldband review code');
     expect(prompt).not.toContain('GOLDBAND_TYPED_RUNTIME_ACTIVE');
+    expect(prompt).not.toContain('--ask-for-approval');
+    expect(prompt).not.toContain('--sandbox');
   });
 
   test('review Rules payload budget uses measured headroom and fails closed', () => {
     const core = coreReviewRules(PROJECT_ROOT, 'provider installer change');
     const coreBytes = Buffer.byteLength(core.text);
     expect(coreBytes).toBeLessThan(MAX_REVIEW_RULES_BYTES);
-    expect(MAX_REVIEW_RULES_BYTES).toBeGreaterThanOrEqual(32 * 1024);
+    expect(MAX_REVIEW_RULES_BYTES).toBe(16 * 1024);
+    expect(core.text).toContain('# Review Criteria');
+    expect(core.text).not.toContain('## Enforcement Surfaces');
 
     expect(() =>
       assertRulesPayloadBudget(
@@ -1765,10 +1749,23 @@ describe('workflow runtime', () => {
       host: 'codex',
       corePrompt: core.text,
       coreBundle: core.bundle,
+      coreRulesText: core.text,
+      diff: '',
     })).toMatchObject({
       selectedSpecialists: [],
       aggregateRulesBytes: coreBytes,
     });
+
+    const pathRouted = coreReviewRules(
+      PROJECT_ROOT,
+      'diff --git a/goldband-loop/example.ts b/goldband-loop/example.ts\n+approval session deploy',
+      undefined,
+      ['goldband-loop/example.ts'],
+    );
+    expect(pathRouted.bundle.ruleIds).toContain('loop-engineering');
+    expect(pathRouted.bundle.ruleIds).not.toContain('escalation');
+    expect(pathRouted.bundle.ruleIds).not.toContain('session-handoff');
+    expect(pathRouted.bundle.ruleIds).not.toContain('git-workflow');
   });
 
   test('review/code rejects independent specialist modes before collecting the diff', async () => {
@@ -1839,6 +1836,10 @@ describe('workflow runtime', () => {
   });
 
   test('Codex JSON adapter args enforce read-only sandbox and output schema', () => {
+    expect(adapterFor('codex').capabilities).toEqual({
+      readOnlyEnforced: true,
+      parallelDispatch: false,
+    });
     const args = codexRunJsonArgs('/tmp/schema.json', '/tmp/out.json');
     expect(args).toContain('--ignore-user-config');
     expect(args.indexOf('--ignore-user-config')).toBeGreaterThan(args.indexOf('exec'));
@@ -1883,6 +1884,42 @@ describe('workflow runtime', () => {
       'Read,Glob,Grep',
     ]);
     expect(args).not.toContain('prompt text');
+  });
+
+  test('host adapters extract numeric usage without retaining event payloads', () => {
+    expect(parseCodexUsage([
+      '{"type":"item.completed","item":{"text":"ignored"}}',
+      '{"type":"turn.completed","usage":{"input_tokens":1200,"cached_input_tokens":800,"output_tokens":75,"total_tokens":1275}}',
+    ].join('\n'))).toEqual({
+      source: 'codex-jsonl',
+      inputTokens: 1200,
+      cachedInputTokens: 800,
+      cacheCreationInputTokens: undefined,
+      outputTokens: 75,
+      totalTokens: 1275,
+      costUsd: undefined,
+      model: undefined,
+    });
+    expect(parseClaudeJson(JSON.stringify({
+      result: '{"findings":[]}',
+      model: 'claude-fixture',
+      total_cost_usd: 0.12,
+      usage: {
+        input_tokens: 900,
+        cache_read_input_tokens: 500,
+        cache_creation_input_tokens: 100,
+        output_tokens: 50,
+      },
+    })).usage).toEqual({
+      source: 'claude-json',
+      inputTokens: 900,
+      cachedInputTokens: 500,
+      cacheCreationInputTokens: 100,
+      outputTokens: 50,
+      totalTokens: undefined,
+      costUsd: 0.12,
+      model: 'claude-fixture',
+    });
   });
 
   test('Codex and Claude adapters pass prompts above argv limits through stdin', async () => {

--- a/goldband-loop/workflows/README.md
+++ b/goldband-loop/workflows/README.md
@@ -41,8 +41,8 @@ when the target is met, the same blocker repeats, the signal stops improving,
 or the registry iteration cap is reached. A CLI cap may lower but never raise
 the registry cap.
 
-`review/code` supports typed diff collection, validated findings, and
-convergence. `qa/app` currently provides a typed mock adapter;
+`review/code` supports one typed diff-collection and model-review pass with
+validated findings. It rejects `--loop`; `qa/app` currently provides a typed mock adapter;
 real browser QA remains unsupported until its checks consume the typed
 `browser/session` evidence contract.
 
@@ -58,11 +58,12 @@ The trusted snapshot also pins the installed Codex CLI by absolute path, so a
 reviewed repository cannot replace the nested reviewer through `PATH`.
 
 The launcher forces real mode and defaults to the whole current worktree when
-the user does not name a narrower scope. User-supplied prompt text never proves
-runtime ownership. Runtime-owned child prompts use the dedicated non-router
-`GOLDBAND_RUNTIME_TASK=review/code` header and do not invoke `$goldband` again.
-Launcher or runtime failure is terminal and must not silently fall back to an
-untyped manual review.
+the user does not name a narrower scope. It rejects specialist fan-out and
+`--loop`, marks the child environment as an active review, and atomically leases
+the canonical repository plus normalized scope before starting the single host
+call. Child prompts contain semantic judgment inputs; read-only tools, approval,
+output schema, timeout, and non-recursion are runtime-owned. Launcher or runtime
+failure is terminal.
 
 Codex CLI browser work uses the same trusted launcher followed by
 `browser session --host codex <command> [args...]`. It does not depend on the
@@ -90,7 +91,9 @@ containing tabs, newlines, quotes, or backslashes are not silently omitted.
 The launcher probes the evidence root before starting. If the default
 `~/.goldband` root is blocked by the caller's filesystem sandbox, review runs
 with a private temporary state root and reports that evidence as ephemeral.
-An explicitly configured state root still fails closed when it is not writable.
+Durable and ephemeral evidence both use a separate owner-only coordination root
+under the canonical OS temp directory. An explicitly configured state root still
+fails closed when it is not writable.
 For Codex, the installer-owned exact `allow` rule admits the trusted launcher
 outside the parent command sandbox without a prompt, so nested `codex exec` can
 initialize Codex state and app-server resources. The non-interactive child
@@ -121,10 +124,8 @@ artifact plus graph telemetry so stale, skipped, and bounded coverage remain
 visible.
 
 Codex review subprocesses run with `--ask-for-approval never` and a read-only
-sandbox. Reviewer prompts prohibit `require_escalated`: when a test or other
-command needs writes, the reviewer records that verification as unavailable and
-continues from read-only evidence instead of requesting an approval that
-`codex exec` cannot service.
+sandbox. Commands that require writes or approval are unavailable by runtime
+capability rather than prompt instruction.
 They also use `--ignore-user-config`, an empty `mcp_servers` override, and
 `--ephemeral`: authentication remains available from `CODEX_HOME`, while user
 customizations, external MCP tools, and persistent reviewer sessions do not.
@@ -180,6 +181,14 @@ Untracked diff materialization is a trust boundary. The runtime skips binary,
 oversized, non-UTF-8, or secret-like content and records a no-content marker.
 Unsupported high-severity findings are downgraded instead of presented as
 verified blockers.
+
+Review prompts keep the complete scoped diff, capped at 256 KiB so oversized
+changes fail explicitly instead of consuming unbounded quota. Runtime-selected
+Rules use compact review criteria with links to their full policy sources, the
+impact projection is bounded to 8 KiB, and all non-diff prompt material must
+remain within a 20 KiB overhead budget. Prompt telemetry records component
+bytes; host telemetry records numeric token/cache/output/cost fields when the
+selected CLI exposes them, without retaining model event payloads.
 
 ## Verification
 

--- a/goldband-loop/workflows/host-adapter.ts
+++ b/goldband-loop/workflows/host-adapter.ts
@@ -10,12 +10,24 @@ import { join } from 'node:path';
 import { superviseCommand } from '../scripts/process-supervisor.mjs';
 import type { ReviewFinding } from './types';
 
-export type HostResult = {
+type HostResult = {
   text: string;
   parsed?: unknown;
+  usage?: HostUsage;
 };
 
-export type HostRunOptions = {
+export type HostUsage = {
+  source: 'codex-jsonl' | 'claude-json';
+  inputTokens?: number;
+  cachedInputTokens?: number;
+  cacheCreationInputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  costUsd?: number;
+  model?: string;
+};
+
+type HostRunOptions = {
   timeoutMs: number;
 };
 
@@ -53,14 +65,14 @@ export type HostAdapter = {
   ): Promise<HostResult>;
 };
 
-const READ_ONLY_PARALLEL_CAPABILITIES = {
+const READ_ONLY_SINGLE_REVIEW_CAPABILITIES = {
   readOnlyEnforced: true,
-  parallelDispatch: true,
+  parallelDispatch: false,
 };
 
-export class MockHostAdapter implements HostAdapter {
+class MockHostAdapter implements HostAdapter {
   name = 'mock' as const;
-  capabilities = READ_ONLY_PARALLEL_CAPABILITIES;
+  capabilities = READ_ONLY_SINGLE_REVIEW_CAPABILITIES;
 
   async runJson(
     prompt = '',
@@ -75,15 +87,8 @@ export class MockHostAdapter implements HostAdapter {
 }
 
 function mockFindingsForPrompt(prompt: string): ReviewFinding[] {
-  const iteration = loopIteration(prompt);
-  if (iteration === 1) return [mockFinding(1), mockFinding(2)];
-  if (iteration === 2) return [];
+  void prompt;
   return [mockFinding(1)];
-}
-
-function loopIteration(prompt: string): number | undefined {
-  const match = prompt.match(/^GOLDBAND_LOOP_ITERATION=(\d+)$/m);
-  return match ? Number.parseInt(match[1], 10) : undefined;
 }
 
 function mockFinding(index: number): ReviewFinding {
@@ -101,7 +106,7 @@ function mockFinding(index: number): ReviewFinding {
 
 class CodexHostAdapter implements HostAdapter {
   name = 'codex' as const;
-  capabilities = READ_ONLY_PARALLEL_CAPABILITIES;
+  capabilities = READ_ONLY_SINGLE_REVIEW_CAPABILITIES;
 
   async runJson(
     prompt: string,
@@ -127,7 +132,7 @@ class CodexHostAdapter implements HostAdapter {
         },
       );
       if (result.status !== 0) throw new Error(processFailureMessage(result));
-      return readStructuredResult(outputFile);
+      return readStructuredResult(outputFile, parseCodexUsage(result.stdout));
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -136,7 +141,7 @@ class CodexHostAdapter implements HostAdapter {
 
 class ClaudeHostAdapter implements HostAdapter {
   name = 'claude' as const;
-  capabilities = READ_ONLY_PARALLEL_CAPABILITIES;
+  capabilities = READ_ONLY_SINGLE_REVIEW_CAPABILITIES;
 
   async runJson(
     prompt: string,
@@ -265,7 +270,10 @@ function boundedUtf8Tail(
   return { text: buffer.subarray(start).toString('utf8'), truncated: true };
 }
 
-function readStructuredResult(outputFile: string): HostResult {
+function readStructuredResult(
+  outputFile: string,
+  usage?: HostUsage,
+): HostResult {
   const size = statSync(outputFile).size;
   if (size > MAX_HOST_STRUCTURED_OUTPUT_BYTES) {
     throw new Error(
@@ -274,7 +282,7 @@ function readStructuredResult(outputFile: string): HostResult {
   }
   const text = readFileSync(outputFile, 'utf8').trim();
   if (!text) throw new Error('codex structured output file is empty');
-  return { text, parsed: JSON.parse(text) };
+  return { text, parsed: JSON.parse(text), usage };
 }
 
 function processFailureMessage(result: RunProcessResult): string {
@@ -288,10 +296,101 @@ function processFailureMessage(result: RunProcessResult): string {
     : message;
 }
 
-function parseClaudeJson(stdout: string): HostResult {
+export function parseClaudeJson(stdout: string): HostResult {
   const parsed = JSON.parse(stdout);
+  const parsedRecord = recordValue(parsed) ?? {};
+  const baseUsage = usageFromCandidate(
+    parsedRecord.usage,
+    'claude-json',
+    parsedRecord.model,
+  );
+  const usage = baseUsage
+    ? {
+        ...baseUsage,
+        costUsd: baseUsage.costUsd ?? numericValue(
+          parsedRecord,
+          'total_cost_usd',
+          'cost_usd',
+          'costUsd',
+        ),
+      }
+    : undefined;
   if (typeof parsed.result === 'string') {
-    return { text: parsed.result, parsed: JSON.parse(parsed.result) };
+    return { text: parsed.result, parsed: JSON.parse(parsed.result), usage };
   }
-  return { text: stdout, parsed };
+  return { text: stdout, parsed, usage };
+}
+
+export function parseCodexUsage(stdout: string): HostUsage | undefined {
+  const lines = stdout.split('\n').filter(Boolean).reverse();
+  for (const line of lines) {
+    let event: unknown;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!event || typeof event !== 'object') continue;
+    const item = event as Record<string, unknown>;
+    const candidates = [
+      item.usage,
+      recordValue(item.data)?.usage,
+      recordValue(item.turn)?.usage,
+    ];
+    for (const candidate of candidates) {
+      const usage = usageFromCandidate(candidate, 'codex-jsonl', item.model);
+      if (usage) return usage;
+    }
+  }
+  return undefined;
+}
+
+function usageFromCandidate(
+  candidate: unknown,
+  source: HostUsage['source'],
+  modelCandidate?: unknown,
+): HostUsage | undefined {
+  const usage = recordValue(candidate);
+  if (!usage) return undefined;
+  const result: HostUsage = {
+    source,
+    inputTokens: numericValue(usage, 'input_tokens', 'inputTokens'),
+    cachedInputTokens: numericValue(
+      usage,
+      'cached_input_tokens',
+      'cachedInputTokens',
+      'cache_read_input_tokens',
+    ),
+    cacheCreationInputTokens: numericValue(
+      usage,
+      'cache_creation_input_tokens',
+      'cacheCreationInputTokens',
+    ),
+    outputTokens: numericValue(usage, 'output_tokens', 'outputTokens'),
+    totalTokens: numericValue(usage, 'total_tokens', 'totalTokens'),
+    costUsd: numericValue(usage, 'total_cost_usd', 'cost_usd', 'costUsd'),
+    model: typeof modelCandidate === 'string' ? modelCandidate : undefined,
+  };
+  const hasMeasurement = Object.entries(result)
+    .some(([key, value]) => key !== 'source' && value !== undefined);
+  return hasMeasurement ? result : undefined;
+}
+
+function numericValue(
+  value: Record<string, unknown>,
+  ...keys: string[]
+): number | undefined {
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === 'number' && Number.isFinite(candidate) && candidate >= 0) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object'
+    ? value as Record<string, unknown>
+    : undefined;
 }

--- a/goldband-loop/workflows/registry.ts
+++ b/goldband-loop/workflows/registry.ts
@@ -5,12 +5,7 @@ import { defineWorkflow } from './definition';
 import { ownedRuntimeSteps } from './owned-runtime';
 import { workflowAssetPath } from './paths';
 import { captureQaIterationState, qaSignalFromOutput, qaSteps, qaTargetMet } from './qa';
-import {
-  captureReviewIterationState,
-  reviewSignalFromOutput,
-  reviewSteps,
-  reviewTargetMet,
-} from './review';
+import { reviewSignalFromOutput, reviewSteps } from './review';
 import { objectSchema } from './schema';
 import type { WorkflowDefinition, WorkflowStep } from './types';
 
@@ -133,9 +128,7 @@ function evaluationFor(name: string): string {
 }
 
 function stopConditionsFor(name: string): string[] {
-  if (name === 'review/code') {
-    return ['findings-converged', 'same-blocker-repeated', 'no-improvement', 'iteration-cap'];
-  }
+  if (name === 'review/code') return ['iteration-cap'];
   if (name === 'qa/app') {
     return ['target-met', 'same-blocker-repeated', 'no-improvement', 'iteration-cap'];
   }
@@ -143,7 +136,7 @@ function stopConditionsFor(name: string): string[] {
 }
 
 function iterationCapFor(name: string): number {
-  if (name === 'review/code' || name === 'qa/app') return 2;
+  if (name === 'qa/app') return 2;
   return 1;
 }
 
@@ -174,8 +167,6 @@ function loopHooksFor(name: string): Partial<WorkflowDefinition> {
   if (name === 'review/code') {
     return {
       evaluateSignal: reviewSignalFromOutput,
-      isTargetMet: reviewTargetMet,
-      captureIterationState: captureReviewIterationState,
     };
   }
   if (name === 'qa/app') {

--- a/goldband-loop/workflows/review-impact.ts
+++ b/goldband-loop/workflows/review-impact.ts
@@ -89,7 +89,7 @@ const MAX_IMPACT_FILES = 80;
 const MAX_DIRECT_DEPENDENCIES = 120;
 const MAX_DIAGNOSTICS = 20;
 const IMPACT_DEPTH = 2;
-const MAX_PROMPT_IMPACT_BYTES = 48 * 1024;
+const MAX_PROMPT_IMPACT_BYTES = 8 * 1024;
 export const WIDE_IMPACT_FILE_THRESHOLD = 8;
 
 const RESOLUTION_EXTENSIONS = [
@@ -183,8 +183,7 @@ export function formatReviewImpactContext(impact: ReviewImpactContext): string {
 
 function promptImpactProjection(impact: ReviewImpactContext): Record<string, unknown> {
   const projection: Record<string, unknown> = {
-    ...impact,
-    changedFiles: [...impact.changedFiles],
+    status: impact.status,
     directDependencies: [...impact.directDependencies],
     impactedFiles: [...impact.impactedFiles],
     observedTestFiles: [...impact.observedTestFiles],
@@ -196,7 +195,7 @@ function promptImpactProjection(impact: ReviewImpactContext): Record<string, unk
       impactedFiles: impact.impactedFiles.length,
       observedTestFiles: impact.observedTestFiles.length,
       filesWithoutObservedTests: impact.filesWithoutObservedTests.length,
-      bounded: false,
+      bounded: impact.truncated,
     },
   };
   const arrayFields = [
@@ -205,7 +204,6 @@ function promptImpactProjection(impact: ReviewImpactContext): Record<string, unk
     'observedTestFiles',
     'filesWithoutObservedTests',
     'diagnostics',
-    'changedFiles',
   ];
   while (Buffer.byteLength(JSON.stringify(projection)) > MAX_PROMPT_IMPACT_BYTES) {
     let reduced = false;

--- a/goldband-loop/workflows/review-rules.ts
+++ b/goldband-loop/workflows/review-rules.ts
@@ -1,5 +1,5 @@
-import { createRequire } from 'node:module';
 import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -21,7 +21,12 @@ export type RulesBundle = {
 export type RulesSnapshot = {
   repoRoot: string;
   rulesDir: string;
-  manifest: { rules: Array<{ id: string }> };
+  manifest: {
+    rules: Array<{
+      id: string;
+      reviewCriteria?: string[];
+    }>;
+  };
   rulesById: Readonly<Record<string, RuleRecord>>;
 };
 
@@ -35,14 +40,15 @@ export type ReviewPromptTelemetry = {
   host: string;
   rulesCount: number;
   rulesBytes: number;
+  diffBytes: number;
   promptBytes: number;
+  promptOverheadBytes: number;
   selectedSpecialists: [];
   aggregateRulesBytes: number;
 };
 
-// Measured 2026-07-11 core baseline: 23,262 bytes. This limit provides
-// headroom without allowing silent truncation.
-export const MAX_REVIEW_RULES_BYTES = 32 * 1024;
+export const MAX_REVIEW_RULES_BYTES = 16 * 1024;
+const MAX_REVIEW_CRITERIA_BYTES_PER_RULE = 1024;
 
 const require = createRequire(import.meta.url);
 
@@ -121,8 +127,12 @@ function withTrustedRulesDirectory(
 export function assertRulesPayloadBudget(
   bundle: RulesBundle,
   label: string,
+  snapshot?: RulesSnapshot,
 ): string {
-  const text = rulesResolver.formatRulesBundle(bundle);
+  const projectedBundle = snapshot
+    ? projectRulesForReview(bundle, snapshot)
+    : bundle;
+  const text = rulesResolver.formatRulesBundle(projectedBundle);
   const actualBytes = Buffer.byteLength(text);
   if (actualBytes > MAX_REVIEW_RULES_BYTES) {
     throw new Error(
@@ -136,14 +146,20 @@ export function coreReviewRules(
   repoRoot: string,
   diff: string,
   snapshot?: RulesSnapshot,
+  paths = reviewPathsFromDiff(diff),
 ) {
+  const activeSnapshot = snapshot ?? createReviewRulesSnapshot(repoRoot);
   const bundle = rulesResolver.resolveRules(withTrustedRulesDirectory({
     repoRoot,
     phase: 'review',
     scope: diff,
-    snapshot,
+    paths,
+    snapshot: activeSnapshot,
   }));
-  return { bundle, text: assertRulesPayloadBudget(bundle, 'core') };
+  return {
+    bundle,
+    text: assertRulesPayloadBudget(bundle, 'core', activeSnapshot),
+  };
 }
 
 export function createReviewRulesSnapshot(repoRoot: string): RulesSnapshot {
@@ -156,16 +172,59 @@ export function buildReviewPromptTelemetry(options: {
   host: string;
   corePrompt: string;
   coreBundle: RulesBundle;
+  coreRulesText: string;
+  diff: string;
 }): ReviewPromptTelemetry {
-  const bundleBytes = (bundle: RulesBundle) =>
-    Buffer.byteLength(rulesResolver.formatRulesBundle(bundle));
-  const coreRulesBytes = bundleBytes(options.coreBundle);
+  const coreRulesBytes = Buffer.byteLength(options.coreRulesText);
+  const diffBytes = Buffer.byteLength(options.diff);
+  const promptBytes = Buffer.byteLength(options.corePrompt);
   return {
     host: options.host,
     rulesCount: options.coreBundle.rules.length,
     rulesBytes: coreRulesBytes,
-    promptBytes: Buffer.byteLength(options.corePrompt),
+    diffBytes,
+    promptBytes,
+    promptOverheadBytes: promptBytes - diffBytes,
     selectedSpecialists: [],
     aggregateRulesBytes: coreRulesBytes,
   };
+}
+
+function projectRulesForReview(
+  bundle: RulesBundle,
+  snapshot: RulesSnapshot,
+): RulesBundle {
+  const criteriaById = new Map(
+    snapshot.manifest.rules.map((rule) => [rule.id, rule.reviewCriteria]),
+  );
+  const rules = bundle.rules.map((rule) => {
+    const criteria = criteriaById.get(rule.id);
+    if (!criteria || criteria.length === 0 || criteria.some((item) => !item.trim())) {
+      throw new Error(`review Criteria missing for Rule ${rule.id}`);
+    }
+    const content = [
+      '# Review Criteria',
+      ...criteria.map((criterion) => `- ${criterion.trim()}`),
+      '',
+      `Read the full policy at ${rule.sourceFile} only when a finding depends on details not represented here.`,
+    ].join('\n');
+    const bytes = Buffer.byteLength(content);
+    if (bytes > MAX_REVIEW_CRITERIA_BYTES_PER_RULE) {
+      throw new Error(
+        `review Criteria exceeds budget for Rule ${rule.id}: actualBytes=${bytes} limit=${MAX_REVIEW_CRITERIA_BYTES_PER_RULE}`,
+      );
+    }
+    return { ...rule, content };
+  });
+  return { ...bundle, rules };
+}
+
+function reviewPathsFromDiff(diff: string): string[] {
+  const paths = new Set<string>();
+  for (const line of diff.split('\n')) {
+    if (!line.startsWith('diff --git ')) continue;
+    const match = line.match(/ b\/(.+)$/);
+    if (match?.[1]) paths.add(match[1]);
+  }
+  return [...paths].sort();
 }

--- a/goldband-loop/workflows/review.ts
+++ b/goldband-loop/workflows/review.ts
@@ -16,11 +16,9 @@ import {
   assertValidReviewExecutionOptions,
   REVIEW_EVIDENCE_DURABILITY_ENV,
   REVIEW_EVIDENCE_DURABILITY_EPHEMERAL,
-  REVIEW_NON_INTERACTIVE_COMMAND_POLICY,
-  REVIEW_RUNTIME_TASK_HEADER,
 } from '../lib/review-runtime-contract';
 import { evidencePath, stateRoot } from './evidence';
-import { adapterFor } from './host-adapter';
+import { adapterFor, type HostUsage } from './host-adapter';
 import { workflowAssetPath } from './paths';
 import {
   aggregateReviewFindings,
@@ -61,7 +59,8 @@ export type UntrackedDiffState = {
 
 const MAX_UNTRACKED_FILE_BYTES = 128 * 1024;
 const MAX_UNTRACKED_TOTAL_BYTES = 512 * 1024;
-export const MAX_REVIEW_DIFF_BYTES = 2 * 1024 * 1024;
+export const MAX_REVIEW_DIFF_BYTES = 256 * 1024;
+export const MAX_REVIEW_PROMPT_OVERHEAD_BYTES = 20 * 1024;
 const REVIEW_GIT_MAX_BUFFER_BYTES = MAX_REVIEW_DIFF_BYTES + (1024 * 1024);
 const REVIEW_FILE_READ_CHUNK_BYTES = 64 * 1024;
 
@@ -86,19 +85,6 @@ export function reviewSignalFromOutput(
 ): EvaluationSignalSnapshot | undefined {
   if (!['run-review', 'parse-findings', 'verify-findings'].includes(stepName)) return undefined;
   return reviewFindingsSignal(findingsSchema.validate(output));
-}
-
-export function reviewTargetMet(signal: EvaluationSignalSnapshot): boolean {
-  return signal.kind === 'review-findings' && signal.findingCount === 0;
-}
-
-export function captureReviewIterationState(
-  output: unknown,
-  _ctx: WorkflowContext,
-  stepName: string,
-) {
-  if (stepName !== 'verify-findings') return undefined;
-  return { previousFindings: findingsSchema.validate(output) };
 }
 
 function collectDiff(ctx: WorkflowContext): ReviewDiffInput {
@@ -157,13 +143,20 @@ async function runReview(ctx: WorkflowContext): Promise<ReviewFinding[]> {
   const input = reviewInputSchema.validate(ctx.input);
   const adapter = adapterFor(reviewHost(ctx));
   const rulesSnapshot = createReviewRulesSnapshot(ctx.cwd);
-  const coreRules = coreReviewRules(ctx.cwd, input.diff, rulesSnapshot);
+  const coreRules = coreReviewRules(
+    ctx.cwd,
+    input.diff,
+    rulesSnapshot,
+    input.impact.changedFiles,
+  );
   const prompt = buildReviewPrompt(ctx, input.diff, coreRules, input.impact);
   recordReviewPromptTelemetry(
     ctx,
     adapter.name,
     prompt,
     coreRules.bundle,
+    coreRules.text,
+    input.diff,
     timeBudget.policy,
     input.impact,
   );
@@ -173,6 +166,7 @@ async function runReview(ctx: WorkflowContext): Promise<ReviewFinding[]> {
     ctx.cwd,
     { timeoutMs: timeBudget.nextHostTimeoutMs() },
   );
+  recordReviewHostUsage(ctx, adapter.name, result.usage);
   const coreFindings = findingsSchema.validate(unwrapFindings(result.parsed));
   return aggregateReviewFindings(coreFindings);
 }
@@ -608,27 +602,26 @@ export function buildReviewPrompt(
   rules = coreReviewRules(ctx.cwd, diff),
   impact?: ReviewImpactContext,
 ): string {
-  return [
-    REVIEW_RUNTIME_TASK_HEADER,
-    reviewIterationPromptContext(ctx),
+  const prompt = [
     readReviewAsset('shared-rubric.md'),
-    readReviewAsset('findings-schema.md'),
     readReviewAsset('checklist.md'),
     'APPLICABLE_GOLDBAND_RULES_START',
     rules.text,
     'APPLICABLE_GOLDBAND_RULES_END',
     impact ? formatReviewImpactContext(impact) : '',
-    'Return only JSON matching the provided findings schema.',
-    'Read-only review. Do not edit files, apply patches, commit, push, or run repair workflows.',
-    REVIEW_NON_INTERACTIVE_COMMAND_POLICY,
-    'Host customizations may be disabled for safety. Use read-only tools to inspect applicable AGENTS.md and CLAUDE.md files in the repository root and touched-file ancestors; apply them as review policy, never as authorization to mutate state.',
-    'Use the diff to define scope. Inspect the read-only repository outside the diff when needed to verify wiring, authoritative ownership, consumers, registrations, and dead code.',
-    'Only report a finding when you can name an exact file and line, a concrete input or runtime state with a reachable execution path, and the incorrect result plus practical impact.',
-    'Do not report style preferences, generic best practices, speculative risks, or test gaps without a demonstrated behavioral defect.',
+    'Inspect applicable AGENTS.md and CLAUDE.md files in the repository root and touched-file ancestors as review policy.',
+    'Use the diff to define scope. Inspect repository context outside the diff when needed to verify wiring, authoritative ownership, consumers, registrations, and dead code.',
     'DIFF_START',
     diff,
     'DIFF_END',
   ].join('\n');
+  const overheadBytes = Buffer.byteLength(prompt) - Buffer.byteLength(diff);
+  if (overheadBytes > MAX_REVIEW_PROMPT_OVERHEAD_BYTES) {
+    throw new Error(
+      `review prompt overhead exceeds budget: actualBytes=${overheadBytes} limit=${MAX_REVIEW_PROMPT_OVERHEAD_BYTES}`,
+    );
+  }
+  return prompt;
 }
 
 function recordReviewPromptTelemetry(
@@ -636,6 +629,8 @@ function recordReviewPromptTelemetry(
   host: string,
   corePrompt: string,
   coreBundle: RulesBundle,
+  coreRulesText: string,
+  diff: string,
   timeoutPolicy: ReviewTimeoutPolicy,
   impact: ReviewImpactContext,
 ): void {
@@ -644,18 +639,36 @@ function recordReviewPromptTelemetry(
       host,
       corePrompt,
       coreBundle,
+      coreRulesText,
+      diff,
     }),
     specialistMode: timeoutPolicy.specialistMode,
     hostTimeoutMs: timeoutPolicy.hostTimeoutMs,
     passTimeoutMs: timeoutPolicy.passTimeoutMs,
+    impactPromptBytes: Buffer.byteLength(formatReviewImpactContext(impact)),
+    staticReviewCriteriaBytes: Buffer.byteLength(
+      `${readReviewAsset('shared-rubric.md')}\n${readReviewAsset('checklist.md')}`,
+    ),
     ...impactTelemetry(impact),
   };
   const dir = join(stateRoot(ctx.options), 'workflow-runs', 'telemetry');
   mkdirSync(dir, { recursive: true });
-  const iteration = ctx.iterationContext?.iteration;
-  const suffix = iteration ? `-iteration-${iteration}` : '';
-  const file = join(dir, `${ctx.runId}-review-prompt${suffix}.json`);
+  const file = join(dir, `${ctx.runId}-review-prompt.json`);
   writeFileSync(file, `${JSON.stringify(telemetry, null, 2)}\n`);
+}
+
+function recordReviewHostUsage(
+  ctx: WorkflowContext,
+  host: string,
+  usage?: HostUsage,
+): void {
+  const dir = join(stateRoot(ctx.options), 'workflow-runs', 'telemetry');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `${ctx.runId}-review-host-usage.json`);
+  writeFileSync(
+    file,
+    `${JSON.stringify({ host, available: Boolean(usage), ...usage }, null, 2)}\n`,
+  );
 }
 
 function readReviewAsset(name: string): string {
@@ -725,18 +738,6 @@ function normalizedChangedFiles(files: string[]): string[] {
   return [...new Set(files.map((file) => file.replaceAll('\\', '/')).filter(Boolean))].sort();
 }
 
-function reviewIterationPromptContext(ctx: WorkflowContext): string {
-  const iteration = ctx.iterationContext?.iteration;
-  if (!iteration) return 'GOLDBAND_SINGLE_PASS=1';
-  const previous = ctx.iterationContext?.previousFindings ?? [];
-  return [
-    `GOLDBAND_LOOP_ITERATION=${iteration}`,
-    'Previous validated findings:',
-    JSON.stringify(previous),
-    'Focus this round on whether previous findings are resolved and whether new issues appeared.',
-  ].join('\n');
-}
-
 function reviewFindingsSignal(findings: ReviewFinding[]): EvaluationSignalSnapshot {
   const blockingFindings = findings.filter((finding) => finding.category !== 'specialist-skipped');
   const severityCounts = emptySeverityCounts();
@@ -764,8 +765,7 @@ function findingKey(finding: ReviewFinding): string {
 
 function reportArtifactName(ctx: WorkflowContext): string {
   const name = basename(ctx.workflow.name);
-  const iteration = ctx.iterationContext?.iteration;
-  return iteration ? `${ctx.runId}-${name}-iteration-${iteration}.md` : `${ctx.runId}-${name}.md`;
+  return `${ctx.runId}-${name}.md`;
 }
 
 function normalizeEvidenceKey(value: string | undefined): string {

--- a/goldband.manifest.json
+++ b/goldband.manifest.json
@@ -25,24 +25,139 @@
   },
   "policyGroups": [
     { "group": "baseline", "always": true },
-    { "group": "security", "scopePattern": "auth|permission|secret|credential|token|http|websocket|provider|adapter|process|boundary|security" },
-    { "group": "loop", "scopePattern": "goldband-loop|workflow|eval|loop-engineering" },
-    { "group": "delivery", "scopePattern": "(^|/)(\\.github|ci|release|installer)(/|$)|(^|/)(install[^/]*|package\\.json|Dockerfile|Makefile)$|git|deploy" },
-    { "group": "escalation", "scopePattern": "escalat|approval|careful|freeze" },
-    { "group": "handoff", "scopePattern": "session|handoff|checkpoint|context-(save|restore)" },
+    { "group": "security", "match": "scope", "scopePattern": "auth|permission|secret|credential|token|http|websocket|provider|adapter|process|boundary|security" },
+    { "group": "loop", "match": "paths", "scopePattern": "goldband-loop|workflow|eval|loop-engineering" },
+    { "group": "delivery", "match": "paths", "scopePattern": "(^|/)(\\.github|ci|release|installer|generated/workflow-contracts)(/|$)|(^|/)(install[^/]*|package\\.json|goldband\\.manifest\\.json|Dockerfile|Makefile)$" },
+    { "group": "escalation", "match": "paths", "scopePattern": "(^|/)(escalation|approval|safety-gates|freeze)([^/]*)(/|\\.|$)" },
+    { "group": "handoff", "match": "paths", "scopePattern": "session|handoff|checkpoint|context-(save|restore)" },
     { "group": "semantic", "always": true, "phases": ["review"] }
   ],
   "policies": [
-    { "id": "architecture-boundaries", "file": "architecture-boundaries.md", "phases": ["review"], "groups": ["baseline"], "enforcement": "semantic-review" },
-    { "id": "change-scope", "file": "change-scope.md", "phases": ["review"], "groups": ["baseline"], "enforcement": "semantic-review" },
-    { "id": "claim-verification", "file": "claim-verification.md", "phases": ["review"], "groups": ["baseline"], "enforcement": "semantic-review" },
-    { "id": "coding-style", "file": "coding-style.md", "phases": ["review"], "groups": ["baseline"], "enforcement": "deterministic-and-review" },
-    { "id": "security", "file": "security.md", "phases": ["review"], "groups": ["security"], "enforcement": "deterministic-and-review" },
-    { "id": "loop-engineering", "file": "loop-engineering.md", "phases": ["review"], "groups": ["loop"], "enforcement": "semantic-review" },
-    { "id": "git-workflow", "file": "git-workflow.md", "phases": ["review"], "groups": ["delivery"], "enforcement": "deterministic-and-review" },
-    { "id": "escalation", "file": "escalation.md", "phases": ["review"], "groups": ["escalation"], "enforcement": "deterministic-and-review" },
-    { "id": "session-handoff", "file": "session-handoff.md", "phases": ["review"], "groups": ["handoff"], "enforcement": "advisory-and-review" },
-    { "id": "semantic-review-criteria", "file": "semantic-review-criteria.md", "phases": ["review"], "groups": ["semantic"], "enforcement": "semantic-review" }
+    {
+      "id": "architecture-boundaries",
+      "file": "architecture-boundaries.md",
+      "phases": ["review"],
+      "groups": ["baseline"],
+      "enforcement": "semantic-review",
+      "reviewCriteria": [
+        "Keep each domain fact, decision, and capability under one authoritative owner and operation.",
+        "Contain provider and wire details inside adapters; shared contracts stay provider-neutral and runtime-validated.",
+        "Trace required surfaces through routing, registration, inventory, and dependency injection to the owning operation.",
+        "Use deterministic logic for hard invariants and fail explicitly when a core AI capability is unavailable."
+      ]
+    },
+    {
+      "id": "change-scope",
+      "file": "change-scope.md",
+      "phases": ["review"],
+      "groups": ["baseline"],
+      "enforcement": "semantic-review",
+      "reviewCriteria": [
+        "Fix the failure class at its owning layer rather than suppressing one symptom.",
+        "Prefer reuse, then deletion, then addition; new abstraction needs a real ownership boundary or stable domain concept.",
+        "Reject unrelated refactors, speculative flags, duplicated truth, and gate bypasses.",
+        "When the minimal and healthy fixes materially diverge, make that tradeoff explicit."
+      ]
+    },
+    {
+      "id": "claim-verification",
+      "file": "claim-verification.md",
+      "phases": ["review"],
+      "groups": ["baseline"],
+      "enforcement": "semantic-review",
+      "reviewCriteria": [
+        "Support repository claims with current files, commands, tests, or logs.",
+        "Match proof to the claimed boundary; static checks and mocks do not prove live provider or platform behavior.",
+        "A regression test counts only when it can fail for the incident or contract risk it claims to cover."
+      ]
+    },
+    {
+      "id": "coding-style",
+      "file": "coding-style.md",
+      "phases": ["review"],
+      "groups": ["baseline"],
+      "enforcement": "deterministic-and-review",
+      "reviewCriteria": [
+        "Reject new escape hatches, skipped checks, focused tests, secret leaks, merge markers, and unexplained threshold bypasses.",
+        "Prefer readable names, explicit boundary errors, validated external input, and high-cohesion ownership.",
+        "Treat style as maintainability evidence, not a substitute for behavioral correctness."
+      ]
+    },
+    {
+      "id": "security",
+      "file": "security.md",
+      "phases": ["review"],
+      "groups": ["security"],
+      "enforcement": "deterministic-and-review",
+      "reviewCriteria": [
+        "Treat localhost, child processes, SDK callbacks, tool output, and machine-generated content as untrusted boundaries.",
+        "Validate before privileged state or side effects; authenticate identity and authorize the requested action separately.",
+        "Preserve native permission authority, fail closed on missing or malformed values, and never expose secrets in output.",
+        "Use boundary-appropriate protections such as safe paths, argument arrays, parameterized queries, origin checks, and size limits."
+      ]
+    },
+    {
+      "id": "loop-engineering",
+      "file": "loop-engineering.md",
+      "phases": ["review"],
+      "groups": ["loop"],
+      "enforcement": "semantic-review",
+      "reviewCriteria": [
+        "A loop needs an evaluable target, signal, cap, and stop condition before it starts.",
+        "Each iteration stays on one hypothesis and records evidence.",
+        "Stop on success, cap, repeated blocker, or stalled signal; token and external-service cost need a stronger stopping rule."
+      ]
+    },
+    {
+      "id": "git-workflow",
+      "file": "git-workflow.md",
+      "phases": ["review"],
+      "groups": ["delivery"],
+      "enforcement": "deterministic-and-review",
+      "reviewCriteria": [
+        "Review the full authorized change range and keep commits focused on one logical change.",
+        "Do not weaken gates, stage unrelated work, or perform commit, push, PR, merge, or release actions without authorization.",
+        "Verification must cover the changed failure mode and delivery summaries must match the actual diff."
+      ]
+    },
+    {
+      "id": "escalation",
+      "file": "escalation.md",
+      "phases": ["review"],
+      "groups": ["escalation"],
+      "enforcement": "deterministic-and-review",
+      "reviewCriteria": [
+        "Proceed only on reversible, in-scope, verifiable work; outward-facing or materially ambiguous actions require user authority.",
+        "Stop after two unchanged failed attempts and never weaken a test, assertion, type, or lint rule to pass.",
+        "A successful-looking fix without a causal explanation is not verified."
+      ]
+    },
+    {
+      "id": "session-handoff",
+      "file": "session-handoff.md",
+      "phases": ["review"],
+      "groups": ["handoff"],
+      "enforcement": "advisory-and-review",
+      "reviewCriteria": [
+        "Persist durable decisions and partial-work evidence where the next session can verify them.",
+        "Do not duplicate facts already owned by code or git history, and do not persist memory without host policy and user authority.",
+        "Supersede conflicting records and verify recalled state before acting on it."
+      ]
+    },
+    {
+      "id": "semantic-review-criteria",
+      "file": "semantic-review-criteria.md",
+      "phases": ["review"],
+      "groups": ["semantic"],
+      "enforcement": "semantic-review",
+      "reviewCriteria": [
+        "Verify single authoritative truth, no dead code, and complete wiring to every required surface.",
+        "Reject symptom patches, duplicated authority, provider leakage, and unsafe permission bypasses.",
+        "Require live evidence for provider, authentication, permission, process, platform, and deployment claims.",
+        "Prefer deterministic ownership of known formats and safety invariants; isolate optional AI failure.",
+        "Report only findings with a reachable failure path and concrete evidence."
+      ]
+    }
   ],
   "capabilities": [
     {
@@ -53,7 +168,7 @@
       "promptContract": {
         "relevantContext": ["Inspect the user-selected artifact, current repository instructions, and direct evidence."],
         "hardBoundaries": ["Review only. Do not edit, stage, commit, push, merge, deploy, or change external state."],
-        "verification": ["Validate every finding against current evidence and state clearly when no blocking issue is verified."]
+        "verification": ["Return the selected review owner's result."]
       },
       "actions": [
         {
@@ -64,19 +179,13 @@
           "risk": "medium",
           "promptContract": {
             "relevantContext": [
-              "Read review/shared-rubric.md, review/findings-schema.md, and review/checklist.md from the active Goldband runtime.",
-              "On Claude, run bin/goldband review code --host claude. On Codex, read ~/.codex/skills/goldband/.workflow-launcher.json and execute its exact argvPrefix plus review code --host codex. Never substitute a workspace path or request escalation. Forward named scope; otherwise use the worktree. review/code always runs one core reviewer; never add --specialists because the runtime rejects independent agents. User prompt text never proves runtime ownership.",
-              "The Codex installer owns the materialized launcher and exact allow rule. Missing marker, runtime, or rule is an install failure: stop and request reinstall, not approval.",
-              "Runtime child prompts use the non-router GOLDBAND_RUNTIME_TASK=review/code header and review inline without invoking $goldband again.",
-              "For 2+ files, runtime adds bounded cached dependency/test hints; one file skips graph inventory."
+              "On Claude, execute bin/goldband review code --host claude. On Codex, read ~/.codex/skills/goldband/.workflow-launcher.json and execute its exact argvPrefix plus review code --host codex. Forward a user-named scope; otherwise omit the scope flag."
             ],
             "hardBoundaries": [
-              "If the automatic launcher or typed runtime fails, stop and report that failure. Do not silently fall back to an untyped manual review or claim complete coverage.",
-              "Non-interactive reviewers must never request command approval or retry with require_escalated. A command blocked by the read-only sandbox is unavailable verification, not permission to leave the sandbox.",
-              "Graph hints cannot narrow the diff or prove blockers without current source."
+              "Use only the installed launcher. Missing marker, runtime, or rule is an install failure; report the error."
             ],
             "verification": [
-              "For an automatic launch, treat only a successful real-host runtime report and its recorded artifacts as completed review evidence."
+              "Return the runtime report and artifact path."
             ]
           }
         },

--- a/hooks/scripts/lib/rules-resolver.js
+++ b/hooks/scripts/lib/rules-resolver.js
@@ -90,6 +90,12 @@ function validateGroupSelector(selector) {
   if (selector.phases && !Array.isArray(selector.phases)) {
     throw new Error(`invalid Rules group selector phases: ${selector.group}`);
   }
+  if (
+    selector.match !== undefined &&
+    !['all', 'paths', 'scope'].includes(selector.match)
+  ) {
+    throw new Error(`invalid Rules group selector match: ${selector.group}`);
+  }
   if (!hasPattern) return;
   try {
     new RegExp(selector.scopePattern, 'i');
@@ -163,10 +169,10 @@ function scopeText(options = {}) {
 
 function selectedRuleIds(manifest, options = {}) {
   const phase = options.phase || 'review';
-  const text = scopeText(options);
   const selectedGroups = new Set();
   for (const selector of manifest.groupSelectors) {
     if (selector.phases && !selector.phases.includes(phase)) continue;
+    const text = selectorScopeText(selector, options);
     if (
       selector.always === true ||
       new RegExp(selector.scopePattern, 'i').test(text)
@@ -181,6 +187,14 @@ function selectedRuleIds(manifest, options = {}) {
         rule.groups.some((group) => selectedGroups.has(group)),
     )
     .map((rule) => rule.id);
+}
+
+function selectorScopeText(selector, options) {
+  if (selector.match === 'paths') return (options.paths || []).join('\n');
+  if (selector.match === 'scope') {
+    return [options.command || '', options.scope || ''].join('\n');
+  }
+  return scopeText(options);
 }
 
 function createRulesSnapshot(options = {}) {

--- a/plugin-assets/claude-code-plugin/hooks/scripts/lib/rules-resolver.js
+++ b/plugin-assets/claude-code-plugin/hooks/scripts/lib/rules-resolver.js
@@ -90,6 +90,12 @@ function validateGroupSelector(selector) {
   if (selector.phases && !Array.isArray(selector.phases)) {
     throw new Error(`invalid Rules group selector phases: ${selector.group}`);
   }
+  if (
+    selector.match !== undefined &&
+    !['all', 'paths', 'scope'].includes(selector.match)
+  ) {
+    throw new Error(`invalid Rules group selector match: ${selector.group}`);
+  }
   if (!hasPattern) return;
   try {
     new RegExp(selector.scopePattern, 'i');
@@ -163,10 +169,10 @@ function scopeText(options = {}) {
 
 function selectedRuleIds(manifest, options = {}) {
   const phase = options.phase || 'review';
-  const text = scopeText(options);
   const selectedGroups = new Set();
   for (const selector of manifest.groupSelectors) {
     if (selector.phases && !selector.phases.includes(phase)) continue;
+    const text = selectorScopeText(selector, options);
     if (
       selector.always === true ||
       new RegExp(selector.scopePattern, 'i').test(text)
@@ -181,6 +187,14 @@ function selectedRuleIds(manifest, options = {}) {
         rule.groups.some((group) => selectedGroups.has(group)),
     )
     .map((rule) => rule.id);
+}
+
+function selectorScopeText(selector, options) {
+  if (selector.match === 'paths') return (options.paths || []).join('\n');
+  if (selector.match === 'scope') {
+    return [options.command || '', options.scope || ''].join('\n');
+  }
+  return scopeText(options);
 }
 
 function createRulesSnapshot(options = {}) {

--- a/plugin-assets/claude-code-plugin/rules/manifest.json
+++ b/plugin-assets/claude-code-plugin/rules/manifest.json
@@ -7,22 +7,27 @@
     },
     {
       "group": "security",
+      "match": "scope",
       "scopePattern": "auth|permission|secret|credential|token|http|websocket|provider|adapter|process|boundary|security"
     },
     {
       "group": "loop",
+      "match": "paths",
       "scopePattern": "goldband-loop|workflow|eval|loop-engineering"
     },
     {
       "group": "delivery",
-      "scopePattern": "(^|/)(\\.github|ci|release|installer)(/|$)|(^|/)(install[^/]*|package\\.json|Dockerfile|Makefile)$|git|deploy"
+      "match": "paths",
+      "scopePattern": "(^|/)(\\.github|ci|release|installer|generated/workflow-contracts)(/|$)|(^|/)(install[^/]*|package\\.json|goldband\\.manifest\\.json|Dockerfile|Makefile)$"
     },
     {
       "group": "escalation",
-      "scopePattern": "escalat|approval|careful|freeze"
+      "match": "paths",
+      "scopePattern": "(^|/)(escalation|approval|safety-gates|freeze)([^/]*)(/|\\.|$)"
     },
     {
       "group": "handoff",
+      "match": "paths",
       "scopePattern": "session|handoff|checkpoint|context-(save|restore)"
     },
     {
@@ -42,6 +47,12 @@
       ],
       "groups": [
         "baseline"
+      ],
+      "reviewCriteria": [
+        "Keep each domain fact, decision, and capability under one authoritative owner and operation.",
+        "Contain provider and wire details inside adapters; shared contracts stay provider-neutral and runtime-validated.",
+        "Trace required surfaces through routing, registration, inventory, and dependency injection to the owning operation.",
+        "Use deterministic logic for hard invariants and fail explicitly when a core AI capability is unavailable."
       ]
     },
     {
@@ -52,6 +63,12 @@
       ],
       "groups": [
         "baseline"
+      ],
+      "reviewCriteria": [
+        "Fix the failure class at its owning layer rather than suppressing one symptom.",
+        "Prefer reuse, then deletion, then addition; new abstraction needs a real ownership boundary or stable domain concept.",
+        "Reject unrelated refactors, speculative flags, duplicated truth, and gate bypasses.",
+        "When the minimal and healthy fixes materially diverge, make that tradeoff explicit."
       ]
     },
     {
@@ -62,6 +79,11 @@
       ],
       "groups": [
         "baseline"
+      ],
+      "reviewCriteria": [
+        "Support repository claims with current files, commands, tests, or logs.",
+        "Match proof to the claimed boundary; static checks and mocks do not prove live provider or platform behavior.",
+        "A regression test counts only when it can fail for the incident or contract risk it claims to cover."
       ]
     },
     {
@@ -72,6 +94,11 @@
       ],
       "groups": [
         "baseline"
+      ],
+      "reviewCriteria": [
+        "Reject new escape hatches, skipped checks, focused tests, secret leaks, merge markers, and unexplained threshold bypasses.",
+        "Prefer readable names, explicit boundary errors, validated external input, and high-cohesion ownership.",
+        "Treat style as maintainability evidence, not a substitute for behavioral correctness."
       ]
     },
     {
@@ -82,6 +109,12 @@
       ],
       "groups": [
         "security"
+      ],
+      "reviewCriteria": [
+        "Treat localhost, child processes, SDK callbacks, tool output, and machine-generated content as untrusted boundaries.",
+        "Validate before privileged state or side effects; authenticate identity and authorize the requested action separately.",
+        "Preserve native permission authority, fail closed on missing or malformed values, and never expose secrets in output.",
+        "Use boundary-appropriate protections such as safe paths, argument arrays, parameterized queries, origin checks, and size limits."
       ]
     },
     {
@@ -92,6 +125,11 @@
       ],
       "groups": [
         "loop"
+      ],
+      "reviewCriteria": [
+        "A loop needs an evaluable target, signal, cap, and stop condition before it starts.",
+        "Each iteration stays on one hypothesis and records evidence.",
+        "Stop on success, cap, repeated blocker, or stalled signal; token and external-service cost need a stronger stopping rule."
       ]
     },
     {
@@ -102,6 +140,11 @@
       ],
       "groups": [
         "delivery"
+      ],
+      "reviewCriteria": [
+        "Review the full authorized change range and keep commits focused on one logical change.",
+        "Do not weaken gates, stage unrelated work, or perform commit, push, PR, merge, or release actions without authorization.",
+        "Verification must cover the changed failure mode and delivery summaries must match the actual diff."
       ]
     },
     {
@@ -112,6 +155,11 @@
       ],
       "groups": [
         "escalation"
+      ],
+      "reviewCriteria": [
+        "Proceed only on reversible, in-scope, verifiable work; outward-facing or materially ambiguous actions require user authority.",
+        "Stop after two unchanged failed attempts and never weaken a test, assertion, type, or lint rule to pass.",
+        "A successful-looking fix without a causal explanation is not verified."
       ]
     },
     {
@@ -122,6 +170,11 @@
       ],
       "groups": [
         "handoff"
+      ],
+      "reviewCriteria": [
+        "Persist durable decisions and partial-work evidence where the next session can verify them.",
+        "Do not duplicate facts already owned by code or git history, and do not persist memory without host policy and user authority.",
+        "Supersede conflicting records and verify recalled state before acting on it."
       ]
     },
     {
@@ -132,6 +185,13 @@
       ],
       "groups": [
         "semantic"
+      ],
+      "reviewCriteria": [
+        "Verify single authoritative truth, no dead code, and complete wiring to every required surface.",
+        "Reject symptom patches, duplicated authority, provider leakage, and unsafe permission bypasses.",
+        "Require live evidence for provider, authentication, permission, process, platform, and deployment claims.",
+        "Prefer deterministic ownership of known formats and safety invariants; isolate optional AI failure.",
+        "Report only findings with a reachable failure path and concrete evidence."
       ]
     }
   ]

--- a/rules/manifest.json
+++ b/rules/manifest.json
@@ -7,22 +7,27 @@
     },
     {
       "group": "security",
+      "match": "scope",
       "scopePattern": "auth|permission|secret|credential|token|http|websocket|provider|adapter|process|boundary|security"
     },
     {
       "group": "loop",
+      "match": "paths",
       "scopePattern": "goldband-loop|workflow|eval|loop-engineering"
     },
     {
       "group": "delivery",
-      "scopePattern": "(^|/)(\\.github|ci|release|installer)(/|$)|(^|/)(install[^/]*|package\\.json|Dockerfile|Makefile)$|git|deploy"
+      "match": "paths",
+      "scopePattern": "(^|/)(\\.github|ci|release|installer|generated/workflow-contracts)(/|$)|(^|/)(install[^/]*|package\\.json|goldband\\.manifest\\.json|Dockerfile|Makefile)$"
     },
     {
       "group": "escalation",
-      "scopePattern": "escalat|approval|careful|freeze"
+      "match": "paths",
+      "scopePattern": "(^|/)(escalation|approval|safety-gates|freeze)([^/]*)(/|\\.|$)"
     },
     {
       "group": "handoff",
+      "match": "paths",
       "scopePattern": "session|handoff|checkpoint|context-(save|restore)"
     },
     {
@@ -42,6 +47,12 @@
       ],
       "groups": [
         "baseline"
+      ],
+      "reviewCriteria": [
+        "Keep each domain fact, decision, and capability under one authoritative owner and operation.",
+        "Contain provider and wire details inside adapters; shared contracts stay provider-neutral and runtime-validated.",
+        "Trace required surfaces through routing, registration, inventory, and dependency injection to the owning operation.",
+        "Use deterministic logic for hard invariants and fail explicitly when a core AI capability is unavailable."
       ]
     },
     {
@@ -52,6 +63,12 @@
       ],
       "groups": [
         "baseline"
+      ],
+      "reviewCriteria": [
+        "Fix the failure class at its owning layer rather than suppressing one symptom.",
+        "Prefer reuse, then deletion, then addition; new abstraction needs a real ownership boundary or stable domain concept.",
+        "Reject unrelated refactors, speculative flags, duplicated truth, and gate bypasses.",
+        "When the minimal and healthy fixes materially diverge, make that tradeoff explicit."
       ]
     },
     {
@@ -62,6 +79,11 @@
       ],
       "groups": [
         "baseline"
+      ],
+      "reviewCriteria": [
+        "Support repository claims with current files, commands, tests, or logs.",
+        "Match proof to the claimed boundary; static checks and mocks do not prove live provider or platform behavior.",
+        "A regression test counts only when it can fail for the incident or contract risk it claims to cover."
       ]
     },
     {
@@ -72,6 +94,11 @@
       ],
       "groups": [
         "baseline"
+      ],
+      "reviewCriteria": [
+        "Reject new escape hatches, skipped checks, focused tests, secret leaks, merge markers, and unexplained threshold bypasses.",
+        "Prefer readable names, explicit boundary errors, validated external input, and high-cohesion ownership.",
+        "Treat style as maintainability evidence, not a substitute for behavioral correctness."
       ]
     },
     {
@@ -82,6 +109,12 @@
       ],
       "groups": [
         "security"
+      ],
+      "reviewCriteria": [
+        "Treat localhost, child processes, SDK callbacks, tool output, and machine-generated content as untrusted boundaries.",
+        "Validate before privileged state or side effects; authenticate identity and authorize the requested action separately.",
+        "Preserve native permission authority, fail closed on missing or malformed values, and never expose secrets in output.",
+        "Use boundary-appropriate protections such as safe paths, argument arrays, parameterized queries, origin checks, and size limits."
       ]
     },
     {
@@ -92,6 +125,11 @@
       ],
       "groups": [
         "loop"
+      ],
+      "reviewCriteria": [
+        "A loop needs an evaluable target, signal, cap, and stop condition before it starts.",
+        "Each iteration stays on one hypothesis and records evidence.",
+        "Stop on success, cap, repeated blocker, or stalled signal; token and external-service cost need a stronger stopping rule."
       ]
     },
     {
@@ -102,6 +140,11 @@
       ],
       "groups": [
         "delivery"
+      ],
+      "reviewCriteria": [
+        "Review the full authorized change range and keep commits focused on one logical change.",
+        "Do not weaken gates, stage unrelated work, or perform commit, push, PR, merge, or release actions without authorization.",
+        "Verification must cover the changed failure mode and delivery summaries must match the actual diff."
       ]
     },
     {
@@ -112,6 +155,11 @@
       ],
       "groups": [
         "escalation"
+      ],
+      "reviewCriteria": [
+        "Proceed only on reversible, in-scope, verifiable work; outward-facing or materially ambiguous actions require user authority.",
+        "Stop after two unchanged failed attempts and never weaken a test, assertion, type, or lint rule to pass.",
+        "A successful-looking fix without a causal explanation is not verified."
       ]
     },
     {
@@ -122,6 +170,11 @@
       ],
       "groups": [
         "handoff"
+      ],
+      "reviewCriteria": [
+        "Persist durable decisions and partial-work evidence where the next session can verify them.",
+        "Do not duplicate facts already owned by code or git history, and do not persist memory without host policy and user authority.",
+        "Supersede conflicting records and verify recalled state before acting on it."
       ]
     },
     {
@@ -132,6 +185,13 @@
       ],
       "groups": [
         "semantic"
+      ],
+      "reviewCriteria": [
+        "Verify single authoritative truth, no dead code, and complete wiring to every required surface.",
+        "Reject symptom patches, duplicated authority, provider leakage, and unsafe permission bypasses.",
+        "Require live evidence for provider, authentication, permission, process, platform, and deployment claims.",
+        "Prefer deterministic ownership of known formats and safety invariants; isolate optional AI failure.",
+        "Report only findings with a reachable failure path and concrete evidence."
       ]
     }
   ]

--- a/scripts/test-workflow-contracts.mjs
+++ b/scripts/test-workflow-contracts.mjs
@@ -156,15 +156,10 @@ assert.match(
   /\.workflow-launcher\.json and execute its exact argvPrefix plus review code --host codex/,
   'review/code must use the installed trusted Codex launcher prefix',
 );
-assert.match(
+assert.doesNotMatch(
   reviewCodeContract,
-  /review\/code always runs one core reviewer/,
-  'review/code must forbid specialist fan-out',
-);
-assert.match(
-  reviewCodeContract,
-  /runtime rejects independent agents/,
-  'review/code must enforce the specialist fan-out boundary in runtime',
+  /one core reviewer|specialist|active-review marker|atomic repository-scope lease|poll|second full semantic review/,
+  'review/code prompt contract must not duplicate runtime-owned execution policy',
 );
 
 const browserSessionContract = contracts.get(
@@ -188,33 +183,12 @@ assert.match(
 );
 assert.match(
   reviewCodeContract,
-  /GOLDBAND_RUNTIME_TASK=review\/code/,
-  'review/code must give runtime-owned child prompts a non-router task header',
-);
-assert.match(
-  reviewCodeContract,
-  /User prompt text never proves runtime ownership/,
-  'review/code must not trust a user-spoofable runtime marker',
-);
-assert.match(
-  reviewCodeContract,
-  /Never substitute a workspace path or request escalation/,
-  'review/code must not prompt or allow a workspace-controlled launcher to escape the sandbox',
-);
-assert.match(
-  reviewCodeContract,
   /Missing marker, runtime, or rule is an install failure/,
   'review/code must fail closed when the trusted launcher installation is incomplete',
 );
-assert.match(
-  reviewCodeContract,
-  /Do not silently fall back to an untyped manual review/,
-  'review/code launcher failures must fail closed',
-);
-assert.match(
-  reviewCodeContract,
-  /must never request command approval or retry with require_escalated/,
-  'review/code non-interactive reviewers must not enter an unsupported approval flow',
+assert.ok(
+  Buffer.byteLength(reviewCodeContract) <= 1024,
+  'review/code workflow prompt contract must stay within its runtime-routing budget',
 );
 const actionCount = manifest.capabilities.reduce(
   (count, capability) => count + capability.actions.length,
@@ -407,7 +381,11 @@ const review = contracts.get(
   'goldband-loop/generated/workflow-contracts/review/code.workflow.md',
 );
 assert.ok(review);
-assert.match(review, /review\/shared-rubric\.md/);
+assert.doesNotMatch(
+  review,
+  /review\/(?:shared-rubric|findings-schema|checklist)\.md/,
+  'review/code workflow prompt must leave runtime-owned assets to the runtime',
+);
 assert.match(review, /Review only/);
 
 const release = contracts.get(


### PR DESCRIPTION
## Summary
- enforce one active review owner per canonical repository and normalized scope
- block nested review launches before starting another runtime or host
- move execution and cost controls into the typed runtime while shrinking prompt-only policy
- add regression coverage for lease recovery, scope normalization, prompt budgets, and host usage telemetry

## Verification
- Validate Config (dev push): passed
- Goldband Loop Windows (dev push): passed
- Workflow Lint (dev push): passed