### PR TITLE
fix(review): scope external runner evidence contract (#35)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -165,6 +165,11 @@ Fixture, local, sandboxed-service, live-provider,
 device-platform, and production-readback evidence remain distinct in records
 and reports. The local runner can attest only local levels; live, device, and
 production levels require an authorized external runner.
+The external-runner admission boundary is owned by the path-scoped review
+evidence test provider, so its fail-closed enforcement applies when that
+contract changes without turning the absence of a future external runner into
+a global gap for unrelated local candidates. Providerless `manual` and
+`unsupported` dispositions remain explicit global requirements.
 
 Repair closure is a separate conditional invocation. It consumes the initial
 artifact only after a canonical HMAC receipt is read back from the installed

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2050,6 +2050,73 @@ Revisit triggers:
 - A demonstrated cross-machine review needs portable attestation, freshness,
   transport, and key-rotation contracts.
 
+## ADR: Scope external-runner enforcement through provider applicability
+
+Status: Accepted
+
+Decision:
+
+- Model `external-authorized-runner` as an automated boundary owned by the
+  existing path-scoped `review-evidence-tests` provider.
+- Keep providerless `manual` and `unsupported` dispositions global. Do not
+  change effective-cell selection or add caller-, prompt-, environment-, or
+  prose-driven applicability.
+- Keep external runner availability separate from admission enforcement. A
+  declared network, live-provider, device-platform, or production-readback
+  operation still requires current typed authorization and an
+  operation-specific external runner; the local runner remains deny-only.
+
+Why:
+
+The previous providerless `unsupported` cell represented both an implemented
+fail-closed boundary and a future external-runner roadmap item. Because
+providerless dispositions are intentionally global, unrelated local-only
+candidates received a permanent coverage gap even when they declared no
+external operation.
+
+Assumptions:
+
+- `review-evidence-tests` remains the authoritative deterministic owner of
+  local external-operation rejection.
+- Provider applicability continues to be derived only from the typed manifest
+  and candidate paths.
+- External runner implementation remains outside the current requirement.
+
+Consequences:
+
+- Unrelated local-only candidates no longer inherit an external-runner roadmap
+  gap and can obtain completion authority when all applicable evidence passes.
+- Changes to the evidence manifest, schema, runtime, or its tests still select
+  the enforcement cell and provider.
+- Existing artifacts bind a different behavior-contract digest and must be
+  revalidated rather than reused across this evolution.
+
+Alternatives considered:
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| Make every providerless disposition non-applicable | It would silently remove genuine global manual and unsupported requirements. |
+| Add operation-aware cell applicability to the schema | Existing provider applicability expresses the observed requirement without another state owner or selection mechanism. |
+| Mark the roadmap gap `not-applicable` | It would hide the boundary instead of assigning its implemented enforcement to an accountable provider. |
+| Use a prompt, environment marker, or caller declaration | Those inputs are outside the authoritative manifest/runtime contract and would create a bypass. |
+
+Failure signals:
+
+- A local-only dependency candidate emits an `external-authorized-runner`
+  record or coverage gap.
+- An authorized network or external-level operation executes in the local
+  runner, degrades to fixture/mock/local evidence, or obtains completion
+  authority without an external runner.
+- A providerless global manual or unsupported cell disappears from effective
+  completeness.
+
+Revisit triggers:
+
+- A real external runner is implemented and needs its own typed provider,
+  authorization, freshness, and readback contract.
+- Provider path applicability cannot represent an observed external-operation
+  requirement without over- or under-selecting candidates.
+
 ## ADR: Monotonic review contract resolution and local repository store
 
 Status: Accepted

--- a/goldband-loop/test/review-evidence.test.ts
+++ b/goldband-loop/test/review-evidence.test.ts
@@ -831,6 +831,50 @@ describe('review evidence contracts', () => {
     });
   });
 
+  test('providerless manual and unsupported dispositions remain globally effective', async () => {
+    const repo = gitFixture();
+    const value = manifest();
+    value.behaviorMatrix = [
+      {
+        ...value.behaviorMatrix[0]!,
+        id: 'global-manual',
+        risk: 'medium',
+        disposition: 'manual',
+        providerIds: [],
+        reason: 'Owner readback is required.',
+      },
+      {
+        ...value.behaviorMatrix[0]!,
+        id: 'global-unsupported',
+        disposition: 'unsupported',
+        providerIds: [],
+        reason: 'No approved device runner exists.',
+      },
+    ];
+    value.providers = [];
+    const validated = reviewEvidenceManifestSchema.validate(value);
+    const input = {
+      source: 'git diff',
+      diff: 'diff --git a/unrelated.ts b/unrelated.ts',
+      changedFiles: ['unrelated.ts'],
+    };
+    const evidence = await executeEvidencePlan(
+      context(repo),
+      input,
+      validated,
+      createCandidateBinding(repo, input, validated),
+    );
+
+    expect(evidence.records.map((record) => [record.id, record.status])).toEqual([
+      ['cell:global-manual:manual', 'coverage-gap'],
+      ['cell:global-unsupported:unsupported', 'coverage-gap'],
+    ]);
+    expect(evidence.completeness.coverageGapCellIds).toEqual([
+      'global-manual',
+      'global-unsupported',
+    ]);
+  });
+
   test('completeness rejects a record from a provider not authorized by the behavior cell', () => {
     const value = manifest();
     const forged = {
@@ -1399,6 +1443,69 @@ describe('review evidence contracts', () => {
       validated,
       createCandidateBinding(repo, input, validated),
     )).rejects.toThrow('requires an operation-specific external runner');
+  });
+
+  test('root external-runner enforcement does not apply to a local-only dependency candidate', async () => {
+    const repo = gitFixture();
+    const rootManifest = reviewEvidenceManifestSchema.validate(
+      JSON.parse(readFileSync(join(import.meta.dir, '../../goldband.review-evidence.json'), 'utf8')),
+    );
+    const input = {
+      source: 'git diff',
+      diff: [
+        'diff --git a/goldband-loop/bun.lock b/goldband-loop/bun.lock',
+        'diff --git a/goldband-loop/package.json b/goldband-loop/package.json',
+      ].join('\n'),
+      changedFiles: ['goldband-loop/bun.lock', 'goldband-loop/package.json'],
+    };
+    const evidence = await executeEvidencePlan(
+      context(repo),
+      input,
+      rootManifest,
+      createCandidateBinding(repo, input, rootManifest),
+      new Set(['external-authorized-runner']),
+    );
+
+    expect(evidence.records).toEqual([]);
+    expect(evidence.completeness).toEqual({
+      complete: true,
+      hostEligible: true,
+      blockingCellIds: [],
+      coverageGapCellIds: [],
+      runtimeIncompleteCellIds: [],
+    });
+  });
+
+  test('root external-runner enforcement remains fail closed when its provider applies', async () => {
+    const repo = gitFixture();
+    const rootManifest = reviewEvidenceManifestSchema.validate(
+      JSON.parse(readFileSync(join(import.meta.dir, '../../goldband.review-evidence.json'), 'utf8')),
+    );
+    const input = {
+      source: 'git diff',
+      diff: 'diff --git a/goldband-loop/workflows/review-evidence.ts b/goldband-loop/workflows/review-evidence.ts',
+      changedFiles: ['goldband-loop/workflows/review-evidence.ts'],
+    };
+    const evidence = await executeEvidencePlan(
+      context(repo),
+      input,
+      rootManifest,
+      createCandidateBinding(repo, input, rootManifest),
+      new Set(['external-authorized-runner']),
+    );
+
+    expect(evidence.records).toHaveLength(1);
+    expect(evidence.records[0]).toMatchObject({
+      id: 'review-evidence-tests:candidate-green',
+      cellIds: expect.arrayContaining(['external-authorized-runner']),
+      status: 'runtime-incomplete',
+      fresh: false,
+    });
+    expect(evidence.completeness).toMatchObject({
+      complete: false,
+      hostEligible: false,
+      runtimeIncompleteCellIds: ['external-authorized-runner'],
+    });
   });
 
   test('runtime integration evidence preserves its declared verification level', async () => {

--- a/goldband.review-evidence.json
+++ b/goldband.review-evidence.json
@@ -258,13 +258,13 @@
       "id": "external-authorized-runner",
       "behavior": "Networked live, device, and production evidence executes only through an operation-specific authorized external runner.",
       "kind": "boundary",
-      "input": "network-authorized runtime integration operation",
-      "preconditions": "an external runner implementation and current authorization exist",
-      "expected": "local execution fails closed until the external runner is implemented",
+      "input": "review evidence manifest or runtime enforcement change",
+      "preconditions": "the review-evidence provider applies to the candidate",
+      "expected": "deterministic tests prove that authorized network operations fail closed in the local runner",
       "risk": "medium",
-      "disposition": "unsupported",
-      "providerIds": [],
-      "reason": "Issue #22 implements fail-closed admission but does not yet provide an external authorized runner."
+      "disposition": "automated",
+      "providerIds": ["review-evidence-tests"],
+      "reason": "Issue #22 completed local fail-closed admission; external runner availability remains an operation-specific roadmap concern, not a global candidate gap."
     }
   ],
   "providers": [
@@ -291,7 +291,8 @@
         "sealed-runtime-projection",
         "redacted-untracked-candidate-binding",
         "sandbox-error-signature",
-        "closure-git-path-decoding"
+        "closure-git-path-decoding",
+        "external-authorized-runner"
       ],
       "applicability": {
         "kind": "paths",


### PR DESCRIPTION
## Summary

- model `external-authorized-runner` as provider-backed enforcement instead of a global roadmap gap
- preserve providerless global `manual` and `unsupported` dispositions
- add local-only, applicable-provider, external-runner rejection, and global-disposition regressions
- document the contract evolution in architecture and ADR records

## Verification

- Issue-specific review-evidence regressions: 6 pass, 0 fail
- TypeScript typecheck
- review contract freshness and generated surface checks
- JSON/TOML syntax and style gate
- installed launcher/receipt targeted tests: 7 pass, 0 fail
- plugin distribution and persisted-artifact revalidation checks

## Evidence boundary

The managed outer sandbox cannot provide a full supported-host suite pass: nested `sandbox-exec` operations return exit 71. Formal installed review run `d453530e-62f1-4671-a73e-c090f5289a72` therefore retained three deterministic blockers (nested Seatbelt, ignored `browse/dist` absent from the exact candidate snapshot, and a receipt timeout). A separate read-only reviewer found no diff-specific finding, but these blockers are not reported as successful verification.

Closes #35