### PR TITLE
feat(review): add manifest authoring and hardened evidence gates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,7 +18,8 @@
 codex/local/
 node_modules/
 **/node_modules/
-docs/
+docs/**
+!docs/review-evidence-manifest.md
 .DS_Store
 **/.DS_Store
 .goldband-sandbox-unmounted-probe

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Validate JSON files
         run: |
           echo "=== Validating JSON files ==="
@@ -66,6 +68,8 @@ jobs:
       - name: Verify decision guidance parity
         run: bash scripts/verify-decision-guidance.sh
       - name: Check Goldband Loop source quality
+        env:
+          GOLDBAND_COMPLEXITY_BASE_REF: ${{ github.event.before }}
         run: cd goldband-loop && bun run check:source
 
   config-runtime-integrations:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -132,6 +132,12 @@ preserve seed, iteration budget, and replay command. Unsupported high-risk
 cells, missing runners, malformed evidence, candidate drift, and provenance
 mismatch fail closed before model dispatch.
 
+Executable sealed evidence currently has one supported local adapter: macOS
+Seatbelt. Linux and Windows return typed `runtime-incomplete` records before
+operation materialization, semantic dispatch, or completion authority. Linux
+Bubblewrap belongs to the separate managed-worktree boundary and is not a
+`review/code` adapter.
+
 The repository-owned provider store is persistent-only. Exact base-to-candidate
 RED/GREEN transitions carry repository, base, candidate, scope, and operation
 contract digests in the one review artifact and fail validation on a successor

--- a/README.en.md
+++ b/README.en.md
@@ -24,6 +24,18 @@ This repo has two layers:
 For detailed ownership and runtime contracts, see
 [ARCHITECTURE.md](ARCHITECTURE.md).
 
+### `review/code` platform boundary
+
+| Platform | Goldband Loop installation | Executable sealed evidence | `review/code` result |
+| --- | --- | --- | --- |
+| macOS | Supported | Runs under Seatbelt | May start semantic review after evidence is complete |
+| Linux | Other workflow capabilities are supported | **Unsupported** | Emits typed `runtime-incomplete`, starts no semantic review, and grants no completion or closure authority |
+| Windows | Some capabilities install through Git Bash/WSL | **Unsupported** | Fails closed with the same incomplete result |
+
+Linux Bubblewrap currently owns only the managed-worktree boundary. It is not a
+sealed `review/code` evidence runner and does not imply review parity. Run a
+contract that requires executable evidence on a supported macOS Seatbelt host.
+
 `review/code` first resolves a non-downgradable evidence contract. A repository
 Review uses the canonical Git repository root as the shared coordinate for
 diffs, snapshots, scopes, and contracts. Starting in a tracked subdirectory

--- a/README.en.md
+++ b/README.en.md
@@ -26,6 +26,16 @@ For detailed ownership and runtime contracts, see
 
 ### `review/code` platform boundary
 
+When adding an evidence contract to another project, run
+`goldband review contract help` to locate the installed guide, public example,
+and JSON Schema. `review contract init` creates a non-overwriting, fail-closed
+scaffold at the canonical repository root. After declaring project-owned
+behaviors and providers, use `review contract validate --manifest <path>` to
+invoke the production runtime validator without executing evidence, changing
+the contract store, or claiming review/deployment completion. See the
+[manifest authoring guide](docs/review-evidence-manifest.md) for the complete
+field and safety contract.
+
 | Platform | Goldband Loop installation | Executable sealed evidence | `review/code` result |
 | --- | --- | --- | --- |
 | macOS | Supported | Runs under Seatbelt | May start semantic review after evidence is complete |

--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ git pull --ff-only
 目前支援的 capability/action 清單以
 [docs/generated/capabilities.md](docs/generated/capabilities.md) 為準。
 
+### `review/code` 平台邊界
+
+| 平台 | Goldband Loop 安裝 | executable sealed evidence | `review/code` 結果 |
+| --- | --- | --- | --- |
+| macOS | 支援 | 由 Seatbelt 執行 | evidence complete 後才可啟動 semantic review |
+| Linux | 支援其他 workflow 能力 | **不支援** | typed `runtime-incomplete`；不啟動 semantic review，也沒有 completion/closure authority |
+| Windows | Git Bash/WSL 可安裝部分能力 | **不支援** | 與 Linux 相同，fail closed |
+
+Linux 的 Bubblewrap 目前只負責 managed worktree boundary，**不是**
+`review/code` 的 sealed evidence runner，也不代表 review parity。若 effective
+contract 需要執行 executable evidence，請在受支援的 macOS Seatbelt host 執行。
+
 `review/code` 會先解析不可降級的 evidence contract。Repo 內的
 review 以 canonical Git repo root 作為 diff、snapshot、scope 與 contract 的
 共同座標；從 tracked subdirectory 啟動只會留下 execution offset，不會改變

--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ git pull --ff-only
 
 ### `review/code` 平台邊界
 
+第一次在其他專案建立 evidence contract 時，先執行
+`goldband review contract help` 找到 installed guide、public example 與 JSON
+Schema。`review contract init` 會在 canonical repo root 建立不覆寫既有檔案的
+fail-closed scaffold；完成 project-owned behavior/provider 後，以
+`review contract validate --manifest <path>` 呼叫正式 runtime validator。Validate
+不執行 evidence、不寫入 contract store，也不代表 review 或 deploy 已完成。完整欄位與
+安全邊界見 [manifest authoring guide](docs/review-evidence-manifest.md)。
+
 | 平台 | Goldband Loop 安裝 | executable sealed evidence | `review/code` 結果 |
 | --- | --- | --- | --- |
 | macOS | 支援 | 由 Seatbelt 執行 | evidence complete 後才可啟動 semantic review |

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1727,7 +1727,18 @@ Implementation contract:
   re-denies the baseline's exact syslog, Mach service, and shared-memory channels in
   addition to broad network, system-socket, and Mach lookup denial,
   so commands cannot use the local system log as an output side channel. The baseline
-  does not grant arbitrary HOME, workspace, or temporary-directory reads. The runtime
+  common Mach allow-clause set is parsed from the current `system.sb` and must
+  exactly match the reviewed contract. Global/local names, registration prefix,
+  XPC lookup prefix, and bootstrap operations receive matching explicit denies;
+  an added or removed Apple clause fails before execution. Live macOS probes prove
+  the syslog socket and one global-name Mach lookup remain blocked; prefix and
+  registration clauses currently have deterministic profile assertions, not live probes.
+  Executable sealed evidence has one supported adapter: macOS Seatbelt. Linux and
+  Windows stop before operation materialization with typed `runtime-incomplete`
+  evidence, no semantic conclusion, and no completion authority. Linux Bubblewrap
+  continues to isolate managed worktrees and is not treated as review-evidence parity.
+  The baseline does not grant arbitrary HOME, workspace, or temporary-directory
+  reads. The runtime
   compares pre/post snapshot digests, gives it
   unique HOME/TMP state that is removed after execution,
   bounds time and output, and persists fresh
@@ -2334,3 +2345,45 @@ Revisit triggers:
 - A real nested-project contract requires an explicit scope identity and
   repo-root monotonic composition rule.
 - Git is no longer the authoritative candidate/base transport for review.
+
+## ADR: Goldband Loop complexity debt is monotonic
+
+Status: Accepted
+
+Decision:
+
+- Enforce the shared source thresholds for Goldband Loop: at most 50 nonblank
+  lines per function, cognitive complexity 12, and four parameters.
+- Keep normal source lint focused on correctness. A dedicated Biome-backed gate
+  owns these quantitative rules and compares normalized per-file violation
+  vectors with a checked-in baseline.
+- Reject a worsened sorted magnitude vector for each file and rule. Require an
+  explicit baseline update when aggregate debt decreases, so line movement alone
+  cannot hide the vector change and the baseline can only shrink. Compare
+  candidate baseline values with the GitHub
+  push-before SHA, GitHub merge-base, GitLab diff base, or parent of the local
+  baseline-changing commit. CI fetches full history, and an unavailable required
+  predecessor is an error rather than an implicit pass.
+- Refactor the executable evidence runner first because it crossed all three
+  limits. Do not attempt an unrelated repository-wide rewrite in the same change.
+
+Why:
+
+Goldband Loop had no local quantitative gate and already contains substantial
+legacy debt. Enabling the thresholds as immediate zero-tolerance lint would make
+the source gate unusable; leaving them unenforced would allow the debt to grow.
+The normalized monotonic baseline makes current debt visible without weakening
+the shared thresholds or claiming the existing source already complies.
+
+The baseline intentionally has no function identity. A repair that removes a
+larger violation can therefore offset a different function becoming worse while
+the ranked vector still improves. Baseline reductions require diff review; this
+gate does not claim per-function regression identity.
+
+Revisit triggers:
+
+- The baseline reaches zero and the rules can move into ordinary source lint.
+- Biome changes diagnostic identities or metrics so normalized vectors no longer
+  represent the intended thresholds.
+- A stable AST-backed function identity is available and per-function monotonicity
+  is worth the additional migration and rename contract.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2387,3 +2387,55 @@ Revisit triggers:
   represent the intended thresholds.
 - A stable AST-backed function identity is available and per-function monotonicity
   is worth the additional migration and rename contract.
+
+## ADR: Review contract authoring uses one fail-closed runtime authority
+
+Status: Accepted
+
+Decision:
+
+- Keep `reviewEvidenceManifestSchema.validate()` as the final manifest authority.
+  JSON Schema remains a distributed structural/editor aid and explicitly does
+  not own graph, candidate, lineage, or runner semantics.
+- Expose `review contract validate --manifest <path>` as a side-effect-free
+  authoring check. It reads through the same stable regular-file and runtime
+  validator path as import, but does not resolve or mutate the runtime store,
+  execute providers, create lineage, or invoke a semantic host.
+- Expose `review contract init [--output <path>]` as an exclusive-create,
+  repo-bounded scaffold operation. The scaffold is valid schema v2 but contains
+  one high-risk unsupported cell, so it remains ineligible for semantic review
+  until a project owner replaces it with real behavior and evidence providers.
+- Distribute the canonical guide, one public local-gate example, and both JSON
+  Schemas with Claude and Codex authoring surfaces. Installed help reports their
+  exact paths.
+- Do not infer frameworks, commands, risk, applicability, evidence level, or
+  authorization. Do not add a preset catalog or another manifest validator.
+
+Why:
+
+`review/code` correctly fails closed without a resolvable contract, but an
+installed user in another repository previously had no supported path to learn,
+create, or dry-run validate the first manifest. Internal fixtures and repository
+manifests were not public examples, and the source-only JSON Schema could accept
+some inputs that the runtime rejected. A blocking scaffold plus the production
+validator closes the onboarding gap without fabricating project knowledge or
+weakening completion authority.
+
+Consequences:
+
+- A successful authoring validation proves only contract validity. Its output
+  states that no evidence ran and no completion authority exists.
+- `init` may create one new repository file but cannot overwrite, escape the
+  canonical Git repository, import state, or start review.
+- Safety-critical local conditions shared by JSON Schema and runtime are kept in
+  a representative conformance corpus. Runtime-only graph rules remain
+  explicitly documented rather than represented by a second incomplete
+  implementation.
+- Installed-distribution drift now includes the guide, example, and Schemas.
+
+Revisit triggers:
+
+- Multiple real projects demonstrate repeated, identical provider contracts
+  that justify a curated preset with a named owner and compatibility policy.
+- The manifest model moves to a declarative source capable of generating both
+  the runtime validator and JSON Schema without losing graph semantics.

--- a/docs/generated/capabilities.md
+++ b/docs/generated/capabilities.md
@@ -7,7 +7,7 @@ Public inventory: 20 actions. Experimental actions are excluded from routing and
 
 | Capability | Action | Outcome | Runtime owner | Runtime | Dispatch | Risk |
 | --- | --- | --- | --- | --- | --- | --- |
-| `review` | `code` | Evidence-first code review with authoritative lineage and scoped closure. | `review-runtime` | `typed` | `trusted-launcher` | `medium` |
+| `review` | `code` | Evidence-first code review. | `review-runtime` | `typed` | `trusted-launcher` | `medium` |
 | `review` | `security` | Review security and trust boundaries. | `prompt-contract-dispatch` | `compatibility` | `prompt-contract` | `medium` |
 | `investigate` | `code` | Investigate code or runtime behavior. | `prompt-contract-dispatch` | `compatibility` | `prompt-contract` | `medium` |
 | `qa` | `app` | Run product QA and record evidence. | `qa-runtime` | `typed` | `host-runtime` | `medium` |

--- a/docs/review-evidence-manifest.md
+++ b/docs/review-evidence-manifest.md
@@ -1,0 +1,297 @@
+# Review evidence manifest authoring
+
+`goldband.review-evidence.json` 是專案擁有的行為與驗證 contract。Goldband 在啟動 semantic review 前，會先用它決定哪些行為必須成立、哪些 deterministic checks 適用，以及目前 evidence 是否足以繼續。
+
+Manifest 合法不代表測試已通過、review 已完成或可以部署。真正的 evidence 仍必須由同一個 candidate-bound runtime 執行並讀回。
+
+## Quick start
+
+先查看目前安裝所附的 guide、example 與 schema 路徑：
+
+```bash
+goldband review contract help
+```
+
+在 Git repository 任意 tracked subdirectory 執行：
+
+```bash
+goldband review contract init
+```
+
+`init` 會在 canonical repository root 建立 `goldband.review-evidence.json`。它使用 exclusive create，既有檔案不會被覆寫。產生的內容只有一格 high-risk `unsupported` behavior，因此格式合法但仍會阻擋 semantic review；這可避免 scaffold 被誤認成完整證據。
+
+接著依專案真正的 contract 修改 behavior、provider、paths 與 command。可參考 [minimal local gate example](../examples/review-evidence/minimal-local-gate.json)，但必須把 TypeScript／npm 範例值換成該專案實際擁有的 check。
+
+修改後只驗證 manifest，不執行 provider、不啟動 host，也不寫入 runtime store：
+
+```bash
+goldband review contract validate --manifest goldband.review-evidence.json
+```
+
+`validate` exit 0 只表示 installed runtime 接受這份 contract。輸出中的 `evidenceExecuted: false` 與 `completionAuthorized: false` 是刻意的，不是待補的成功訊號。
+
+最後選擇 contract ownership：
+
+- 專案共同擁有：將 repo-root `goldband.review-evidence.json` 納入 Git。Reviewed base 中的檔案是 authoritative baseline。
+- 僅本機持有：repository 沒有 committed manifest 時，執行 `goldband review contract import --manifest <path>`，把完整 contract 註冊到 runtime-owned per-repository store。
+- 單次 candidate extension：以 `review code --evidence-manifest <path>` 傳入完整 manifest；它只能 monotonic 增加 baseline coverage，不能縮小或取代 baseline。
+
+用下列命令讀回實際 resolution、tracking state、source 與 digest：
+
+```bash
+goldband review contract inspect
+```
+
+## 最小 local gate
+
+受支援的 public example 宣告一格 TypeScript contract，並以 path-scoped `npm run typecheck` provider 覆蓋它：
+
+```json
+{
+  "schemaVersion": 2,
+  "behaviorMatrix": [
+    {
+      "id": "typescript-contracts",
+      "behavior": "The project preserves its declared TypeScript contracts.",
+      "kind": "boundary",
+      "input": "a candidate that changes TypeScript source, tests, or project configuration",
+      "preconditions": "dependencies are installed in the isolated candidate snapshot",
+      "expected": "the project typecheck exits successfully",
+      "risk": "high",
+      "disposition": "static",
+      "providerIds": ["typescript-typecheck"]
+    }
+  ],
+  "providers": [
+    {
+      "id": "typescript-typecheck",
+      "owner": "package.json#scripts.typecheck",
+      "kind": "project-gate",
+      "lifecycle": "persistent",
+      "cellIds": ["typescript-contracts"],
+      "applicability": {
+        "kind": "paths",
+        "pathPrefixes": ["src", "test", "package.json", "tsconfig.json"]
+      },
+      "executionContext": {
+        "sandboxOwner": "review-runtime",
+        "runner": "sealed"
+      },
+      "operations": [
+        {
+          "id": "candidate-typecheck",
+          "target": "candidate",
+          "argv": ["npm", "run", "typecheck"],
+          "expectedExit": "zero",
+          "timeoutMs": 120000,
+          "maxOutputBytes": 65536,
+          "network": "deny",
+          "evidenceLevel": "local"
+        }
+      ]
+    }
+  ],
+  "authorizations": []
+}
+```
+
+這只是 contract 形狀範例，不是 universal preset。只有當專案真的由 `package.json#scripts.typecheck` 擁有該行為，而且 command 可在 isolated snapshot 執行時，這些值才成立。
+
+## Top-level fields
+
+| Field | Contract |
+| --- | --- |
+| `schemaVersion` | 必須是 `2`。Runtime 不會替安全欄位猜預設值。 |
+| `behaviorMatrix` | 非空行為清單。每格描述一個必須被評估的 domain／engineering fact。 |
+| `providers` | Typed deterministic evidence owners。可以是空陣列，但 high-risk uncovered behavior 會 fail closed。 |
+| `authorizations` | 外部 network／credential／shared-environment operation 的 typed approvals。Local runner 本身仍是 network-deny。 |
+
+Unknown fields 會被拒絕。Manifest 目前不接受 instance-level `$schema` property；編輯器若需要 JSON Schema association，請把 `goldband.review-evidence.json` filename 對應到 installed 或 repository 內的 `review-evidence-manifest.schema.json`。
+
+## Behavior cells
+
+每個 cell 必須有：
+
+- `id`：manifest 內唯一且穩定的 ID。
+- `behavior`：要成立的行為事實。
+- `kind`：`normal`、`branch`、`exception` 或 `boundary`。
+- `input`、`preconditions`、`expected`：可被 reviewer 與 evidence owner理解的 contract。
+- `risk`：`low`、`medium` 或 `high`。
+- `disposition`：如何處理這格 evidence。
+- `providerIds`：能證明此 cell 的 provider IDs。
+
+Disposition：
+
+| Value | Meaning |
+| --- | --- |
+| `automated` | 由自動化 behavior／regression check 證明。 |
+| `static` | 由 typecheck、lint、schema、generated drift 等 static/project gate 證明。 |
+| `runtime-readback` | 需要 runtime integration readback。 |
+| `manual` | 目前只有人工證據；必須有 `reason`，仍是 coverage gap。 |
+| `not-applicable` | 對這個 contract 確定不適用；必須有可判定的 `reason`。不要用它跳過尚未設計的 checks。 |
+| `unsupported` | 目前無法提供 evidence；必須有 `reason`。High-risk 時阻擋 semantic host。 |
+
+`automated`、`static` 與 `runtime-readback` 至少需要一個 provider。Cell 的 `providerIds` 與 provider 的 `cellIds` 必須雙向一致；單邊宣告會被 runtime 拒絕。
+
+## Providers
+
+每個 provider 必須宣告：
+
+- `id`：manifest 全域唯一 provider ID。
+- `owner`：實際 contract owner，例如 `package.json#scripts.typecheck`。
+- `kind`：`regression`、`static`、`project-gate`、`property-fuzz` 或 `runtime-integration`。
+- `lifecycle`：`persistent` 或 `transition`。
+- `cellIds`：由此 provider 證明的 cells，且需與 cell 端 reciprocal。
+- `applicability`：哪些 candidate paths 使它適用。
+- `executionContext`：誰擁有 sandbox 與 runner。
+- `operations`：至少一個 typed argv operation。
+
+### Lifecycle
+
+Repository-owned manifest 只接受 `persistent` providers。Persistent operation 應對 successor candidate 保持有效，不能保存會過期的 base RED。
+
+一次性 bugfix RED／GREEN 使用 `transition` provider，並以 `transitionBinding` 綁定 exact repository、base、candidate、scope 與 operation contract digest。Transition evidence 屬於當次 artifact，不應手寫進 repository manifest。
+
+### Applicability
+
+Path scope：
+
+```json
+{ "kind": "paths", "pathPrefixes": ["src", "test", "package.json"] }
+```
+
+至少要有一個 non-empty prefix。Prefix 必須是 normalized repo-root coordinate：不以 `/`、drive prefix 開頭或 `/` 結尾，不含 `.`／`..`／empty segments，不用 `\\`，也不在前後留空白。寫 `src`，不要寫 `./src`、`../src`、`C:/src` 或 invocation subdirectory 的相對座標。
+
+Global scope：
+
+```json
+{ "kind": "global", "reason": "The repository-wide policy must hold for every candidate." }
+```
+
+Global provider 每次都適用，必須說明原因。不要為了省下 path design 把所有 gates 設成 global。
+
+### Execution context
+
+一般 local evidence 使用 runtime-owned sealed runner：
+
+```json
+{ "sandboxOwner": "review-runtime", "runner": "sealed" }
+```
+
+需要 provider-owned macOS Seatbelt lane 時：
+
+```json
+{
+  "sandboxOwner": "provider",
+  "runner": "host-seatbelt",
+  "lane": "the-owned-lane-id"
+}
+```
+
+如果正式 producer／consumer handoff 不存在，runtime 會回報 `runtime-incomplete`，不會把 nested sandbox failure 當成 candidate failure。
+
+## Operations
+
+Operation 的主要欄位：
+
+| Field | Contract |
+| --- | --- |
+| `id` | Provider 內唯一 operation ID；被 authorization 引用時，該 operation／authorization 配對在 manifest 內必須只解析到一組。 |
+| `target` | `candidate`，或 transition regression provider 的 `base`。 |
+| `argv` | 非空 argument array。第一項必須是由 `PATH` 解析的 command name，不能含 `/` 或 `\\`。 |
+| `expectedExit` | `zero` 或 `nonzero`。後者必須提供 exact `expectedExitCode`。 |
+| `timeoutMs` | `100` 至 `900000`。 |
+| `maxOutputBytes` | `1` 至 `65536`。 |
+| `network` | `deny` 或 `authorized`。 |
+| `authorizationId` | `network: authorized` 時必填；deny 時禁止。 |
+| `evidenceLevel` | `fixture`、`local`、`sandboxed-service`、`live-provider`、`device-platform` 或 `production-readback`。 |
+| `requiredSystemTools` | 可選的 PATH tool names；不會因此放寬任意 filesystem access。 |
+| `seed`、`iterations` | `property-fuzz` operations 必填，用於 replay。 |
+
+Script launcher 必須把 interpreter 寫進 argv，例如：
+
+```json
+{ "argv": ["bash", "scripts/check-contract.sh"] }
+```
+
+不要只寫 `scripts/check-contract.sh`。Runtime 會拒絕 path-shaped executable，避免 shebang／interpreter 與依賴邊界變成隱含 contract。
+
+## Network 與 authorizations
+
+`live-provider`、`device-platform` 與 `production-readback` evidence 必須使用 `network: authorized` 與 matching `authorizationId`。Authorization 包含：
+
+- `id`
+- `operation`
+- `scope`
+- `approvedBy`
+- `approvedAt`
+- `expiresAt`
+
+`expiresAt` 必須晚於 `approvedAt`。每個 `authorizationId` 必須找到同 ID、且 `operation` 相符的 authorization；每個 authorization 也必須被恰好一個 operation 引用。
+
+目前 local review runner 仍是 deny-only。即使 manifest 與 authorization 格式合法，network operation 也需要 operation-specific external runner；缺少 runner 時會 fail closed。不要把 fixture 或 local green 結果描述成 live／device／production proof。
+
+## Contract resolution
+
+Runtime 在 evidence execution、lineage admission 與 semantic dispatch 前先解析：
+
+```text
+authoritative baseline + optional monotonic extension = effective contract
+```
+
+Resolution order：
+
+1. Reviewed base 的 repo-root manifest。
+2. Base 沒有 manifest 時，明確 import 的 runtime-owned per-repository contract。
+3. 都沒有時 fail closed。
+
+Working-tree、index 與 `--evidence-manifest` 內容是 candidate-controlled extension。它們可以增加 required coverage，但不能刪除、反轉、降風險或降低 evidence level。
+
+## Platform boundary
+
+- macOS：sealed executable evidence 由 Seatbelt owner 執行；evidence complete 後才能啟動 semantic review。
+- Linux／Windows：目前沒有等價的 sealed evidence runner。需要 executable evidence 時回報 typed `runtime-incomplete`，不啟動 semantic host，也沒有 completion／closure authority。
+
+Bubblewrap managed worktree boundary 不是 `review/code` evidence parity。
+
+## Schema 與 runtime authority
+
+JSON Schema 協助 editor 與 local structural validation，能描述 enums、required fields、局部 conditional rules與 unknown-field rejection。
+
+以下規則需要 runtime graph／candidate context，因此 runtime validator 才是最終 authority：
+
+- provider／cell reciprocal ownership；
+- unknown provider／cell references；
+- operation ID 與 authorization cross-reference；
+- persistent RED 與 transition binding lifecycle；
+- authoritative baseline monotonicity；
+- exact repository／base／candidate／scope binding；
+- authorization freshness與 external runner availability。
+
+因此不要以「JSON Schema 通過」替代 `goldband review contract validate`，也不要以 `validate` 通過替代真正的 candidate-bound evidence run。
+
+## 常見錯誤
+
+### `review/code evidence contract is required`
+
+Repository 沒有 committed baseline，也沒有 runtime-store baseline。先執行 `review contract init` 並完成 project-owned contract，或 validate 後明確 import 外部 manifest。
+
+### `disposition ... requires a reason`
+
+`manual`、`not-applicable` 與 `unsupported` 必須說明原因。若其實已有自動化 owner，改成相符 disposition 並宣告 provider。
+
+### `must authorize each other`
+
+Cell 的 `providerIds` 與 provider 的 `cellIds` 不一致。兩邊都必須引用對方。
+
+### `persistent ... stale-prone`
+
+Persistent provider 含 base RED。把一次性 RED／GREEN 移到 exact-bound transition artifact，或改成 successor-safe candidate check。
+
+### `requires typed authorization`
+
+Network operation 缺少 matching authorization。補上格式不代表 local runner會連網；仍需正式 external runner。
+
+### `runtime-incomplete`
+
+Manifest 合法，但目前 platform、sandbox、tool、dependency 或 provider lane 無法完成 evidence。不要改成 `not-applicable` 或降低 risk 來消除訊號。

--- a/examples/review-evidence/minimal-local-gate.json
+++ b/examples/review-evidence/minimal-local-gate.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 2,
+  "behaviorMatrix": [
+    {
+      "id": "typescript-contracts",
+      "behavior": "The project preserves its declared TypeScript contracts.",
+      "kind": "boundary",
+      "input": "a candidate that changes TypeScript source, tests, or project configuration",
+      "preconditions": "dependencies are installed in the isolated candidate snapshot",
+      "expected": "the project typecheck exits successfully",
+      "risk": "high",
+      "disposition": "static",
+      "providerIds": ["typescript-typecheck"]
+    }
+  ],
+  "providers": [
+    {
+      "id": "typescript-typecheck",
+      "owner": "package.json#scripts.typecheck",
+      "kind": "project-gate",
+      "lifecycle": "persistent",
+      "cellIds": ["typescript-contracts"],
+      "applicability": {
+        "kind": "paths",
+        "pathPrefixes": ["src", "test", "package.json", "tsconfig.json"]
+      },
+      "executionContext": {
+        "sandboxOwner": "review-runtime",
+        "runner": "sealed"
+      },
+      "operations": [
+        {
+          "id": "candidate-typecheck",
+          "target": "candidate",
+          "argv": ["npm", "run", "typecheck"],
+          "expectedExit": "zero",
+          "timeoutMs": 120000,
+          "maxOutputBytes": 65536,
+          "network": "deny",
+          "evidenceLevel": "local"
+        }
+      ]
+    }
+  ],
+  "authorizations": []
+}

--- a/goldband-loop/ARCHITECTURE.md
+++ b/goldband-loop/ARCHITECTURE.md
@@ -18,6 +18,14 @@ provenance, tracking state, and baseline/candidate/explicit/effective digests.
 Import/remove are explicit CLI mutations with private regular-file checks and
 atomic writes; review never mutates the repository or store.
 
+`workflows/review-contract-cli.ts` owns the authoring surface. `validate` reads
+through the same stable manifest source and production validator as import but
+does not resolve or mutate store state. `init` exclusively creates a repo-bounded
+high-risk unsupported scaffold, so onboarding cannot fabricate host eligibility.
+The installed guide, public example, and JSON Schemas are discoverable assets;
+JSON Schema assists structural editing while runtime validation retains graph,
+candidate, lineage, and runner authority.
+
 The resolved code validates the behavior
 matrix and provider registry, materializes isolated base/candidate snapshots,
 executes bounded argument arrays under a default-deny read/write/network OS

--- a/goldband-loop/README.md
+++ b/goldband-loop/README.md
@@ -47,6 +47,12 @@ complete v2 validation. Every other v1 input is rejected with
 observed/supported versions, source, and remediation; safety fields are never
 inferred.
 
+For first-time project onboarding, run `goldband review contract help` to find
+the installed guide, public example, and JSON Schema. `review contract init`
+creates a non-overwriting, fail-closed repo-root scaffold, while
+`review contract validate --manifest <path>` invokes the production validator
+without running evidence, changing the store, or granting completion authority.
+
 The effective contract declares behavior cells and typed provider commands; the
 runtime executes each operation in its own read-only,
 default-deny read/write/network snapshot, verifies the pre/post tree digest, and requires reciprocal provider/cell

--- a/goldband-loop/bin/goldband.ts
+++ b/goldband-loop/bin/goldband.ts
@@ -112,6 +112,9 @@ function printUsage(stream: Pick<Console, "log">): void {
 		"  goldband review code --host <claude|codex> [--work-id <id> --ticket-id <id>] [--evidence-manifest <file>] [--closure-artifact <initial-review-artifact>] [--staged|--worktree|--base <ref>|--diff-file <file>] [--include-untracked] [--review-host-timeout-seconds <60-1800>] [--review-pass-timeout-seconds <60-1800>] [--review-claude-max-budget-usd <0.01-100.00>]",
 	);
 	stream.log(
+		"  goldband review contract help",
+		"  goldband review contract init [--output <path>]",
+		"  goldband review contract validate --manifest <path>",
 		"  goldband review contract inspect",
 		"  goldband review contract import --manifest <path>",
 		"  goldband review contract remove",
@@ -433,18 +436,23 @@ function reviewContract(args: string[]): number {
 			"review contract runtime unavailable: rerun the Goldband workflow installer",
 		);
 	}
-	const runtimeEnvironment = prepareReviewProcessEnvironment(process.env);
-	if (runtimeEnvironment.durability !== "durable") {
-		throw new Error(
-			"review contract store requires a writable durable Goldband state root",
-		);
+	const command = args[0];
+	const needsState = command === "inspect" || command === "import" || command === "remove";
+	const runtimeEnvironment = needsState
+		? prepareReviewProcessEnvironment(process.env)
+		: undefined;
+	if (runtimeEnvironment && runtimeEnvironment.durability !== "durable") {
+		throw new Error("review contract store requires a writable durable Goldband state root");
 	}
+	const runtimeArgs = runtimeEnvironment
+		? [...args, "--goldband-home", runtimeEnvironment.evidenceRoot]
+		: args;
 	const result = spawnSync(
 		process.execPath,
-		[runtimeFile, ...args, "--goldband-home", runtimeEnvironment.evidenceRoot],
+		[runtimeFile, ...runtimeArgs],
 		{
 			cwd: process.cwd(),
-			env: runtimeEnvironment.env,
+			env: runtimeEnvironment?.env ?? process.env,
 			stdio: "inherit",
 		},
 	);

--- a/goldband-loop/biome.json
+++ b/goldband-loop/biome.json
@@ -33,6 +33,27 @@
         "noUnusedImports": "error",
         "noUnusedVariables": "error"
       },
+      "complexity": {
+        "noExcessiveLinesPerFunction": {
+          "level": "off",
+          "options": {
+            "maxLines": 50,
+            "skipBlankLines": true
+          }
+        },
+        "noExcessiveCognitiveComplexity": {
+          "level": "off",
+          "options": {
+            "maxAllowedComplexity": 12
+          }
+        },
+        "useMaxParams": {
+          "level": "off",
+          "options": {
+            "max": 4
+          }
+        }
+      },
       "suspicious": {
         "noDebugger": "error"
       }

--- a/goldband-loop/bun.lock
+++ b/goldband-loop/bun.lock
@@ -18,6 +18,7 @@
         "@anthropic-ai/sdk": "^0.78.0",
         "@biomejs/biome": "^2.2.0",
         "@types/bun": "^1.3.14",
+        "ajv": "^8.18.0",
         "knip": "^6.26.0",
         "typescript": "^7.0.2",
         "xterm": "5",

--- a/goldband-loop/config/source-complexity-baseline.json
+++ b/goldband-loop/config/source-complexity-baseline.json
@@ -1,0 +1,906 @@
+{
+  "schemaVersion": 1,
+  "files": {
+    "bin/goldband-global-discover.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        49,
+        48,
+        24,
+        20,
+        17,
+        13
+      ]
+    },
+    "bin/goldband-work-verify.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        46
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        60
+      ]
+    },
+    "bin/goldband.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        68,
+        49,
+        30,
+        26,
+        25,
+        18,
+        15,
+        14,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        87,
+        61,
+        57,
+        51
+      ]
+    },
+    "browse/src/activity.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        18,
+        16
+      ]
+    },
+    "browse/src/browse-client.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        18,
+        17
+      ]
+    },
+    "browse/src/browser-manager.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        50,
+        25,
+        25,
+        19,
+        19,
+        18,
+        16,
+        15,
+        15,
+        14,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        151,
+        59,
+        59
+      ]
+    },
+    "browse/src/browser-skill-commands.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        23,
+        16
+      ]
+    },
+    "browse/src/browser-skill-write.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        14
+      ]
+    },
+    "browse/src/browser-skills.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        28,
+        24,
+        23
+      ]
+    },
+    "browse/src/bun-polyfill.cjs": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        14
+      ]
+    },
+    "browse/src/cdp-inspector.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        115,
+        25,
+        19
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        155,
+        65,
+        55
+      ]
+    },
+    "browse/src/cli.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        120,
+        42,
+        36,
+        34,
+        15,
+        14,
+        14,
+        13,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        187,
+        92,
+        51
+      ]
+    },
+    "browse/src/config.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        14
+      ]
+    },
+    "browse/src/content-security.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        73
+      ]
+    },
+    "browse/src/cookie-import-browser.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        43,
+        36,
+        26,
+        13,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        67
+      ]
+    },
+    "browse/src/cookie-picker-routes.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        70
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        138
+      ]
+    },
+    "browse/src/media-extract.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        43
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        74,
+        70
+      ]
+    },
+    "browse/src/meta-commands.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        255,
+        54,
+        25
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        539,
+        64
+      ],
+      "lint/complexity/useMaxParams": [
+        6
+      ]
+    },
+    "browse/src/network-capture.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        14
+      ]
+    },
+    "browse/src/proxy-config.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        23
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        51
+      ]
+    },
+    "browse/src/read-commands.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        136,
+        28,
+        19
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        316
+      ]
+    },
+    "browse/src/security-bunnative.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        24
+      ]
+    },
+    "browse/src/security-classifier.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        21
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        88
+      ]
+    },
+    "browse/src/security-sidecar-client.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        15
+      ]
+    },
+    "browse/src/security.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        32
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        65
+      ]
+    },
+    "browse/src/server.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        255,
+        99,
+        90,
+        24,
+        23,
+        16,
+        14
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        755,
+        661,
+        661,
+        192,
+        165
+      ]
+    },
+    "browse/src/snapshot.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        163,
+        60,
+        17,
+        17
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        288,
+        53
+      ]
+    },
+    "browse/src/socks-bridge.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        35,
+        22,
+        20,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        95,
+        63
+      ]
+    },
+    "browse/src/terminal-agent.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        71,
+        41,
+        27,
+        25,
+        16,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        179,
+        69
+      ]
+    },
+    "browse/src/url-validation.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        23,
+        15
+      ]
+    },
+    "browse/src/write-commands.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        255
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        818
+      ]
+    },
+    "browser-skills/hackernews-frontpage/_lib/browse-client.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        18,
+        17
+      ]
+    },
+    "cross-review/core.cjs": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        22,
+        20,
+        19,
+        18,
+        15,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        98
+      ],
+      "lint/complexity/useMaxParams": [
+        5
+      ]
+    },
+    "design/src/cli.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        42
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        140
+      ]
+    },
+    "design/src/daemon-client.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        27,
+        15
+      ]
+    },
+    "design/src/daemon.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        29,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        53
+      ]
+    },
+    "design/src/gallery.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        22
+      ]
+    },
+    "design/src/generate.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        18
+      ]
+    },
+    "design/src/serve.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        20,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        94
+      ]
+    },
+    "design/src/variants.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        34,
+        19
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        56
+      ],
+      "lint/complexity/useMaxParams": [
+        6,
+        5
+      ]
+    },
+    "extension/background.js": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        27
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        116
+      ]
+    },
+    "extension/content.js": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        47,
+        24
+      ]
+    },
+    "extension/inspector.js": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        60,
+        31,
+        24,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        279
+      ]
+    },
+    "extension/sidepanel-terminal.js": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        41,
+        36,
+        29,
+        26,
+        22,
+        19,
+        18,
+        16,
+        14,
+        13,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        500,
+        103,
+        71,
+        55
+      ]
+    },
+    "extension/sidepanel.js": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        16,
+        14,
+        13,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        54
+      ]
+    },
+    "ios-qa/daemon/src/cli-mint.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        18,
+        14
+      ]
+    },
+    "ios-qa/daemon/src/index.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        31,
+        24,
+        14
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        79,
+        60
+      ]
+    },
+    "ios-qa/daemon/src/tailscale-localapi.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        15,
+        14
+      ]
+    },
+    "ios-qa/daemon/src/tunnel-bootstrap.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        25
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        67
+      ]
+    },
+    "ios-qa/scripts/gen-accessors.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        34,
+        14
+      ]
+    },
+    "lib/knowledge.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        27,
+        22,
+        20
+      ]
+    },
+    "lib/managed-worktree-boundary.ts": {
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        66,
+        58
+      ]
+    },
+    "lib/managed-worktree-contract.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        129
+      ]
+    },
+    "lib/managed-worktree.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        20,
+        20,
+        16,
+        14,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        162,
+        126,
+        87,
+        71
+      ]
+    },
+    "lib/review-execution-lease.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        13
+      ]
+    },
+    "lib/verification-receipt.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        22,
+        20,
+        18,
+        15,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        80,
+        68,
+        62,
+        56
+      ],
+      "lint/complexity/useMaxParams": [
+        6
+      ]
+    },
+    "make-pdf/src/browseClient.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        15,
+        15
+      ]
+    },
+    "make-pdf/src/cli.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        18
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        54
+      ]
+    },
+    "make-pdf/src/orchestrator.ts": {
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        65
+      ]
+    },
+    "make-pdf/src/render.ts": {
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        63
+      ]
+    },
+    "make-pdf/src/setup.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        64
+      ]
+    },
+    "scripts/analytics.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        28
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        53
+      ]
+    },
+    "scripts/eval-watch.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        26
+      ]
+    },
+    "scripts/gen-llms-txt.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        17
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        81
+      ]
+    },
+    "scripts/install-codex-review-launcher.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        19
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        134
+      ]
+    },
+    "scripts/one-way-doors.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        13
+      ]
+    },
+    "scripts/output-throughput-comparison.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        31,
+        16,
+        16
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        78,
+        51
+      ]
+    },
+    "scripts/process-supervisor.mjs": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        18
+      ]
+    },
+    "scripts/task-emission-schema.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        13,
+        13
+      ]
+    },
+    "scripts/test-free-shards.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        22,
+        17
+      ]
+    },
+    "supabase/functions/community-pulse/index.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        39
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        141
+      ]
+    },
+    "supabase/functions/telemetry-ingest/index.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        35
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        65
+      ]
+    },
+    "workflows/host-adapter.ts": {
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        51
+      ]
+    },
+    "workflows/loop.ts": {
+      "lint/complexity/useMaxParams": [
+        6,
+        5
+      ]
+    },
+    "workflows/owned-runtime.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        22,
+        18
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        174,
+        79,
+        78,
+        71,
+        70,
+        67
+      ],
+      "lint/complexity/useMaxParams": [
+        6,
+        5
+      ]
+    },
+    "workflows/review-contract-cli.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        23,
+        19
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        63
+      ]
+    },
+    "workflows/review-contract-resolution.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        44,
+        43
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        127,
+        65
+      ]
+    },
+    "workflows/review-evidence.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        45,
+        38,
+        37,
+        37,
+        35,
+        32,
+        29,
+        27,
+        27,
+        23,
+        22,
+        20,
+        20,
+        18,
+        16,
+        16,
+        15,
+        15,
+        15,
+        14,
+        14
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        94,
+        89,
+        87,
+        78,
+        72,
+        63,
+        61,
+        57,
+        56,
+        52
+      ],
+      "lint/complexity/useMaxParams": [
+        7,
+        5
+      ]
+    },
+    "workflows/review-impact.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        30,
+        18,
+        17,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        74,
+        63
+      ]
+    },
+    "workflows/review-lineage.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        55,
+        31,
+        14,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        141
+      ],
+      "lint/complexity/useMaxParams": [
+        5
+      ]
+    },
+    "workflows/review.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        105,
+        26,
+        22,
+        17,
+        16,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        182,
+        112,
+        86,
+        71,
+        69,
+        62,
+        55
+      ],
+      "lint/complexity/useMaxParams": [
+        10,
+        7,
+        6,
+        6,
+        5,
+        5
+      ]
+    },
+    "workflows/run.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        48,
+        32
+      ]
+    },
+    "workflows/runtime.ts": {
+      "lint/complexity/useMaxParams": [
+        6,
+        5
+      ]
+    },
+    "workflows/safety-gates.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        17,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        73,
+        59,
+        56,
+        55
+      ]
+    },
+    "workflows/tracker-adapters/cli-adapter.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        20,
+        16
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        63
+      ]
+    },
+    "workflows/tracker-adapters/github.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        17,
+        16
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        80
+      ]
+    },
+    "workflows/tracker-adapters/gitlab.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        19,
+        16
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        92
+      ]
+    },
+    "workflows/tracker-adapters/import.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        42
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        136
+      ],
+      "lint/complexity/useMaxParams": [
+        8
+      ]
+    },
+    "workflows/tracker-adapters/projection.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        35,
+        21
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        81,
+        62,
+        54
+      ]
+    },
+    "workflows/tracker-config.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        16
+      ],
+      "lint/complexity/useMaxParams": [
+        5
+      ]
+    },
+    "workflows/tracker-runtime.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        21
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        78
+      ],
+      "lint/complexity/useMaxParams": [
+        5
+      ]
+    },
+    "workflows/work-map-cli.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        46,
+        38
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        64
+      ]
+    },
+    "workflows/work-map-store.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        30,
+        16,
+        15,
+        13
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        78
+      ],
+      "lint/complexity/useMaxParams": [
+        5
+      ]
+    },
+    "workflows/work-map.ts": {
+      "lint/complexity/noExcessiveCognitiveComplexity": [
+        40
+      ],
+      "lint/complexity/noExcessiveLinesPerFunction": [
+        83,
+        66,
+        56
+      ]
+    }
+  }
+}

--- a/goldband-loop/config/source-complexity-baseline.json
+++ b/goldband-loop/config/source-complexity-baseline.json
@@ -580,7 +580,7 @@
     },
     "scripts/install-codex-review-launcher.ts": {
       "lint/complexity/noExcessiveCognitiveComplexity": [
-        19
+        16
       ],
       "lint/complexity/noExcessiveLinesPerFunction": [
         134
@@ -666,8 +666,7 @@
     },
     "workflows/review-contract-cli.ts": {
       "lint/complexity/noExcessiveCognitiveComplexity": [
-        23,
-        19
+        23
       ],
       "lint/complexity/noExcessiveLinesPerFunction": [
         63
@@ -697,10 +696,10 @@
         23,
         22,
         20,
-        20,
         18,
         16,
         16,
+        15,
         15,
         15,
         15,
@@ -715,9 +714,9 @@
         72,
         63,
         61,
-        57,
         56,
-        52
+        52,
+        51
       ],
       "lint/complexity/useMaxParams": [
         7,

--- a/goldband-loop/generated/capability-actions.json
+++ b/goldband-loop/generated/capability-actions.json
@@ -58,7 +58,7 @@
       "capability": "review",
       "action": "code",
       "name": "review/code",
-      "description": "Evidence-first code review with authoritative lineage and scoped closure.",
+      "description": "Evidence-first code review.",
       "contractPath": "generated/workflow-contracts/review/code.workflow.md",
       "runtime": "typed",
       "dispatch": "trusted-launcher",

--- a/goldband-loop/generated/workflow-contracts/review/code.workflow.md
+++ b/goldband-loop/generated/workflow-contracts/review/code.workflow.md
@@ -3,13 +3,14 @@
 
 ## Goal
 
-Evidence-first code review with authoritative lineage and scoped closure.
+Evidence-first code review.
 
 ## Relevant context
 
 - Inspect the user-selected artifact, current repository instructions, and direct evidence.
 - Claude executes bin/goldband review code --host claude. On Codex, read ~/.codex/skills/goldband/.workflow-launcher.json and execute its exact argvPrefix plus review code --host codex.
-- Forward scope, evidence/closure files, or Work Map IDs; runtime owns acceptance lineage and defaults.
+- Forward scope or Work Map IDs; runtime owns lineage.
+- Missing/new contract: use goldband review contract help, init, validate.
 
 ## Hard boundaries
 

--- a/goldband-loop/goldband/llms.txt
+++ b/goldband-loop/goldband/llms.txt
@@ -23,7 +23,7 @@ Conventions:
 - `$goldband plan create`: Create a versioned Work Map for tracked work.
 - `$goldband plan sync`: Preview, inspect, or synchronize a Work Map tracker projection.
 - `$goldband qa app`: Run product QA and record evidence.
-- `$goldband review code`: Evidence-first code review with authoritative lineage and scoped closure.
+- `$goldband review code`: Evidence-first code review.
 - `$goldband review security`: Review security and trust boundaries.
 - `$goldband safety freeze`: Enable read-only freeze-mode for a Claude session.
 - `$goldband safety guard`: Enable careful-mode for a Claude session.

--- a/goldband-loop/inventory.json
+++ b/goldband-loop/inventory.json
@@ -15,7 +15,7 @@
       "actions": [
         {
           "id": "code",
-          "description": "Evidence-first code review with authoritative lineage and scoped closure.",
+          "description": "Evidence-first code review.",
           "runtime": "typed",
           "owner": "review-runtime",
           "dispatch": "trusted-launcher",

--- a/goldband-loop/package.json
+++ b/goldband-loop/package.json
@@ -13,9 +13,11 @@
   "scripts": {
     "build": "bash scripts/build.sh",
     "lint:source": "biome lint --config-path biome.json bin browse/src browser-skills cross-review design hosts ios-qa/daemon/src ios-qa/scripts/gen-accessors.ts lib make-pdf/src scripts supabase/functions workflows extension/background.js extension/content.js extension/inspector.js extension/popup.js extension/sidepanel-terminal.js extension/sidepanel.js",
+    "lint:complexity": "bun run scripts/check-source-complexity.ts",
+    "lint:complexity:update": "bun run scripts/check-source-complexity.ts --update",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint:exports": "knip --config knip.json --include files,exports,nsExports,types,nsTypes,enumMembers,namespaceMembers,duplicates",
-    "check:source": "bun run lint:source && bun run typecheck && bun run lint:exports",
+    "check:source": "bun run lint:source && bun run lint:complexity && bun run typecheck && bun run lint:exports",
     "vendor:xterm": "mkdir -p extension/lib && cp node_modules/xterm/lib/xterm.js extension/lib/xterm.js && cp node_modules/xterm/css/xterm.css extension/lib/xterm.css && cp node_modules/xterm-addon-fit/lib/xterm-addon-fit.js extension/lib/xterm-addon-fit.js",
     "dev:make-pdf": "bun run make-pdf/src/cli.ts",
     "dev:design": "bun run design/src/cli.ts",

--- a/goldband-loop/package.json
+++ b/goldband-loop/package.json
@@ -66,6 +66,7 @@
     "@anthropic-ai/sdk": "^0.78.0",
     "@biomejs/biome": "^2.2.0",
     "@types/bun": "^1.3.14",
+    "ajv": "^8.18.0",
     "knip": "^6.26.0",
     "typescript": "^7.0.2",
     "xterm": "5",

--- a/goldband-loop/scripts/check-source-complexity.ts
+++ b/goldband-loop/scripts/check-source-complexity.ts
@@ -1,0 +1,274 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+type Diagnostic = {
+	category?: string;
+	message?: string;
+	location?: { path?: string };
+};
+
+export type ComplexityBaseline = {
+	schemaVersion: 1;
+	files: Record<string, Record<string, number[]>>;
+};
+
+const ROOT = join(import.meta.dir, "..");
+const REPOSITORY_ROOT = join(ROOT, "..");
+const BASELINE_FILE = join(ROOT, "config", "source-complexity-baseline.json");
+const BASELINE_REPOSITORY_PATH =
+	"goldband-loop/config/source-complexity-baseline.json";
+const RULES = [
+	"complexity/noExcessiveLinesPerFunction",
+	"complexity/noExcessiveCognitiveComplexity",
+	"complexity/useMaxParams",
+];
+
+export function summarizeDiagnostics(
+	diagnostics: Diagnostic[],
+): ComplexityBaseline {
+	const files: ComplexityBaseline["files"] = {};
+	for (const diagnostic of diagnostics) {
+		const path = diagnostic.location?.path;
+		const category = diagnostic.category;
+		const value = Number(diagnostic.message?.match(/\d+/)?.[0]);
+		if (
+			!path ||
+			!category ||
+			!RULES.some((rule) => category.endsWith(rule)) ||
+			!Number.isFinite(value)
+		)
+			continue;
+		const metrics = files[path] ?? {};
+		const values = metrics[category] ?? [];
+		values.push(value);
+		metrics[category] = values;
+		files[path] = metrics;
+	}
+	return normalizeBaseline({ schemaVersion: 1, files });
+}
+
+export function worsenedMetrics(
+	expected: ComplexityBaseline,
+	actual: ComplexityBaseline,
+): string[] {
+	const failures: string[] = [];
+	for (const [path, rules] of Object.entries(actual.files)) {
+		for (const [category, values] of Object.entries(rules)) {
+			const allowed = expected.files[path]?.[category] ?? [];
+			if (ruleDebtIncreased(values, allowed)) {
+				failures.push(
+					`${path} ${category}: ${values.join(",")} > ${allowed.join(",") || "none"}`,
+				);
+			}
+		}
+	}
+	return failures;
+}
+
+export function baselineTransitionFailures(
+	predecessor: ComplexityBaseline,
+	candidate: ComplexityBaseline,
+	actual: ComplexityBaseline,
+): string[] {
+	return [
+		...worsenedMetrics(predecessor, candidate).map(
+			(failure) => `candidate baseline exceeds predecessor: ${failure}`,
+		),
+		...worsenedMetrics(candidate, actual).map(
+			(failure) => `source exceeds candidate baseline: ${failure}`,
+		),
+	];
+}
+
+function ruleDebtIncreased(actual: number[], allowed: number[]): boolean {
+	return actual.some((value, index) => value > (allowed[index] ?? 0));
+}
+
+function runBiome(): ComplexityBaseline {
+	const executable = join(
+		ROOT,
+		"node_modules",
+		".bin",
+		process.platform === "win32" ? "biome.cmd" : "biome",
+	);
+	const args = [
+		"lint",
+		"--config-path",
+		"biome.json",
+		"--max-diagnostics=none",
+		"--reporter=json",
+		...RULES.flatMap((rule) => [`--only=${rule}`]),
+		".",
+	];
+	const result = spawnSync(executable, args, {
+		cwd: ROOT,
+		encoding: "utf8",
+		maxBuffer: 16 * 1024 * 1024,
+	});
+	if (result.status !== 0) {
+		throw new Error(
+			`Biome complexity scan failed:\n${result.stderr || result.stdout}`,
+		);
+	}
+	const report = JSON.parse(result.stdout) as { diagnostics?: Diagnostic[] };
+	return summarizeDiagnostics(report.diagnostics ?? []);
+}
+
+function readBaseline(): ComplexityBaseline {
+	return parseBaseline(readFileSync(BASELINE_FILE, "utf8"));
+}
+
+function parseBaseline(source: string): ComplexityBaseline {
+	const parsed = JSON.parse(source) as ComplexityBaseline;
+	if (
+		parsed.schemaVersion !== 1 ||
+		!parsed.files ||
+		Array.isArray(parsed.files)
+	) {
+		throw new Error("source complexity baseline has an unsupported schema");
+	}
+	return normalizeBaseline(parsed);
+}
+
+function predecessorBaseline(candidate: ComplexityBaseline): ComplexityBaseline | undefined {
+	const predecessor = predecessorRef(candidate);
+	if (!predecessor) return undefined;
+	if (!gitCommitExists(predecessor.ref)) {
+		if (predecessor.required) {
+			throw new Error(`required complexity predecessor is unavailable: ${predecessor.ref}`);
+		}
+		return undefined;
+	}
+	const result = spawnSync(
+		"git",
+		["show", `${predecessor.ref}:${BASELINE_REPOSITORY_PATH}`],
+		{ cwd: REPOSITORY_ROOT, encoding: "utf8" },
+	);
+	if (result.status === 0) return parseBaseline(result.stdout);
+	if (result.status === 128 && /does not exist|not in/.test(result.stderr)) {
+		return undefined;
+	}
+	throw new Error(`cannot read predecessor complexity baseline at ${predecessor.ref}: ${result.stderr}`);
+}
+
+function predecessorRef(
+	candidate: ComplexityBaseline,
+): { ref: string; required: boolean } | undefined {
+	const pushBase = process.env.GOLDBAND_COMPLEXITY_BASE_REF;
+	if (pushBase && !/^0+$/.test(pushBase)) return { ref: pushBase, required: true };
+	const mergeRequestBase = process.env.CI_MERGE_REQUEST_DIFF_BASE_SHA;
+	if (mergeRequestBase) return { ref: mergeRequestBase, required: true };
+	const githubBase = process.env.GITHUB_BASE_REF;
+	if (githubBase) return { ref: githubMergeBase(githubBase), required: true };
+	const head = baselineAtRef("HEAD");
+	return localPredecessorAuthority(candidate, head, baselineLastChange());
+}
+
+function gitCommitExists(ref: string): boolean {
+	return spawnSync("git", ["cat-file", "-e", `${ref}^{commit}`], {
+		cwd: REPOSITORY_ROOT,
+		stdio: "ignore",
+	}).status === 0;
+}
+
+export function localPredecessorAuthority(
+	candidate: ComplexityBaseline,
+	head: ComplexityBaseline | undefined,
+	lastBaselineChange: string | undefined,
+): { ref: string; required: boolean } {
+	if (!head) return { ref: "HEAD", required: false };
+	if (JSON.stringify(head) !== JSON.stringify(candidate)) {
+		return { ref: "HEAD", required: true };
+	}
+	return {
+		ref: lastBaselineChange ? `${lastBaselineChange}^` : "HEAD^",
+		required: true,
+	};
+}
+
+function baselineLastChange(): string | undefined {
+	const result = spawnSync(
+		"git",
+		["log", "-n", "1", "--format=%H", "--", BASELINE_REPOSITORY_PATH],
+		{ cwd: REPOSITORY_ROOT, encoding: "utf8" },
+	);
+	if (result.status !== 0) throw new Error(`cannot resolve baseline history: ${result.stderr}`);
+	return result.stdout.trim() || undefined;
+}
+
+function githubMergeBase(base: string): string {
+	for (const reference of [`origin/${base}`, `refs/remotes/origin/${base}`, base]) {
+		const result = spawnSync("git", ["merge-base", "HEAD", reference], {
+			cwd: REPOSITORY_ROOT,
+			encoding: "utf8",
+		});
+		if (result.status === 0 && result.stdout.trim()) return result.stdout.trim();
+	}
+	throw new Error(`cannot resolve GitHub merge-base for ${base}; fetch authoritative history before source checks`);
+}
+
+function baselineAtRef(ref: string): ComplexityBaseline | undefined {
+	const result = spawnSync(
+		"git",
+		["show", `${ref}:${BASELINE_REPOSITORY_PATH}`],
+		{ cwd: REPOSITORY_ROOT, encoding: "utf8" },
+	);
+	return result.status === 0 ? parseBaseline(result.stdout) : undefined;
+}
+
+function normalizeBaseline(value: ComplexityBaseline): ComplexityBaseline {
+	const files: ComplexityBaseline["files"] = {};
+	for (const path of Object.keys(value.files).sort()) {
+		const rules: Record<string, number[]> = {};
+		for (const category of Object.keys(value.files[path] ?? {}).sort()) {
+			rules[category] = [...value.files[path]![category]!].sort(
+				(left, right) => right - left,
+			);
+		}
+		files[path] = rules;
+	}
+	return { schemaVersion: 1, files };
+}
+
+function writeBaseline(value: ComplexityBaseline): void {
+	const temporary = `${BASELINE_FILE}.tmp.${process.pid}`;
+	writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+		flag: "wx",
+	});
+	renameSync(temporary, BASELINE_FILE);
+}
+
+function main(): void {
+	const update = process.argv.slice(2).includes("--update");
+	const actual = runBiome();
+	const expected = readBaseline();
+	const predecessor = predecessorBaseline(expected);
+	const transitionFailures = predecessor
+		? baselineTransitionFailures(predecessor, expected, actual)
+		: worsenedMetrics(expected, actual);
+	if (transitionFailures.length > 0) {
+		throw new Error(
+			`source complexity debt increased:\n${transitionFailures.join("\n")}`,
+		);
+	}
+	if (update) {
+		writeBaseline(actual);
+		console.log(
+			`updated source complexity baseline (${Object.keys(actual.files).length} files)`,
+		);
+		return;
+	}
+	if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+		throw new Error(
+			"source complexity debt decreased; run bun run lint:complexity:update and review the baseline reduction",
+		);
+	}
+	console.log(
+		`ok - source complexity baseline is monotonic (${Object.keys(actual.files).length} files)`,
+	);
+}
+
+if (import.meta.main) main();

--- a/goldband-loop/scripts/install-codex-review-launcher.ts
+++ b/goldband-loop/scripts/install-codex-review-launcher.ts
@@ -28,6 +28,13 @@ const REVIEW_ASSETS = [
 	"TODOS-format.md",
 ] as const;
 
+const REVIEW_AUTHORING_ASSETS = [
+	{ source: "../docs/review-evidence-manifest.md", target: "review/review-evidence-manifest.md" },
+	{ source: "../examples/review-evidence/minimal-local-gate.json", target: "review/examples/minimal-local-gate.json" },
+	{ source: "../schemas/review-evidence-manifest.schema.json", target: "review/schemas/review-evidence-manifest.schema.json" },
+	{ source: "../schemas/review-behavior-matrix.schema.json", target: "review/schemas/review-behavior-matrix.schema.json" },
+] as const;
+
 export interface CodexReviewLauncherInstallOptions {
 	sourceRoot: string;
 	runtimeRoot: string;
@@ -176,6 +183,21 @@ function bundleBrowserServer(
 	}
 }
 
+function assertRequiredSources(paths: string[]): void {
+	for (const path of paths) {
+		if (!existsSync(path)) throw new Error(`required source missing: ${path}`);
+	}
+}
+
+function copyReviewAuthoringAssets(sourceRoot: string, stageRoot: string): void {
+	for (const asset of REVIEW_AUTHORING_ASSETS) {
+		const source = join(sourceRoot, asset.source);
+		const target = join(stageRoot, asset.target);
+		mkdirSync(dirname(target), { recursive: true });
+		copyFileSync(source, target);
+	}
+}
+
 export function installCodexReviewLauncher(
 	options: CodexReviewLauncherInstallOptions,
 ): CodexReviewLauncherMarker {
@@ -214,7 +236,6 @@ export function installCodexReviewLauncher(
 
 	const launcherEntry = join(sourceRoot, "bin", "goldband.ts");
 	const runtimeEntry = join(sourceRoot, "workflows", "run.ts");
-	const reviewContractEntry = join(sourceRoot, "workflows", "review-contract-cli.ts");
 	const browserServerEntry = join(sourceRoot, "browse", "src", "server.ts");
 	const rulesResolverSource = join(
 		sourceRoot,
@@ -225,16 +246,15 @@ export function installCodexReviewLauncher(
 		"rules-resolver.js",
 	);
 	const rulesSource = join(sourceRoot, "..", "rules");
-	for (const required of [
+	assertRequiredSources([
 		launcherEntry,
 		runtimeEntry,
-		reviewContractEntry,
+		join(sourceRoot, "workflows", "review-contract-cli.ts"),
 		browserServerEntry,
 		rulesResolverSource,
 		join(rulesSource, "manifest.json"),
-	]) {
-		if (!existsSync(required)) throw new Error(`required source missing: ${required}`);
-	}
+		...REVIEW_AUTHORING_ASSETS.map((asset) => join(sourceRoot, asset.source)),
+	]);
 
 	const stageRoot = `${runtimeRoot}.tmp-${process.pid}`;
 	const backupRoot = `${runtimeRoot}.backup`;
@@ -247,7 +267,7 @@ export function installCodexReviewLauncher(
 		bundle(bunPath, runtimeEntry, join(stageRoot, "workflows", "run.ts"));
 		bundle(
 			bunPath,
-			reviewContractEntry,
+			join(sourceRoot, "workflows", "review-contract-cli.ts"),
 			join(stageRoot, "workflows", "review-contract-cli.ts"),
 		);
 		const stagedBrowserExecutable = join(stageRoot, "browse", "browse");
@@ -266,6 +286,7 @@ export function installCodexReviewLauncher(
 			if (!existsSync(source)) throw new Error(`review asset missing: ${source}`);
 			copyFileSync(source, join(stageRoot, "review", asset));
 		}
+		copyReviewAuthoringAssets(sourceRoot, stageRoot);
 		const stagedRulesResolver = join(
 			stageRoot,
 			"review",

--- a/goldband-loop/scripts/test-workflows.ts
+++ b/goldband-loop/scripts/test-workflows.ts
@@ -17,6 +17,7 @@ export const MACOS_REVIEW_HOST_TEST_NAMES = [
   'review evidence contracts > sealed runtime projection cannot read source images or mutate projected images',
   'review evidence contracts > sealed runtime projection identity is stable across separate evidence plans',
   'review evidence contracts > evidence sandbox denies the system log socket inherited from the macOS process baseline',
+  'review evidence contracts > evidence sandbox denies Mach service lookup inherited from the macOS process baseline',
   'review evidence contracts > applicability selects only scoped providers and excludes unrelated cells from completeness',
   'review evidence contracts > regression and property providers preserve RED/GREEN and replay metadata',
   'review evidence contracts > each operation receives an independent read-only snapshot',

--- a/goldband-loop/scripts/test-workflows.ts
+++ b/goldband-loop/scripts/test-workflows.ts
@@ -52,6 +52,7 @@ export const WORKFLOW_TESTS = [
   'test/workflows-runtime.test.ts',
   'test/review-evidence.test.ts',
   'test/review-evidence-platform.test.ts',
+  'test/review-contract-authoring.test.ts',
   'test/review-lineage.test.ts',
   'test/work-map.test.ts',
   'test/work-map-store.test.ts',
@@ -69,6 +70,7 @@ export const WORKFLOW_TESTS = [
   'test/tracker-import.test.ts',
   'test/review-impact.test.ts',
   'test/goldband-review-cli.test.ts',
+  'test/codex-review-contract-authoring-install.test.ts',
   'test/codex-review-launcher-install.test.ts',
   'test/codex-workflow-status.test.ts',
 ] as const;

--- a/goldband-loop/setup
+++ b/goldband-loop/setup
@@ -862,6 +862,44 @@ create_internal_workflow_docs() {
   fi
 }
 
+install_review_authoring_assets() {
+  local goldband_dir="$1"
+  local runtime_root="$2"
+  local repo_root
+  repo_root="$(cd "$goldband_dir/.." && pwd -P)"
+
+  [ -f "$repo_root/docs/review-evidence-manifest.md" ] || {
+    echo "goldband setup failed: missing review manifest authoring guide" >&2
+    exit 1
+  }
+  [ -f "$repo_root/examples/review-evidence/minimal-local-gate.json" ] || {
+    echo "goldband setup failed: missing review manifest example" >&2
+    exit 1
+  }
+  [ -f "$repo_root/schemas/review-evidence-manifest.schema.json" ] || {
+    echo "goldband setup failed: missing review manifest schema" >&2
+    exit 1
+  }
+  [ -f "$repo_root/schemas/review-behavior-matrix.schema.json" ] || {
+    echo "goldband setup failed: missing review behavior schema" >&2
+    exit 1
+  }
+
+  mkdir -p "$runtime_root/review/examples" "$runtime_root/review/schemas"
+  _link_or_copy \
+    "$repo_root/docs/review-evidence-manifest.md" \
+    "$runtime_root/review/review-evidence-manifest.md"
+  _link_or_copy \
+    "$repo_root/examples/review-evidence/minimal-local-gate.json" \
+    "$runtime_root/review/examples/minimal-local-gate.json"
+  _link_or_copy \
+    "$repo_root/schemas/review-evidence-manifest.schema.json" \
+    "$runtime_root/review/schemas/review-evidence-manifest.schema.json"
+  _link_or_copy \
+    "$repo_root/schemas/review-behavior-matrix.schema.json" \
+    "$runtime_root/review/schemas/review-behavior-matrix.schema.json"
+}
+
 # ─── Helper: create a minimal ~/.codex/skills/goldband runtime root ───────────
 # Codex scans ~/.codex/skills recursively. Exposing the whole repo here causes
 # duplicate skills when old per-workflow entries remain discoverable. Keep this
@@ -907,6 +945,7 @@ create_codex_runtime_root() {
       _link_or_copy "$goldband_dir/review/$f" "$codex_goldband/review/$f"
     fi
   done
+  install_review_authoring_assets "$goldband_dir" "$codex_goldband"
   # ETHOS.md — referenced by "Search Before Building" in all skill preambles
   if [ -f "$goldband_dir/ETHOS.md" ]; then
     _link_or_copy "$goldband_dir/ETHOS.md" "$codex_goldband/ETHOS.md"
@@ -1001,6 +1040,7 @@ create_claude_runtime_root() {
       _link_or_copy "$goldband_dir/review/$f" "$claude_goldband/review/$f"
     fi
   done
+  install_review_authoring_assets "$goldband_dir" "$claude_goldband"
   if [ -f "$goldband_dir/ETHOS.md" ]; then
     _link_or_copy "$goldband_dir/ETHOS.md" "$claude_goldband/ETHOS.md"
   fi

--- a/goldband-loop/setup
+++ b/goldband-loop/setup
@@ -865,38 +865,47 @@ create_internal_workflow_docs() {
 install_review_authoring_assets() {
   local goldband_dir="$1"
   local runtime_root="$2"
-  local repo_root
+  local repo_root guide_source example_source manifest_schema_source behavior_schema_source
   repo_root="$(cd "$goldband_dir/.." && pwd -P)"
 
-  [ -f "$repo_root/docs/review-evidence-manifest.md" ] || {
+  guide_source="$repo_root/docs/review-evidence-manifest.md"
+  example_source="$repo_root/examples/review-evidence/minimal-local-gate.json"
+  manifest_schema_source="$repo_root/schemas/review-evidence-manifest.schema.json"
+  behavior_schema_source="$repo_root/schemas/review-behavior-matrix.schema.json"
+  [ -f "$guide_source" ] || guide_source="$goldband_dir/review/review-evidence-manifest.md"
+  [ -f "$example_source" ] || example_source="$goldband_dir/review/examples/minimal-local-gate.json"
+  [ -f "$manifest_schema_source" ] || manifest_schema_source="$goldband_dir/review/schemas/review-evidence-manifest.schema.json"
+  [ -f "$behavior_schema_source" ] || behavior_schema_source="$goldband_dir/review/schemas/review-behavior-matrix.schema.json"
+
+  [ -f "$guide_source" ] || {
     echo "goldband setup failed: missing review manifest authoring guide" >&2
     exit 1
   }
-  [ -f "$repo_root/examples/review-evidence/minimal-local-gate.json" ] || {
+  [ -f "$example_source" ] || {
     echo "goldband setup failed: missing review manifest example" >&2
     exit 1
   }
-  [ -f "$repo_root/schemas/review-evidence-manifest.schema.json" ] || {
+  [ -f "$manifest_schema_source" ] || {
     echo "goldband setup failed: missing review manifest schema" >&2
     exit 1
   }
-  [ -f "$repo_root/schemas/review-behavior-matrix.schema.json" ] || {
+  [ -f "$behavior_schema_source" ] || {
     echo "goldband setup failed: missing review behavior schema" >&2
     exit 1
   }
 
   mkdir -p "$runtime_root/review/examples" "$runtime_root/review/schemas"
   _link_or_copy \
-    "$repo_root/docs/review-evidence-manifest.md" \
+    "$guide_source" \
     "$runtime_root/review/review-evidence-manifest.md"
   _link_or_copy \
-    "$repo_root/examples/review-evidence/minimal-local-gate.json" \
+    "$example_source" \
     "$runtime_root/review/examples/minimal-local-gate.json"
   _link_or_copy \
-    "$repo_root/schemas/review-evidence-manifest.schema.json" \
+    "$manifest_schema_source" \
     "$runtime_root/review/schemas/review-evidence-manifest.schema.json"
   _link_or_copy \
-    "$repo_root/schemas/review-behavior-matrix.schema.json" \
+    "$behavior_schema_source" \
     "$runtime_root/review/schemas/review-behavior-matrix.schema.json"
 }
 

--- a/goldband-loop/test/codex-review-contract-authoring-install.test.ts
+++ b/goldband-loop/test/codex-review-contract-authoring-install.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { installCodexReviewLauncher } from "../scripts/install-codex-review-launcher";
+
+const sourceRoot = resolve(import.meta.dir, "..");
+
+describe("Codex review contract authoring install", () => {
+	test("installed help, init, and validate remain discoverable and state free", () => {
+		const fixture = mkdtempSync(join(tmpdir(), "goldband-contract-authoring-install-"));
+		try {
+			const trustedBin = join(fixture, "trusted-bin");
+			const emptyHome = join(fixture, "empty-home");
+			const runtimeRoot = join(fixture, "runtime");
+			const repo = join(fixture, "repo");
+			const nested = join(repo, "packages", "app");
+			const stateRoot = join(fixture, "state-must-not-exist");
+			mkdirSync(trustedBin, { recursive: true });
+			mkdirSync(emptyHome, { recursive: true });
+			mkdirSync(nested, { recursive: true });
+			const fakeCodex = executable(join(trustedBin, "codex"));
+			const fakeBrowser = executable(join(trustedBin, "browse"));
+			const marker = installCodexReviewLauncher({
+				sourceRoot,
+				runtimeRoot,
+				ruleFile: join(fixture, "rules", "goldband-workflows.rules"),
+				markerFile: join(fixture, "skills", "goldband", ".workflow-launcher.json"),
+				bunPath: process.execPath,
+				codexPath: fakeCodex,
+				browserPath: fakeBrowser,
+				bundleBrowserServer: (_bun, _entry, outputDirectory) => {
+					mkdirSync(outputDirectory, { recursive: true });
+					writeFileSync(join(outputDirectory, "server.js"), "// fixture\n");
+				},
+			});
+			expect(spawnSync("git", ["init", "-q"], { cwd: repo }).status).toBe(0);
+			const env = { ...process.env, HOME: emptyHome, GOLDBAND_HOME: stateRoot };
+			const run = (cwd: string, args: string[]) => spawnSync(
+				marker.argvPrefix[0],
+				[marker.argvPrefix[1], "review", "contract", ...args],
+				{ cwd, env, encoding: "utf8" },
+			);
+
+			const help = run(repo, ["help"]);
+			expect(help.status, help.stderr).toBe(0);
+			const installedRoot = realpathSync(runtimeRoot);
+			expect(JSON.parse(help.stdout).assets).toEqual({
+				guide: join(installedRoot, "review", "review-evidence-manifest.md"),
+				example: join(installedRoot, "review", "examples", "minimal-local-gate.json"),
+				schema: join(installedRoot, "review", "schemas", "review-evidence-manifest.schema.json"),
+			});
+
+			const initialized = run(nested, ["init"]);
+			expect(initialized.status, initialized.stderr).toBe(0);
+			const manifestFile = join(realpathSync(repo), "goldband.review-evidence.json");
+			expect(JSON.parse(initialized.stdout)).toMatchObject({
+				operation: "init",
+				status: "blocking-scaffold",
+				output: manifestFile,
+				blockingCellIds: ["project-evidence-contract"],
+			});
+			expect(JSON.parse(readFileSync(manifestFile, "utf8")).behaviorMatrix[0]).toMatchObject({
+				risk: "high",
+				disposition: "unsupported",
+				providerIds: [],
+			});
+
+			const validated = run(repo, ["validate", "--manifest", manifestFile]);
+			expect(validated.status, validated.stderr).toBe(0);
+			expect(JSON.parse(validated.stdout)).toMatchObject({
+				operation: "validate",
+				valid: true,
+				evidenceExecuted: false,
+				completionAuthorized: false,
+				behaviorCellIds: ["project-evidence-contract"],
+				providerIds: [],
+			});
+
+			const duplicate = run(repo, ["init"]);
+			expect(duplicate.status).not.toBe(0);
+			expect(duplicate.stderr).toContain("refusing to overwrite existing review contract");
+			expect(existsSync(stateRoot)).toBe(false);
+		} finally {
+			rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+});
+
+function executable(file: string): string {
+	writeFileSync(file, "#!/usr/bin/env bash\nexit 0\n");
+	chmodSync(file, 0o755);
+	return file;
+}

--- a/goldband-loop/test/codex-review-launcher-install.test.ts
+++ b/goldband-loop/test/codex-review-launcher-install.test.ts
@@ -150,6 +150,10 @@ describe("Codex trusted workflow launcher install", () => {
 			expect(existsSync(join(runtimeRoot, "browse", "browse"))).toBe(true);
 			expect(existsSync(join(runtimeRoot, "browse", "server", "server.js"))).toBe(true);
 			expect(existsSync(join(runtimeRoot, "review", "shared-rubric.md"))).toBe(true);
+			expect(existsSync(join(runtimeRoot, "review", "review-evidence-manifest.md"))).toBe(true);
+			expect(existsSync(join(runtimeRoot, "review", "examples", "minimal-local-gate.json"))).toBe(true);
+			expect(existsSync(join(runtimeRoot, "review", "schemas", "review-evidence-manifest.schema.json"))).toBe(true);
+			expect(existsSync(join(runtimeRoot, "review", "schemas", "review-behavior-matrix.schema.json"))).toBe(true);
 			expect(existsSync(join(runtimeRoot, "review", "rules-resolver.js"))).toBe(true);
 			expect(existsSync(join(runtimeRoot, "review", "rules", "manifest.json"))).toBe(true);
 			expect(existsSync(join(runtimeRoot, "distribution-manifest.json"))).toBe(true);
@@ -221,6 +225,8 @@ describe("Codex trusted workflow launcher install", () => {
 			});
 			expect(help.status).toBe(0);
 			expect(help.stdout).toContain("goldband review code");
+			expect(help.stdout).toContain("goldband review contract init");
+			expect(help.stdout).toContain("goldband review contract validate");
 			for (const promptAction of PROMPT_CONTRACT_ACTIONS) {
 				const [capability = "", action = ""] = promptAction.split("/");
 				const guidance = spawnSync(marker.argvPrefix[0], [

--- a/goldband-loop/test/review-contract-authoring.test.ts
+++ b/goldband-loop/test/review-contract-authoring.test.ts
@@ -1,0 +1,378 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import Ajv2020 from "ajv/dist/2020";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+	createReviewContractScaffold,
+	initializeReviewContract,
+	reviewContractAuthoringAssets,
+	validateReviewContractFile,
+} from "../workflows/review-contract-cli";
+import {
+	evaluateEvidenceCompleteness,
+	reviewEvidenceManifestSchema,
+	selectedEvidenceProviderIds,
+	type ReviewEvidenceManifest,
+} from "../workflows/review-evidence";
+
+const roots: string[] = [];
+const repoRoot = resolve(import.meta.dir, "../..");
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("review contract authoring", () => {
+	test("scaffold is valid but blocks semantic review until project evidence is declared", () => {
+		const manifest = reviewEvidenceManifestSchema.validate(createReviewContractScaffold());
+		const completeness = evaluateEvidenceCompleteness(manifest, []);
+
+		expect(manifest.behaviorMatrix).toEqual([
+			expect.objectContaining({
+				id: "project-evidence-contract",
+				risk: "high",
+				disposition: "unsupported",
+				providerIds: [],
+			}),
+		]);
+		expect(manifest.providers).toEqual([]);
+		expect(completeness).toEqual({
+			complete: false,
+			hostEligible: false,
+			blockingCellIds: ["project-evidence-contract"],
+			coverageGapCellIds: ["project-evidence-contract"],
+			runtimeIncompleteCellIds: [],
+		});
+	});
+
+	test("init writes once at the canonical repository root and refuses escapes or overwrite", () => {
+		const root = gitRepository();
+		const nested = join(root, "packages", "app");
+		mkdirSync(nested, { recursive: true });
+
+		const initialized = initializeReviewContract(nested);
+		const manifestFile = join(realpathSync(root), "goldband.review-evidence.json");
+
+		expect(initialized.output).toBe(manifestFile);
+		expect(initialized.blockingCellIds).toEqual(["project-evidence-contract"]);
+		expect(JSON.parse(readFileSync(manifestFile, "utf8"))).toEqual(
+			createReviewContractScaffold(),
+		);
+		expect(() => initializeReviewContract(nested)).toThrow(
+			"refusing to overwrite existing review contract",
+		);
+		expect(() => initializeReviewContract(nested, "../../../escaped.json")).toThrow(
+			"review contract output must stay inside the canonical Git repository",
+		);
+		const outside = mkdtempSync(join(tmpdir(), "goldband-contract-outside-"));
+		roots.push(outside);
+		symlinkSync(outside, join(root, "external"));
+		expect(() => initializeReviewContract(nested, "../../external/escaped.json")).toThrow(
+			"review contract output must stay inside the canonical Git repository",
+		);
+	});
+
+	test("validate uses the runtime authority and returns a side-effect-free summary", () => {
+		const root = gitRepository();
+		const manifestFile = join(repoRoot, "examples", "review-evidence", "minimal-local-gate.json");
+		const before = gitStatus(root);
+		const result = validateReviewContractFile(manifestFile, root);
+
+		expect(result).toMatchObject({
+			valid: true,
+			compatibilityIdentity: "review-evidence-schema-v2/runtime-contract-v2",
+			behaviorCellIds: ["typescript-contracts"],
+			providerIds: ["typescript-typecheck"],
+			authorizationIds: [],
+		});
+		expect(result.digest).toMatch(/^[a-f0-9]{64}$/);
+		expect(gitStatus(root)).toBe(before);
+	});
+
+	test("source authoring assets are discoverable and the public example passes JSON Schema", () => {
+		const assets = reviewContractAuthoringAssets();
+		expect(assets.guide).toBe(join(repoRoot, "docs", "review-evidence-manifest.md"));
+		expect(assets.example).toBe(
+			join(repoRoot, "examples", "review-evidence", "minimal-local-gate.json"),
+		);
+		expect(assets.schema).toBe(join(repoRoot, "schemas", "review-evidence-manifest.schema.json"));
+
+		const validateJsonSchema = jsonSchemaValidator();
+		const example = JSON.parse(readFileSync(assets.example, "utf8"));
+		expect(validateJsonSchema(example), JSON.stringify(validateJsonSchema.errors)).toBe(true);
+		expect(reviewEvidenceManifestSchema.validate(example).schemaVersion).toBe(2);
+		expect(selectedEvidenceProviderIds(example, ["src/index.ts"])).toEqual([
+			"typescript-typecheck",
+		]);
+		for (const pathPrefix of ["./src", "../src", "/src", "C:/src", "src\\nested", "src//nested", "src/"]) {
+			const invalid = {
+				...example,
+				providers: [{
+					...example.providers[0]!,
+					applicability: { kind: "paths", pathPrefixes: [pathPrefix] },
+				}],
+			};
+			expect(validateJsonSchema(invalid), pathPrefix).toBe(false);
+			expect(() => reviewEvidenceManifestSchema.validate(invalid), pathPrefix).toThrow();
+		}
+	});
+
+	test("JSON Schema and runtime conformance corpus covers local constraints and runtime-only graph rules", () => {
+		const validateJsonSchema = jsonSchemaValidator();
+		const example = JSON.parse(
+			readFileSync(join(repoRoot, "examples", "review-evidence", "minimal-local-gate.json"), "utf8"),
+		) as ReviewEvidenceManifest;
+		const cases: Array<{
+			name: string;
+			value: unknown;
+			schemaValid: boolean;
+			runtimeValid: boolean;
+		}> = [
+			{
+				name: "missing not-applicable reason",
+				value: {
+					schemaVersion: 2,
+					behaviorMatrix: [{
+						...example.behaviorMatrix[0]!,
+						disposition: "not-applicable",
+						providerIds: [],
+					}],
+					providers: [],
+					authorizations: [],
+				},
+				schemaValid: false,
+				runtimeValid: false,
+			},
+			{
+				name: "providerIds is explicit even when empty",
+				value: {
+					...example,
+					behaviorMatrix: [{
+						...example.behaviorMatrix[0]!,
+						disposition: "manual",
+						reason: "manual evidence is not yet automated",
+						providerIds: undefined,
+					}],
+					providers: [],
+				},
+				schemaValid: false,
+				runtimeValid: false,
+			},
+			{
+				name: "automated cell without provider",
+				value: {
+					schemaVersion: 2,
+					behaviorMatrix: [{
+						...example.behaviorMatrix[0]!,
+						disposition: "automated",
+						providerIds: [],
+					}],
+					providers: [],
+					authorizations: [],
+				},
+				schemaValid: false,
+				runtimeValid: false,
+			},
+			{
+				name: "provider references are unique",
+				value: {
+					...example,
+					behaviorMatrix: [{
+						...example.behaviorMatrix[0]!,
+						providerIds: ["typescript-typecheck", "typescript-typecheck"],
+					}],
+				},
+				schemaValid: false,
+				runtimeValid: false,
+			},
+			{
+				name: "unknown provider reference is a runtime graph rule",
+				value: {
+					...example,
+					behaviorMatrix: [{ ...example.behaviorMatrix[0]!, providerIds: ["missing"] }],
+					providers: [],
+				},
+				schemaValid: true,
+				runtimeValid: false,
+			},
+			{
+				name: "non-reciprocal ownership is a runtime graph rule",
+				value: {
+					...example,
+					providers: [{ ...example.providers[0]!, cellIds: ["different-cell"] }],
+				},
+				schemaValid: true,
+				runtimeValid: false,
+			},
+			{
+				name: "path prefixes use normalized repo-root coordinates",
+				value: {
+					...example,
+					providers: [{
+						...example.providers[0]!,
+						applicability: { kind: "paths", pathPrefixes: ["./src"] },
+					}],
+				},
+				schemaValid: false,
+				runtimeValid: false,
+			},
+			{
+				name: "persistent provider cannot carry transition binding",
+				value: {
+					...example,
+					providers: [{
+						...example.providers[0]!,
+						transitionBinding: {
+							repository: "fixture",
+							baseDigest: "a".repeat(64),
+							candidateDigest: "b".repeat(64),
+							scopeDigest: "c".repeat(64),
+							operationContractDigest: "d".repeat(64),
+						},
+					}],
+				},
+				schemaValid: false,
+				runtimeValid: false,
+			},
+			{
+				name: "persistent RED is a runtime lifecycle rule",
+				value: {
+					...example,
+					providers: [{
+						...example.providers[0]!,
+						kind: "regression",
+						operations: [
+							{
+								...example.providers[0]!.operations[0]!,
+								id: "base-red",
+								target: "base",
+								expectedExit: "nonzero",
+								expectedExitCode: 42,
+							},
+							example.providers[0]!.operations[0]!,
+						],
+					}],
+				},
+				schemaValid: true,
+				runtimeValid: false,
+			},
+			{
+				name: "property fuzz requires replay metadata",
+				value: {
+					...example,
+					providers: [{ ...example.providers[0]!, kind: "property-fuzz" }],
+				},
+				schemaValid: false,
+				runtimeValid: false,
+			},
+			{
+				name: "authorized network requires authorization id",
+				value: {
+					...example,
+					providers: [{
+						...example.providers[0]!,
+						operations: [{ ...example.providers[0]!.operations[0]!, network: "authorized" }],
+					}],
+				},
+				schemaValid: false,
+				runtimeValid: false,
+			},
+			{
+				name: "authorization id must resolve to the named operation",
+				value: {
+					...example,
+					providers: [{
+						...example.providers[0]!,
+						operations: [{
+							...example.providers[0]!.operations[0]!,
+							network: "authorized",
+							authorizationId: "missing-approval",
+						}],
+					}],
+				},
+				schemaValid: true,
+				runtimeValid: false,
+			},
+			{
+				name: "live evidence requires authorized network",
+				value: {
+					...example,
+					providers: [{
+						...example.providers[0]!,
+						operations: [{ ...example.providers[0]!.operations[0]!, evidenceLevel: "live-provider" }],
+					}],
+				},
+				schemaValid: false,
+				runtimeValid: false,
+			},
+		];
+
+		for (const fixture of cases) {
+			expect(validateJsonSchema(fixture.value), fixture.name).toBe(fixture.schemaValid);
+			let runtimeValid = true;
+			try {
+				reviewEvidenceManifestSchema.validate(fixture.value);
+			} catch {
+				runtimeValid = false;
+			}
+			expect(runtimeValid, fixture.name).toBe(fixture.runtimeValid);
+		}
+	});
+});
+
+function gitRepository(): string {
+	const root = mkdtempSync(join(tmpdir(), "goldband-contract-authoring-"));
+	roots.push(root);
+	const initialized = spawnSync("git", ["init", "-q"], { cwd: root, encoding: "utf8" });
+	if (initialized.status !== 0) throw new Error(initialized.stderr);
+	writeFileSync(join(root, "README.md"), "fixture\n");
+	const committed = spawnSync(
+		"git",
+		[
+			"-c",
+			"user.name=Goldband Test",
+			"-c",
+			"user.email=goldband@example.invalid",
+			"add",
+			"README.md",
+		],
+		{ cwd: root, encoding: "utf8" },
+	);
+	if (committed.status !== 0) throw new Error(committed.stderr);
+	const commit = spawnSync(
+		"git",
+		[
+			"-c",
+			"user.name=Goldband Test",
+			"-c",
+			"user.email=goldband@example.invalid",
+			"commit",
+			"-qm",
+			"fixture",
+		],
+		{ cwd: root, encoding: "utf8" },
+	);
+	if (commit.status !== 0) throw new Error(commit.stderr);
+	return root;
+}
+
+function gitStatus(root: string): string {
+	return spawnSync("git", ["status", "--porcelain=v1", "--untracked-files=all"], {
+		cwd: root,
+		encoding: "utf8",
+	}).stdout;
+}
+
+function jsonSchemaValidator() {
+	const ajv = new Ajv2020({ strict: false, validateFormats: false });
+	const behaviorSchema = JSON.parse(
+		readFileSync(join(repoRoot, "schemas", "review-behavior-matrix.schema.json"), "utf8"),
+	);
+	const manifestSchema = JSON.parse(
+		readFileSync(join(repoRoot, "schemas", "review-evidence-manifest.schema.json"), "utf8"),
+	);
+	ajv.addSchema(behaviorSchema);
+	return ajv.compile(manifestSchema);
+}

--- a/goldband-loop/test/review-evidence-platform.test.ts
+++ b/goldband-loop/test/review-evidence-platform.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -9,6 +9,13 @@ import {
   reviewEvidenceManifestSchema,
   type ReviewEvidenceManifest,
 } from '../workflows/review-evidence';
+import {
+  commonSystemMachServices,
+  darwinOutputChannelDenials,
+  sealedEvidenceExecutionUnavailable,
+  SYSTEM_SANDBOX_MACH_SERVICES,
+  validateSystemSandboxMachServices,
+} from '../workflows/review-evidence-sandbox';
 import { getWorkflow } from '../workflows/registry';
 
 const roots: string[] = [];
@@ -18,6 +25,85 @@ afterEach(() => {
 });
 
 describe('review evidence platform ownership', () => {
+  test('sealed review evidence declares macOS-only support without guessing a fallback', () => {
+    expect(sealedEvidenceExecutionUnavailable('darwin', true)).toBeUndefined();
+    expect(sealedEvidenceExecutionUnavailable('darwin', false)).toEqual({
+      actual: 'darwin/review-runtime',
+      detail: 'the supported macOS Seatbelt executable is unavailable',
+    });
+    expect(sealedEvidenceExecutionUnavailable('linux', false)).toEqual({
+      actual: 'linux/review-runtime',
+      detail: 'sealed executable review evidence currently requires macOS Seatbelt; Linux and Windows review parity is not supported',
+    });
+    expect(sealedEvidenceExecutionUnavailable('win32', false)?.actual)
+      .toBe('win32/review-runtime');
+  });
+
+  test('the imported macOS common Mach-service baseline fails closed on drift', () => {
+    const baseline = sandboxBaselineFixture([...SYSTEM_SANDBOX_MACH_SERVICES]);
+    expect(commonSystemMachServices(baseline)).toEqual([...SYSTEM_SANDBOX_MACH_SERVICES].sort());
+    expect(() => validateSystemSandboxMachServices(baseline)).not.toThrow();
+    expect(() => validateSystemSandboxMachServices(
+      sandboxBaselineFixture([...SYSTEM_SANDBOX_MACH_SERVICES, 'com.apple.future-service']),
+    )).toThrow('com.apple.future-service');
+    expect(() => validateSystemSandboxMachServices(
+      sandboxBaselineFixture(SYSTEM_SANDBOX_MACH_SERVICES.slice(1)),
+    )).toThrow('com.apple.analyticsd');
+    expect(() => validateSystemSandboxMachServices(
+      baseline.replace('(allow mach-register (local-name-prefix ""))\n', ''),
+    )).toThrow('mach-register');
+    expect(() => validateSystemSandboxMachServices(
+      baseline.replace('(allow mach-lookup (xpc-service-name-prefix ""))\n', ''),
+    )).toThrow('xpc-service-name-prefix');
+    expect(() => validateSystemSandboxMachServices(
+      baseline.replace('  (allow mach-bootstrap)\n', ''),
+    )).toThrow('mach-bootstrap');
+    expect(darwinOutputChannelDenials()).toEqual(expect.arrayContaining([
+      '(deny mach-lookup)',
+      '(deny mach-register)',
+      '(deny mach-bootstrap)',
+      '(deny mach-register (local-name-prefix ""))',
+      '(deny mach-lookup (xpc-service-name-prefix ""))',
+    ]));
+  });
+
+  test('the current macOS system.sb matches the reviewed Mach-service baseline', () => {
+    if (process.platform !== 'darwin') return;
+    expect(() => validateSystemSandboxMachServices(readFileSync(
+      '/System/Library/Sandbox/Profiles/system.sb',
+      'utf8',
+    ))).not.toThrow();
+  });
+
+  test('Linux sealed evidence returns typed incomplete records without semantic authority', async () => {
+    if (process.platform !== 'linux') return;
+    const repo = gitFixture();
+    const value = manifest();
+    value.providers[0]!.executionContext = { sandboxOwner: 'review-runtime', runner: 'sealed' };
+    const validated = reviewEvidenceManifestSchema.validate(value);
+    const input = { source: 'git diff', diff: '', changedFiles: [] };
+    const evidence = await executeEvidencePlan(
+      {
+        runId: 'linux-platform-contract',
+        workflow: getWorkflow('review/code'),
+        cwd: repo,
+        options: { mode: 'mock' as const },
+        artifacts: [],
+      },
+      input,
+      validated,
+      createCandidateBinding(repo, input, validated),
+    );
+
+    expect(evidence.records[0]).toMatchObject({
+      status: 'runtime-incomplete',
+      fresh: false,
+      environment: 'linux/review-runtime',
+    });
+    expect(evidence.records[0]!.outputSummary).toContain('Linux and Windows review parity is not supported');
+    expect(evidence.completeness).toMatchObject({ complete: false, hostEligible: false });
+  });
+
   test('an unsupported source lane remains typed runtime-incomplete without dispatching evidence', async () => {
     const repo = gitFixture();
     const value = manifest();
@@ -46,6 +132,31 @@ describe('review evidence platform ownership', () => {
     expect(evidence.completeness).toMatchObject({ complete: false, hostEligible: false });
   });
 });
+
+function sandboxBaselineFixture(services: readonly string[]): string {
+  const conditional = new Set([
+    'com.apple.internal.objc_trace',
+    'com.apple.osanalytics.osanalyticshelper',
+  ]);
+  const commonServices = services.filter((service) => !conditional.has(service));
+  return [
+    '(version 3)',
+    '(unless *import-path*',
+    '  (allow mach-bootstrap)',
+    '  (allow syscall*))',
+    '(allow mach-register (local-name-prefix ""))',
+    '(allow mach-lookup (xpc-service-name-prefix ""))',
+    `(allow mach-lookup ${commonServices.map((service) =>
+      `(global-name "${service}")`).join(' ')} (local-name "com.apple.cfprefsd.agent"))`,
+    ...(services.includes('com.apple.internal.objc_trace')
+      ? ['(allow mach-lookup (global-name "com.apple.internal.objc_trace"))']
+      : []),
+    ...(services.includes('com.apple.osanalytics.osanalyticshelper')
+      ? ['(allow mach-lookup (global-name "com.apple.osanalytics.osanalyticshelper"))']
+      : []),
+    '(define (system-graphics) (allow default))',
+  ].join('\n');
+}
 
 function gitFixture(): string {
   const root = mkdtempSync(join(tmpdir(), 'review-evidence-platform-'));

--- a/goldband-loop/test/review-evidence.test.ts
+++ b/goldband-loop/test/review-evidence.test.ts
@@ -1383,6 +1383,52 @@ describe('review evidence contracts', () => {
     }
   });
 
+  test('evidence sandbox denies Mach service lookup inherited from the macOS process baseline', async () => {
+    if (!hostBoundaryPrerequisite(process.platform === 'darwin', 'platform=darwin')) return;
+    const clang = spawnSync('/usr/bin/xcrun', ['--find', 'clang'], { encoding: 'utf8' });
+    if (!hostBoundaryPrerequisite(clang.status === 0, 'xcrun clang')) return;
+    const probeRoot = mkdtempSync(join(tmpdir(), 'review-mach-lookup-'));
+    roots.push(probeRoot);
+    const probeSource = join(probeRoot, 'mach-lookup.c');
+    const probe = join(probeRoot, 'mach-lookup');
+    writeFileSync(
+      probeSource,
+      [
+        '#include <mach/mach.h>',
+        '#include <servers/bootstrap.h>',
+        'int main(void) {',
+        '  mach_port_t service = MACH_PORT_NULL;',
+        '  kern_return_t result = bootstrap_look_up(bootstrap_port, "com.apple.logd", &service);',
+        '  if (result != KERN_SUCCESS) return 0;',
+        '  mach_port_deallocate(mach_task_self(), service);',
+        '  return 9;',
+        '}',
+      ].join('\n'),
+    );
+    compileMachO([probeSource, '-o', probe]);
+    const nativeLookup = spawnSync(probe, [], { encoding: 'utf8' });
+    if (!hostBoundaryPrerequisite(
+      nativeLookup.status === 9,
+      'native com.apple.logd Mach lookup',
+    )) return;
+    const repo = gitFixture();
+    const value = manifest();
+    value.providers[0]!.operations[0]!.argv = [basename(probe)];
+    const validated = reviewEvidenceManifestSchema.validate(value);
+    const input = { source: 'git diff', diff: '', changedFiles: [] };
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${probeRoot}:${previousPath ?? '/usr/bin:/bin'}`;
+    try {
+      const evidence = await executeEvidencePlan(
+        context(repo), input, validated, createCandidateBinding(repo, input, validated),
+      );
+      expect(evidence.records[0]).toMatchObject({ status: 'verified-pass', fresh: true });
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+    }
+  });
+
   test('regression RED requires the declared exact exit code', async () => {
     const repo = gitFixture();
     const value = manifest();

--- a/goldband-loop/test/source-complexity.test.ts
+++ b/goldband-loop/test/source-complexity.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import {
+  baselineTransitionFailures,
+  localPredecessorAuthority,
+  summarizeDiagnostics,
+  worsenedMetrics,
+} from '../scripts/check-source-complexity';
+
+describe('source complexity baseline', () => {
+  test('normalizes per-file rule magnitudes independently of source line numbers', () => {
+    const baseline = summarizeDiagnostics([
+      diagnostic('workflows/review.ts', 'complexity/useMaxParams', 7),
+      diagnostic('workflows/review.ts', 'complexity/useMaxParams', 5),
+      diagnostic('workflows/review.ts', 'complexity/noExcessiveLinesPerFunction', 80),
+    ]);
+    expect(baseline.files['workflows/review.ts']).toEqual({
+      'lint/complexity/noExcessiveLinesPerFunction': [80],
+      'lint/complexity/useMaxParams': [7, 5],
+    });
+  });
+
+  test('rejects a worsened sorted magnitude vector and permits aggregate reduction', () => {
+    const expected = summarizeDiagnostics([
+      diagnostic('workflows/review.ts', 'complexity/useMaxParams', 7),
+      diagnostic('workflows/review.ts', 'complexity/useMaxParams', 5),
+    ]);
+    const improved = summarizeDiagnostics([
+      diagnostic('workflows/review.ts', 'complexity/useMaxParams', 6),
+    ]);
+    const worsened = summarizeDiagnostics([
+      diagnostic('workflows/review.ts', 'complexity/useMaxParams', 8),
+    ]);
+    const newFile = summarizeDiagnostics([
+      diagnostic('workflows/new.ts', 'complexity/useMaxParams', 5),
+    ]);
+
+    expect(worsenedMetrics(expected, improved)).toEqual([]);
+    expect(worsenedMetrics(expected, worsened)).toHaveLength(1);
+    expect(worsenedMetrics(expected, newFile)).toHaveLength(1);
+  });
+
+  test('documents that ranked vectors do not carry function identity', () => {
+    const predecessor = summarizeDiagnostics([
+      diagnostic('workflows/review.ts', 'complexity/noExcessiveLinesPerFunction', 100),
+      diagnostic('workflows/review.ts', 'complexity/noExcessiveLinesPerFunction', 60),
+    ]);
+    const aggregateReduction = summarizeDiagnostics([
+      diagnostic('workflows/review.ts', 'complexity/noExcessiveLinesPerFunction', 90),
+    ]);
+
+    expect(worsenedMetrics(predecessor, aggregateReduction)).toEqual([]);
+  });
+
+  test('rejects a hand-expanded candidate baseline even when it matches source', () => {
+    const predecessor = summarizeDiagnostics([
+      diagnostic('workflows/review.ts', 'complexity/useMaxParams', 5),
+    ]);
+    const expandedCandidate = summarizeDiagnostics([
+      diagnostic('workflows/review.ts', 'complexity/useMaxParams', 7),
+    ]);
+
+    expect(baselineTransitionFailures(
+      predecessor,
+      expandedCandidate,
+      expandedCandidate,
+    )).toEqual([
+      expect.stringContaining('candidate baseline exceeds predecessor'),
+    ]);
+  });
+
+  test('uses the baseline-changing commit parent across later unrelated commits', () => {
+    const candidate = summarizeDiagnostics([
+      diagnostic('workflows/review.ts', 'complexity/useMaxParams', 7),
+    ]);
+
+    expect(localPredecessorAuthority(candidate, candidate, 'baseline-change-a'))
+      .toEqual({ ref: 'baseline-change-a^', required: true });
+    expect(localPredecessorAuthority(
+      candidate,
+      summarizeDiagnostics([]),
+      'older-change',
+    )).toEqual({ ref: 'HEAD', required: true });
+    expect(localPredecessorAuthority(candidate, undefined, undefined))
+      .toEqual({ ref: 'HEAD', required: false });
+  });
+
+  test('fails closed when the configured predecessor ref is unavailable', () => {
+    const result = spawnSync(
+      process.execPath,
+      [join(import.meta.dir, '../scripts/check-source-complexity.ts')],
+      {
+        cwd: join(import.meta.dir, '..'),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          GOLDBAND_COMPLEXITY_BASE_REF: 'definitely-not-a-complexity-ref',
+        },
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      'required complexity predecessor is unavailable: definitely-not-a-complexity-ref',
+    );
+  });
+});
+
+function diagnostic(path: string, rule: string, value: number) {
+  return {
+    category: `lint/${rule}`,
+    message: `metric ${value}`,
+    location: { path, start: { line: 1, column: 1 } },
+  };
+}

--- a/goldband-loop/test/test-free-shards.test.ts
+++ b/goldband-loop/test/test-free-shards.test.ts
@@ -105,8 +105,10 @@ describe('test-free-shards: platform ownership', () => {
   test('Linux keeps mixed files while excluding only macOS review-host cases', () => {
     const files = collectFreeTestFiles(ROOT);
     expect(files).toContain('test/review-evidence.test.ts');
+    expect(files).toContain('test/review-contract-authoring.test.ts');
     expect(files).toContain('test/work-map-review.test.ts');
     expect(files).toContain('test/codex-review-launcher-install.test.ts');
+    expect(files).toContain('test/codex-review-contract-authoring-install.test.ts');
     expect(files).toContain('test/review-receipt-authority-install.test.ts');
     expect(files).toContain('test/workflows-runtime.test.ts');
     expect(files).toContain('test/goldband-review-cli.test.ts');

--- a/goldband-loop/workflows/capability-registry.generated.ts
+++ b/goldband-loop/workflows/capability-registry.generated.ts
@@ -22,7 +22,7 @@ export const CAPABILITY_ACTIONS: CapabilityActionRecord[] = [
     "capability": "review",
     "action": "code",
     "name": "review/code",
-    "description": "Evidence-first code review with authoritative lineage and scoped closure.",
+    "description": "Evidence-first code review.",
     "contractPath": "generated/workflow-contracts/review/code.workflow.md",
     "runtime": "typed",
     "dispatch": "trusted-launcher",

--- a/goldband-loop/workflows/review-contract-cli.ts
+++ b/goldband-loop/workflows/review-contract-cli.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env bun
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, realpathSync } from 'node:fs';
-import { isAbsolute, join, resolve } from 'node:path';
+import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { resolveGoldbandStateRoot } from '../lib/state-root';
 import {
+  evaluateEvidenceCompleteness,
   reviewEvidenceManifestSchema,
   type ReviewEvidenceManifest,
 } from './review-evidence';
@@ -12,55 +14,208 @@ import {
   digestManifest,
   importReviewContract,
   inspectReviewContractStore,
+  readReviewContractManifest,
   removeReviewContract,
   type ReviewContractStoreInspection,
 } from './review-contract-store';
 import { assertReviewContractNotWeaker } from './review-lineage';
+import { resolveReviewWorkspace } from './review-workspace';
 
-type Command = 'inspect' | 'import' | 'remove';
+type Command = 'help' | 'init' | 'inspect' | 'import' | 'remove' | 'validate';
+type AuthoringAssets = { guide: string; example: string; schema: string };
+type CliSelection = {
+  command: Command;
+  manifestFile?: string;
+  outputFile?: string;
+  goldbandHome?: string;
+};
+
+const COMPATIBILITY_IDENTITY = 'review-evidence-schema-v2/runtime-contract-v2';
+const DEFAULT_MANIFEST_FILE = 'goldband.review-evidence.json';
+const SCAFFOLD_CELL_ID = 'project-evidence-contract';
+const COMMANDS = new Set<Command>(['help', 'init', 'inspect', 'import', 'remove', 'validate']);
+
+export function createReviewContractScaffold(): ReviewEvidenceManifest {
+  return {
+    schemaVersion: 2,
+    behaviorMatrix: [{
+      id: SCAFFOLD_CELL_ID,
+      behavior: 'Project-owned behavior and verification requirements are declared before review.',
+      kind: 'boundary',
+      input: 'the scoped candidate',
+      preconditions: 'replace this scaffold with project-specific behavior cells and evidence providers',
+      expected: 'every required project behavior is covered by fresh evidence at the declared level',
+      risk: 'high',
+      disposition: 'unsupported',
+      providerIds: [],
+      reason: 'Scaffold only: the project owner must declare real behavior and evidence providers before semantic review can become eligible.',
+    }],
+    providers: [],
+    authorizations: [],
+  };
+}
+
+export function initializeReviewContract(
+  cwd: string,
+  outputFile?: string,
+): { output: string; digest: string; blockingCellIds: string[] } {
+  const workspace = resolveReviewWorkspace(cwd);
+  const output = resolveReviewContractOutput(cwd, workspace.repositoryRoot, outputFile);
+  if (existsSync(output)) throw new Error(`refusing to overwrite existing review contract: ${output}`);
+  const manifest = reviewEvidenceManifestSchema.validate(createReviewContractScaffold());
+  const completeness = evaluateEvidenceCompleteness(manifest, []);
+  if (completeness.hostEligible || completeness.blockingCellIds.length === 0) {
+    throw new Error('review contract scaffold must remain fail closed');
+  }
+  try {
+    writeFileSync(output, `${JSON.stringify(manifest, null, 2)}\n`, { flag: 'wx', mode: 0o644 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      throw new Error(`refusing to overwrite existing review contract: ${output}`);
+    }
+    throw error;
+  }
+  return {
+    output: realpathSync(output),
+    digest: digestManifest(manifest),
+    blockingCellIds: completeness.blockingCellIds,
+  };
+}
+
+function resolveReviewContractOutput(cwd: string, repositoryRoot: string, outputFile?: string): string {
+  const requested = outputFile ? resolve(cwd, outputFile) : join(repositoryRoot, DEFAULT_MANIFEST_FILE);
+  const output = join(realpathSync(dirname(requested)), basename(requested));
+  const outputOffset = relative(realpathSync(repositoryRoot), output);
+  if (isAbsolute(outputOffset) || outputOffset === '..' || outputOffset.startsWith(`..${sep}`)) {
+    throw new Error('review contract output must stay inside the canonical Git repository');
+  }
+  return output;
+}
+
+export function validateReviewContractFile(
+  manifestFile: string,
+  cwd = process.cwd(),
+): {
+  valid: true;
+  source: string;
+  compatibilityIdentity: string;
+  digest: string;
+  behaviorCellIds: string[];
+  providerIds: string[];
+  authorizationIds: string[];
+} {
+  const { source, manifest } = readReviewContractManifest(manifestFile, cwd);
+  return {
+    valid: true,
+    source,
+    compatibilityIdentity: COMPATIBILITY_IDENTITY,
+    digest: digestManifest(manifest),
+    behaviorCellIds: manifest.behaviorMatrix.map((cell) => cell.id).sort(),
+    providerIds: manifest.providers.map((provider) => provider.id).sort(),
+    authorizationIds: manifest.authorizations.map((authorization) => authorization.id).sort(),
+  };
+}
+
+export function reviewContractAuthoringAssets(
+  moduleFile = fileURLToPath(import.meta.url),
+): AuthoringAssets {
+  const runtimeRoot = dirname(dirname(realpathSync(moduleFile)));
+  return {
+    guide: resolveAuthoringAsset(runtimeRoot, 'review/review-evidence-manifest.md', '../docs/review-evidence-manifest.md'),
+    example: resolveAuthoringAsset(runtimeRoot, 'review/examples/minimal-local-gate.json', '../examples/review-evidence/minimal-local-gate.json'),
+    schema: resolveAuthoringAsset(runtimeRoot, 'review/schemas/review-evidence-manifest.schema.json', '../schemas/review-evidence-manifest.schema.json'),
+  };
+}
+
+function resolveAuthoringAsset(runtimeRoot: string, installedRelative: string, sourceRelative: string): string {
+  for (const candidate of [resolve(runtimeRoot, installedRelative), resolve(runtimeRoot, sourceRelative)]) {
+    if (existsSync(candidate)) return realpathSync(candidate);
+  }
+  throw new Error(`review contract authoring asset is missing: ${installedRelative}`);
+}
 
 export function runReviewContractCli(args: string[]): number {
-  const command = args.shift() as Command | undefined;
-  if (!command || !['inspect', 'import', 'remove'].includes(command)) usage();
-  let manifestFile: string | undefined;
-  let goldbandHome: string | undefined;
-  for (let index = 0; index < args.length; index += 1) {
-    const flag = args[index];
-    const value = args[index + 1];
-    if (flag === '--manifest' && command === 'import' && value && !manifestFile) {
-      manifestFile = value;
-    } else if (flag === '--goldband-home' && value && !goldbandHome) {
-      goldbandHome = value;
-    } else {
-      throw new Error(`review contract ${command}: invalid or repeated option ${flag ?? 'option'}`);
-    }
-    index += 1;
-  }
-  if (command === 'import' && !manifestFile) {
-    throw new Error('review contract import requires --manifest <path>');
-  }
-  if (command !== 'import' && manifestFile) usage();
-  if (goldbandHome && !isAbsolute(goldbandHome)) {
-    throw new Error('review contract state root must be absolute');
-  }
-
+  const selection = parseReviewContractArgs(args);
   const cwd = process.cwd();
-  const stateRoot = resolveGoldbandStateRoot(goldbandHome);
+  if (runAuthoringCommand(selection, cwd)) return 0;
+  const stateRoot = resolveGoldbandStateRoot(selection.goldbandHome);
   const before = inspectReviewContractStore(cwd, stateRoot);
-  if (command === 'inspect') {
+  if (selection.command === 'inspect') {
     console.log(JSON.stringify(renderInspection(before), null, 2));
     return 0;
   }
-  const after = command === 'import'
-    ? importReviewContract(cwd, stateRoot, manifestFile!)
+  const after = selection.command === 'import'
+    ? importReviewContract(cwd, stateRoot, selection.manifestFile!)
     : removeReviewContract(cwd, stateRoot);
   console.log(JSON.stringify({
     schemaVersion: 1,
-    operation: command,
+    operation: selection.command,
     before: renderInspection(before),
     after: renderInspection(after),
   }, null, 2));
   return 0;
+}
+
+function parseReviewContractArgs(input: string[]): CliSelection {
+  const args = [...input];
+  const selected = args.shift();
+  const command = selected === '-h' || selected === '--help' ? 'help' : selected as Command | undefined;
+  if (!command || !COMMANDS.has(command)) usage();
+  const selection: CliSelection = { command };
+  for (let index = 0; index < args.length; index += 2) {
+    parseReviewContractOption(selection, args[index], args[index + 1]);
+  }
+  if ((command === 'import' || command === 'validate') && !selection.manifestFile) {
+    throw new Error(`review contract ${command} requires --manifest <path>`);
+  }
+  if (selection.goldbandHome && !isAbsolute(selection.goldbandHome)) {
+    throw new Error('review contract state root must be absolute');
+  }
+  return selection;
+}
+
+function parseReviewContractOption(selection: CliSelection, flag?: string, value?: string): void {
+  const { command } = selection;
+  if (flag === '--manifest' && (command === 'import' || command === 'validate') && value && !selection.manifestFile) {
+    selection.manifestFile = value;
+    return;
+  }
+  if (flag === '--output' && command === 'init' && value && !selection.outputFile) {
+    selection.outputFile = value;
+    return;
+  }
+  if (flag === '--goldband-home' && ['inspect', 'import', 'remove'].includes(command) && value && !selection.goldbandHome) {
+    selection.goldbandHome = value;
+    return;
+  }
+  throw new Error(`review contract ${command}: invalid or repeated option ${flag ?? 'option'}`);
+}
+
+function runAuthoringCommand(selection: CliSelection, cwd: string): boolean {
+  const assets = reviewContractAuthoringAssets;
+  if (selection.command === 'help') {
+    printJson({ schemaVersion: 1, operation: 'help', commands: {
+      init: 'goldband review contract init [--output <path>]',
+      validate: 'goldband review contract validate --manifest <path>',
+      inspect: 'goldband review contract inspect',
+      import: 'goldband review contract import --manifest <path>',
+      remove: 'goldband review contract remove',
+    }, assets: assets(), authority: 'validate uses the installed runtime validator; success does not mean evidence ran or review completed' });
+    return true;
+  }
+  if (selection.command === 'init') {
+    printJson({ schemaVersion: 1, operation: 'init', ...initializeReviewContract(cwd, selection.outputFile), status: 'blocking-scaffold', assets: assets(), next: 'replace the scaffold with project-owned behavior and providers, then run review contract validate' });
+    return true;
+  }
+  if (selection.command === 'validate') {
+    printJson({ schemaVersion: 1, operation: 'validate', ...validateReviewContractFile(selection.manifestFile!, cwd), evidenceExecuted: false, completionAuthorized: false, assets: assets() });
+    return true;
+  }
+  return false;
+}
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
 }
 
 function renderInspection(store: ReviewContractStoreInspection) {
@@ -101,7 +256,7 @@ function renderInspection(store: ReviewContractStoreInspection) {
     repositoryIdentity: store.repository,
     repositoryRoot: store.workspace.repositoryRoot,
     invocationOffset: store.workspace.invocationOffset,
-    compatibilityIdentity: 'review-evidence-schema-v2/runtime-contract-v2',
+    compatibilityIdentity: COMPATIBILITY_IDENTITY,
     schemaMigration: base?.migrated
       ? { observedVersion: 1, supportedVersion: 2, source: base.source }
       : null,
@@ -196,7 +351,7 @@ function manifestTrackingState(repositoryRoot: string): string {
 
 function usage(): never {
   throw new Error(
-    'Usage: goldband review contract inspect | goldband review contract import --manifest <path> | goldband review contract remove',
+    'Usage: goldband review contract help | goldband review contract init [--output <path>] | goldband review contract validate --manifest <path> | goldband review contract inspect | goldband review contract import --manifest <path> | goldband review contract remove',
   );
 }
 

--- a/goldband-loop/workflows/review-contract-store.ts
+++ b/goldband-loop/workflows/review-contract-store.ts
@@ -87,11 +87,7 @@ export function importReviewContract(
 ): ReviewContractStoreInspection {
   const workspace = resolveReviewWorkspace(cwd);
   const repository = resolveReviewContractRepositoryIdentity(cwd);
-  const source = resolve(cwd, manifestFile);
-  const manifest = validateManifestSource(
-    JSON.parse(readStableRegularFile(source).toString('utf8')),
-    source,
-  );
+  const { source, manifest } = readReviewContractManifest(manifestFile, cwd);
   const directory = reviewContractStoreDirectory(stateRoot);
   ensurePrivateDirectory(directory);
   const entryFile = reviewContractEntryFile(stateRoot, repository);
@@ -108,6 +104,20 @@ export function importReviewContract(
   }
   writeAtomicPrivateJson(entryFile, entry);
   return { repository, workspace, entryFile, entry: readAndValidateStoreEntry(entryFile, repository) };
+}
+
+export function readReviewContractManifest(
+  manifestFile: string,
+  cwd = process.cwd(),
+): { source: string; manifest: ReviewEvidenceManifest } {
+  const source = resolve(cwd, manifestFile);
+  let value: unknown;
+  try {
+    value = JSON.parse(readStableRegularFile(source).toString('utf8'));
+  } catch (error) {
+    throw new Error(`${error instanceof Error ? error.message : String(error)}; source: ${source}`);
+  }
+  return { source: realpathSync(source), manifest: validateManifestSource(value, source) };
 }
 
 export function removeReviewContract(
@@ -224,16 +234,16 @@ function readAndValidateStoreEntry(
 function readStableRegularFile(file: string): Buffer {
   const pathBefore = lstatSync(file);
   if (pathBefore.isSymbolicLink() || !pathBefore.isFile()) {
-    throw new Error('review contract import manifest must be a regular file, not a symlink');
+    throw new Error('review contract manifest must be a regular file, not a symlink');
   }
   if (pathBefore.size > MAX_MANIFEST_BYTES) {
-    throw new Error(`review contract import manifest exceeds ${MAX_MANIFEST_BYTES} bytes`);
+    throw new Error(`review contract manifest exceeds ${MAX_MANIFEST_BYTES} bytes`);
   }
   const descriptor = openSync(file, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
   try {
     const before = fstatSync(descriptor, { bigint: true });
     if (!before.isFile() || before.ino !== BigInt(pathBefore.ino) || before.dev !== BigInt(pathBefore.dev)) {
-      throw new Error('review contract import manifest changed while being opened');
+      throw new Error('review contract manifest changed while being opened');
     }
     const content = Buffer.alloc(Number(before.size));
     let offset = 0;
@@ -250,7 +260,7 @@ function readStableRegularFile(file: string): Buffer {
       pathAfter.isSymbolicLink() || !pathAfter.isFile() || BigInt(pathAfter.ino) !== before.ino ||
       BigInt(pathAfter.dev) !== before.dev
     ) {
-      throw new Error('review contract import manifest changed while being read');
+      throw new Error('review contract manifest changed while being read');
     }
     return content;
   } finally {

--- a/goldband-loop/workflows/review-evidence-sandbox.ts
+++ b/goldband-loop/workflows/review-evidence-sandbox.ts
@@ -1,0 +1,302 @@
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import type { EvidenceRuntimeReadAccess } from "./review-evidence";
+
+const SYSTEM_SANDBOX_PROFILE = "/System/Library/Sandbox/Profiles/system.sb";
+
+export const SYSTEM_SANDBOX_MACH_SERVICES = [
+	"com.apple.analyticsd",
+	"com.apple.analyticsd.messagetracer",
+	"com.apple.appsleep",
+	"com.apple.bsd.dirhelper",
+	"com.apple.cfprefsd.agent",
+	"com.apple.cfprefsd.daemon",
+	"com.apple.diagnosticd",
+	"com.apple.dt.automationmode.reader",
+	"com.apple.espd",
+	"com.apple.logd",
+	"com.apple.logd.events",
+	"com.apple.internal.objc_trace",
+	"com.apple.osanalytics.osanalyticshelper",
+	"com.apple.runningboard",
+	"com.apple.secinitd",
+	"com.apple.system.DirectoryService.libinfo_v1",
+	"com.apple.system.logger",
+	"com.apple.system.notification_center",
+	"com.apple.system.opendirectoryd.libinfo",
+	"com.apple.system.opendirectoryd.membership",
+	"com.apple.trustd",
+	"com.apple.trustd.agent",
+	"com.apple.xpc.activity.unmanaged",
+] as const;
+
+const CONDITIONAL_SYSTEM_MACH_SERVICES = new Set([
+	"com.apple.internal.objc_trace",
+	"com.apple.osanalytics.osanalyticshelper",
+]);
+
+const SYSTEM_SANDBOX_MACH_ALLOW_RULES = uniqueSorted([
+	"(allow mach-bootstrap)",
+	'(allow mach-register (local-name-prefix ""))',
+	'(allow mach-lookup (xpc-service-name-prefix ""))',
+	`(allow mach-lookup ${SYSTEM_SANDBOX_MACH_SERVICES
+		.filter((service) => !CONDITIONAL_SYSTEM_MACH_SERVICES.has(service))
+		.map((service) => `(global-name ${schemeString(service)})`)
+		.join(" ")} (local-name "com.apple.cfprefsd.agent"))`,
+	'(allow mach-lookup (global-name "com.apple.internal.objc_trace"))',
+	'(allow mach-lookup (global-name "com.apple.osanalytics.osanalyticshelper"))',
+]);
+
+export type EvidenceSandboxOptions = {
+	cwd: string;
+	writableRoots: string[];
+	argv: string[];
+	runtimeAccess: EvidenceRuntimeReadAccess;
+	systemToolRoots?: string[];
+	systemToolLiterals?: string[];
+	systemToolMapExecutableLiterals?: string[];
+};
+
+export type EvidenceSandboxCommand = {
+	command: string;
+	args: string[];
+	brokered: boolean;
+};
+
+export function sealedEvidenceExecutionUnavailable(
+	platform: NodeJS.Platform = process.platform,
+	seatbeltExists = existsSync("/usr/bin/sandbox-exec"),
+): { actual: string; detail: string } | undefined {
+	if (platform === "darwin" && seatbeltExists) return undefined;
+	return {
+		actual: `${platform}/review-runtime`,
+		detail:
+			platform === "darwin"
+				? "the supported macOS Seatbelt executable is unavailable"
+				: "sealed executable review evidence currently requires macOS Seatbelt; Linux and Windows review parity is not supported",
+	};
+}
+
+export function evidenceSandboxCommand(
+	options: EvidenceSandboxOptions,
+): EvidenceSandboxCommand {
+	const unavailable = sealedEvidenceExecutionUnavailable();
+	if (unavailable) {
+		throw new Error(
+			`review evidence runner unavailable: ${unavailable.detail}`,
+		);
+	}
+	validateSystemSandboxMachServices(
+		readFileSync(SYSTEM_SANDBOX_PROFILE, "utf8"),
+	);
+	return {
+		command: "/usr/bin/sandbox-exec",
+		args: ["-p", darwinSandboxProfile(options), "--", ...options.argv],
+		brokered: false,
+	};
+}
+
+export function validateSystemSandboxMachServices(profile: string): void {
+	const actual = commonSystemMachAllowRules(profile);
+	const expected = SYSTEM_SANDBOX_MACH_ALLOW_RULES;
+	if (JSON.stringify(actual) === JSON.stringify(expected)) return;
+	const actualSet = new Set<string>(actual);
+	const expectedSet = new Set<string>(expected);
+	const missing = expected.filter((rule) => !actualSet.has(rule));
+	const added = actual.filter((rule) => !expectedSet.has(rule));
+	throw new Error(
+		`macOS system.sb Mach allow-clause baseline drifted; review evidence remains blocked until the private baseline is re-audited (added=${added.join(" | ") || "none"} missing=${missing.join(" | ") || "none"})`,
+	);
+}
+
+export function commonSystemMachServices(profile: string): string[] {
+	return uniqueSorted(
+		commonSystemMachAllowRules(profile).flatMap((rule) =>
+			[...rule.matchAll(/\(global-name\s+"([^"]+)"\)/g)].map(
+				(match) => match[1]!,
+			),
+		),
+	);
+}
+
+function commonSystemMachAllowRules(profile: string): string[] {
+	const firstDefinition = profile.search(/^\(define\s+\(/m);
+	if (firstDefinition < 0) {
+		throw new Error(
+			"macOS system.sb common process baseline has an unsupported structure",
+		);
+	}
+	const commonBaseline = profile.slice(0, firstDefinition);
+	return uniqueSorted(machAllowExpressions(commonBaseline));
+}
+
+function machAllowExpressions(profile: string): string[] {
+	const expressions: string[] = [];
+	for (const match of profile.matchAll(/\(allow(?=[^()]*\bmach-[a-z0-9*_-]+)/gi)) {
+		const expression = balancedExpression(profile, match.index);
+		if (expression) expressions.push(expression.replace(/\s+/g, " ").trim());
+	}
+	return expressions;
+}
+
+function balancedExpression(source: string, start: number): string | undefined {
+	let depth = 0;
+	for (let index = start; index < source.length; index += 1) {
+		const character = source[index]!;
+		if (character === "(") depth += 1;
+		else if (character === ")" && --depth === 0) return source.slice(start, index + 1);
+	}
+	return undefined;
+}
+
+export function isEvidenceSandboxRuntimeFailure(
+	sandboxCommand: string,
+	result: { reason: string; exitCode: number; stderr?: string },
+	brokered = false,
+): boolean {
+	if (
+		(!brokered && sandboxCommand !== "/usr/bin/sandbox-exec") ||
+		result.reason !== "exit"
+	)
+		return false;
+	const stderr = result.stderr ?? "";
+	const brokerFailed =
+		brokered &&
+		result.exitCode === 71 &&
+		/^evidence sandbox broker (?:rejected request|timed out|response)/im.test(
+			stderr,
+		);
+	const sandboxInitializationFailed =
+		result.exitCode === 71 && /^(?:sandbox-exec:|sandbox_init:)/im.test(stderr);
+	const dynamicLoaderFailedBeforeMain =
+		result.exitCode !== 0 && /^dyld\[\d+\]:/m.test(stderr);
+	return (
+		brokerFailed || sandboxInitializationFailed || dynamicLoaderFailedBeforeMain
+	);
+}
+
+function darwinSandboxProfile(options: EvidenceSandboxOptions): string {
+	const writableRoots = options.writableRoots.map((root) => realpathSync(root));
+	const readableRoots = uniqueSorted([
+		realpathSync(options.cwd),
+		...writableRoots,
+		...options.runtimeAccess.roots,
+		...(options.systemToolRoots ?? []),
+	]);
+	const ancestorRoots = uniqueSorted([
+		realpathSync(options.cwd),
+		...options.runtimeAccess.roots,
+		...(options.systemToolRoots ?? []),
+	]);
+	return [
+		"(version 1)",
+		"(deny default)",
+		'(import "system.sb")',
+		...darwinOutputChannelDenials(),
+		...darwinProcessAllows(),
+		...darwinRuntimeAllows(
+			options,
+			readableRoots,
+			writableRoots,
+			ancestorRoots,
+		),
+	].join(" ");
+}
+
+export function darwinOutputChannelDenials(): string[] {
+	const machServices = SYSTEM_SANDBOX_MACH_SERVICES.map(
+		(name) => `(global-name ${schemeString(name)})`,
+	).join(" ");
+	return [
+		"(deny network*)",
+		'(deny network-outbound (literal "/private/var/run/syslog"))',
+		"(deny mach-lookup)",
+		"(deny mach-register)",
+		"(deny mach-bootstrap)",
+		'(deny mach-register (local-name-prefix ""))',
+		'(deny mach-lookup (xpc-service-name-prefix ""))',
+		`(deny mach-lookup ${machServices} (local-name "com.apple.cfprefsd.agent"))`,
+		`(if (defined? 'system-socket) (deny system-socket))`,
+		'(deny ipc-posix-shm-read* (ipc-posix-name "apple.shm.notification_center") (ipc-posix-name-prefix "apple.cfprefs."))',
+	];
+}
+
+function darwinProcessAllows(): string[] {
+	return [
+		"(allow process-exec)",
+		"(allow process-fork)",
+		"(allow signal (target self))",
+		"(allow signal (target children))",
+		"(allow sysctl-read)",
+		'(allow file-read* (literal "/dev/null"))',
+		'(allow file-write* (literal "/dev/null"))',
+	];
+}
+
+function darwinRuntimeAllows(
+	options: EvidenceSandboxOptions,
+	readableRoots: string[],
+	writableRoots: string[],
+	ancestorRoots: string[],
+): string[] {
+	const literals = uniqueSorted([
+		...options.runtimeAccess.literals,
+		...(options.systemToolLiterals ?? []),
+	]);
+	const executableLiterals = uniqueSorted([
+		...options.runtimeAccess.mapExecutableLiterals,
+		...(options.systemToolMapExecutableLiterals ?? []),
+	]);
+	return [
+		`(allow file-read* (literal ${schemeString(options.argv[0] ?? "")}))`,
+		...literals.map(
+			(file) => `(allow file-read* (literal ${schemeString(file)}))`,
+		),
+		...literals.map((file) => ancestorMetadataRule(file)),
+		...executableLiterals.map(
+			(file) => `(allow file-map-executable (literal ${schemeString(file)}))`,
+		),
+		...options.runtimeAccess.mapExecutableRoots.map(
+			(root) => `(allow file-map-executable (subpath ${schemeString(root)}))`,
+		),
+		...(options.systemToolRoots ?? []).map(
+			(root) => `(allow file-map-executable (subpath ${schemeString(root)}))`,
+		),
+		...readableRoots.flatMap((root) => readableRootRules(root)),
+		...ancestorRoots.flatMap((root) => ancestorDirectoryRules(root)),
+		...writableRoots.flatMap((root) => writableRootRules(root)),
+	];
+}
+
+function readableRootRules(root: string): string[] {
+	return [
+		ancestorMetadataRule(root),
+		`(allow file-read* (subpath ${schemeString(root)}))`,
+	];
+}
+
+function ancestorDirectoryRules(root: string): string[] {
+	return [
+		`(allow file-read-data (literal ${schemeString(root)}))`,
+		`(allow file-read-data (path-ancestors ${schemeString(root)}))`,
+	];
+}
+
+function writableRootRules(root: string): string[] {
+	return [
+		`(allow file-read* (literal ${schemeString(root)}))`,
+		`(allow file-read-metadata file-test-existence (literal ${schemeString(root)}))`,
+		`(allow file-write* (subpath ${schemeString(root)}))`,
+	];
+}
+
+function ancestorMetadataRule(file: string): string {
+	return `(allow file-read-metadata file-test-existence (path-ancestors ${schemeString(file)}))`;
+}
+
+function schemeString(value: string): string {
+	return JSON.stringify(value);
+}
+
+function uniqueSorted(values: string[]): string[] {
+	return [...new Set(values.filter(Boolean))].sort();
+}

--- a/goldband-loop/workflows/review-evidence.ts
+++ b/goldband-loop/workflows/review-evidence.ts
@@ -45,7 +45,14 @@ import {
 import { superviseCommand } from '../scripts/process-supervisor.mjs';
 import { stateRoot } from './evidence';
 import type { ReviewContractResolution } from './review-contract-resolution';
+import {
+  evidenceSandboxCommand,
+  isEvidenceSandboxRuntimeFailure,
+  sealedEvidenceExecutionUnavailable,
+} from './review-evidence-sandbox';
 import { resolveReviewWorkspace, workspacePath } from './review-workspace';
+
+export { isEvidenceSandboxRuntimeFailure } from './review-evidence-sandbox';
 
 const REVIEW_EVIDENCE_SCHEMA_VERSION = 1;
 const REVIEW_EVIDENCE_MANIFEST_SCHEMA_VERSION = 2;
@@ -61,31 +68,6 @@ const REVIEW_RECEIPT_TRUSTED_CONFIG_ENV = 'GOLDBAND_REVIEW_RECEIPT_TRUSTED_CONFI
 const SUPPORTED_REVIEW_HOST_EVIDENCE_LANE = 'macos-review-contract-host';
 const executableDigestCache = new Map<string, string>();
 const mockReviewReceiptAuthorityKey = randomBytes(32);
-const SYSTEM_SANDBOX_MACH_SERVICES = [
-  'com.apple.analyticsd',
-  'com.apple.analyticsd.messagetracer',
-  'com.apple.appsleep',
-  'com.apple.bsd.dirhelper',
-  'com.apple.cfprefsd.agent',
-  'com.apple.cfprefsd.daemon',
-  'com.apple.diagnosticd',
-  'com.apple.dt.automationmode.reader',
-  'com.apple.espd',
-  'com.apple.logd',
-  'com.apple.logd.events',
-  'com.apple.internal.objc_trace',
-  'com.apple.osanalytics.osanalyticshelper',
-  'com.apple.runningboard',
-  'com.apple.secinitd',
-  'com.apple.system.DirectoryService.libinfo_v1',
-  'com.apple.system.logger',
-  'com.apple.system.notification_center',
-  'com.apple.system.opendirectoryd.libinfo',
-  'com.apple.system.opendirectoryd.membership',
-  'com.apple.trustd',
-  'com.apple.trustd.agent',
-  'com.apple.xpc.activity.unmanaged',
-] as const;
 
 const DISPOSITIONS = new Set<CellDisposition>([
   'automated',
@@ -469,6 +451,18 @@ export async function executeEvidencePlan(
           throw new Error(`review evidence operation limit exceeded: ${MAX_REVIEW_EVIDENCE_OPERATIONS}`);
         }
         validateOperationAuthorization(operation, manifest);
+        if (provider.executionContext.runner === 'sealed') {
+          const unavailable = sealedEvidenceExecutionUnavailable();
+          if (unavailable) {
+            records.push(executionContextIncompleteRecord(
+              provider,
+              operation,
+              binding,
+              unavailable,
+            ));
+            continue;
+          }
+        }
         if (provider.executionContext.runner === 'host-seatbelt') {
           const unavailable = hostEvidenceExecutionUnavailable(ctx, provider);
           if (unavailable) {
@@ -503,19 +497,19 @@ export async function executeEvidencePlan(
           projectDependencyDirectories(workspace.repositoryRoot, operationRoot, input.changedFiles);
         }
         const dependencyDigest = dependencyProjectionDigest(operationRoot, binding.changedFiles);
-        const record = await runEvidenceOperation(
+        const record = await runEvidenceOperation({
           provider,
           operation,
-          operationRoot,
-          workspacePath(operationRoot, workspace.invocationOffset),
+          snapshotRoot: operationRoot,
+          executionCwd: workspacePath(operationRoot, workspace.invocationOffset),
           binding,
           dependencyDigest,
-          input.changedFiles,
+          changedFiles: input.changedFiles,
           runnerRoot,
-          join(tempRoot, 'runtime-projections'),
+          runtimeProjectionRoot: join(tempRoot, 'runtime-projections'),
           preparedRuntimes,
-          workspace.invocationOffset,
-        );
+          executionOffset: workspace.invocationOffset,
+        });
         rmSync(operationRoot, { recursive: true, force: true });
         rmSync(runnerRoot, { recursive: true, force: true });
         outputBytes += Buffer.byteLength(record.outputSummary);
@@ -1633,65 +1627,141 @@ function runtimeProjectionIdentityDigest(
   }));
 }
 
+type RunEvidenceOperationOptions = {
+  provider: EvidenceProvider;
+  operation: EvidenceOperation;
+  snapshotRoot: string;
+  executionCwd: string;
+  binding: CandidateBinding;
+  dependencyDigest: string;
+  changedFiles: string[];
+  runnerRoot: string;
+  runtimeProjectionRoot: string;
+  preparedRuntimes: Map<string, PreparedEvidenceRuntime>;
+  executionOffset: string;
+};
+
+type PreparedChildRuntime = {
+  tool: string;
+  command: string;
+  sourceAccess: EvidenceRuntimeReadAccess;
+  prepared: PreparedEvidenceRuntime;
+};
+
+type PreparedOperationRuntime = {
+  replayCommand: string[];
+  command: string;
+  runtimeAccess: EvidenceRuntimeReadAccess;
+  systemToolAccess: EvidenceSystemToolAccess;
+  preparedRuntime: PreparedEvidenceRuntime;
+  preparedChildRuntimes: PreparedChildRuntime[];
+  sandboxRuntimeAccess: EvidenceRuntimeReadAccess;
+  executionIdentityDigest: string;
+  commandDigest: string;
+};
+
+type EvidenceCommandResult = {
+  reason: string;
+  exitCode: number;
+  stdout?: string;
+  stderr?: string;
+};
+
+type EvidenceExecutionResult = {
+  startedAt: string;
+  finishedAt: string;
+  result: EvidenceCommandResult;
+  snapshotDigestBefore: string;
+  snapshotDigestAfter: string;
+  snapshotUnchanged: boolean;
+  runtimeUnchanged: boolean;
+  sandboxDenied: boolean;
+  outputDigest: string;
+  outputSummary: string;
+};
+
 async function runEvidenceOperation(
-  provider: EvidenceProvider,
-  operation: EvidenceOperation,
-  snapshotRoot: string,
-  executionCwd: string,
-  binding: CandidateBinding,
-  dependencyDigest: string,
-  changedFiles: string[],
-  runnerRoot: string,
-  runtimeProjectionRoot: string,
-  preparedRuntimes: Map<string, PreparedEvidenceRuntime>,
-  executionOffset: string,
+  options: RunEvidenceOperationOptions,
 ): Promise<ReviewEvidenceRecord> {
   const startedAt = new Date().toISOString();
-  const replayCommand = operation.argv.map((value) =>
-    value.replaceAll('{seed}', operation.seed ?? ''));
+  const runtime = prepareOperationRuntime(options);
+  const execution = await executePreparedOperation(options, runtime, startedAt);
+  return evidenceRecord(options, runtime, execution);
+}
+
+function prepareOperationRuntime(
+  options: RunEvidenceOperationOptions,
+): PreparedOperationRuntime {
+  const replayCommand = options.operation.argv.map((value) =>
+    value.replaceAll('{seed}', options.operation.seed ?? ''));
   const command = resolveExecutable(replayCommand[0]!);
   const runtimeAccess = evidenceRuntimeReadAccess(command);
-  const systemToolAccess = evidenceSystemToolAccess(operation.requiredSystemTools);
-  const preparedRuntimeKey = sha256(stableJson({
-    command,
-    sourceRuntimeDigest: runtimeAccess.identityDigest,
-    runnerPolicy: EVIDENCE_RUNNER_POLICY,
-  }));
-  let preparedRuntime = preparedRuntimes.get(preparedRuntimeKey);
-  if (!preparedRuntime) {
-    preparedRuntime = prepareEvidenceRuntime(
-      command,
-      join(runtimeProjectionRoot, preparedRuntimeKey),
-      runtimeAccess,
-    );
-    preparedRuntimes.set(preparedRuntimeKey, preparedRuntime);
-  }
-  const preparedChildRuntimes = operation.requiredSystemTools
+  const systemToolAccess = evidenceSystemToolAccess(options.operation.requiredSystemTools);
+  const preparedRuntime = cachedEvidenceRuntime(options, command, runtimeAccess);
+  const preparedChildRuntimes = options.operation.requiredSystemTools
     .filter((tool) => tool !== 'git')
-    .map((tool) => {
-      const childCommand = resolveExecutable(tool);
-      const childSourceAccess = evidenceRuntimeReadAccess(childCommand);
-      const key = sha256(stableJson({
-        command: childCommand,
-        sourceRuntimeDigest: childSourceAccess.identityDigest,
-        runnerPolicy: EVIDENCE_RUNNER_POLICY,
-      }));
-      let prepared = preparedRuntimes.get(key);
-      if (!prepared) {
-        prepared = prepareEvidenceRuntime(
-          childCommand,
-          join(runtimeProjectionRoot, key),
-          childSourceAccess,
-        );
-        preparedRuntimes.set(key, prepared);
-      }
-      return { tool, command: childCommand, sourceAccess: childSourceAccess, prepared };
-    });
+    .map((tool) => prepareChildRuntime(options, tool));
   const sandboxRuntimeAccess = mergeEvidenceRuntimeReadAccess([
     preparedRuntime.access,
     ...preparedChildRuntimes.map((entry) => entry.prepared.access),
   ]);
-  const executionIdentityDigest = sha256(stableJson({
+  return {
+    replayCommand,
+    command,
+    runtimeAccess,
+    systemToolAccess,
+    preparedRuntime,
+    preparedChildRuntimes,
+    sandboxRuntimeAccess,
+    executionIdentityDigest: operationExecutionIdentity(options, {
+      command, runtimeAccess, systemToolAccess, preparedRuntime, preparedChildRuntimes,
+    }),
+    commandDigest: operationCommandDigest(options),
+  };
+}
+
+function cachedEvidenceRuntime(
+  options: RunEvidenceOperationOptions,
+  command: string,
+  runtimeAccess: EvidenceRuntimeReadAccess,
+): PreparedEvidenceRuntime {
+  const key = sha256(stableJson({
+    command,
+    sourceRuntimeDigest: runtimeAccess.identityDigest,
+    runnerPolicy: EVIDENCE_RUNNER_POLICY,
+  }));
+  const cached = options.preparedRuntimes.get(key);
+  if (cached) return cached;
+  const prepared = prepareEvidenceRuntime(
+    command,
+    join(options.runtimeProjectionRoot, key),
+    runtimeAccess,
+  );
+  options.preparedRuntimes.set(key, prepared);
+  return prepared;
+}
+
+function prepareChildRuntime(
+  options: RunEvidenceOperationOptions,
+  tool: string,
+): PreparedChildRuntime {
+  const command = resolveExecutable(tool);
+  const sourceAccess = evidenceRuntimeReadAccess(command);
+  return {
+    tool,
+    command,
+    sourceAccess,
+    prepared: cachedEvidenceRuntime(options, command, sourceAccess),
+  };
+}
+
+function operationExecutionIdentity(
+  options: RunEvidenceOperationOptions,
+  runtime: Pick<PreparedOperationRuntime,
+    'command' | 'runtimeAccess' | 'systemToolAccess' | 'preparedRuntime' | 'preparedChildRuntimes'>,
+): string {
+  const { binding, provider, operation } = options;
+  return sha256(stableJson({
     repository: binding.repository,
     baseDigest: binding.baseDigest,
     candidateDigest: binding.candidateDigest,
@@ -1700,23 +1770,27 @@ async function runEvidenceOperation(
     providerId: provider.id,
     operationId: operation.id,
     executionContext: provider.executionContext,
-    executableDigest: executableContentDigest(command),
-    sourceRuntimeDigest: runtimeAccess.identityDigest,
-    executionRuntimeDigest: preparedRuntime.identityDigest,
-    childRuntimeDigests: preparedChildRuntimes.map((entry) => ({
+    executableDigest: executableContentDigest(runtime.command),
+    sourceRuntimeDigest: runtime.runtimeAccess.identityDigest,
+    executionRuntimeDigest: runtime.preparedRuntime.identityDigest,
+    childRuntimeDigests: runtime.preparedChildRuntimes.map((entry) => ({
       tool: entry.tool,
       source: entry.sourceAccess.identityDigest,
       execution: entry.prepared.identityDigest,
     })),
-    dependencyProjectionDigest: dependencyDigest,
-    systemToolDigest: systemToolAccess.identityDigest,
+    dependencyProjectionDigest: options.dependencyDigest,
+    systemToolDigest: runtime.systemToolAccess.identityDigest,
     runnerPolicy: EVIDENCE_RUNNER_POLICY,
     platform: process.platform,
     architecture: process.arch,
   }));
-  const commandDigest = sha256(stableJson({
+}
+
+function operationCommandDigest(options: RunEvidenceOperationOptions): string {
+  const { operation } = options;
+  return sha256(stableJson({
     argv: operation.argv,
-    cwd: executionOffset || '.',
+    cwd: options.executionOffset || '.',
     network: operation.network,
     target: operation.target,
     expectedExit: operation.expectedExit,
@@ -1725,18 +1799,21 @@ async function runEvidenceOperation(
     seed: operation.seed,
     iterations: operation.iterations,
   }));
-  const runnerTmpPath = join(runnerRoot, 'tmp');
-  const runnerHomePath = join(runnerRoot, 'home');
+}
+
+function operationRunner(
+  options: RunEvidenceOperationOptions,
+  runtime: PreparedOperationRuntime,
+): { sandbox: ReturnType<typeof evidenceSandboxCommand>; env: Record<string, string> } {
+  const runnerTmpPath = join(options.runnerRoot, 'tmp');
+  const runnerHomePath = join(options.runnerRoot, 'home');
   mkdirSync(runnerTmpPath, { recursive: true });
   mkdirSync(runnerHomePath, { recursive: true });
   const runnerTmp = realpathSync(runnerTmpPath);
   const runnerHome = realpathSync(runnerHomePath);
+  const operation = options.operation;
   const env = {
-    PATH: uniqueSorted([
-      ...systemToolAccess.executableDirectories,
-      dirname(preparedRuntime.command),
-      ...preparedChildRuntimes.map((entry) => dirname(entry.prepared.command)),
-    ]).join(':') + ':/usr/bin:/bin',
+    PATH: operationPath(runtime),
     HOME: runnerHome,
     TMPDIR: runnerTmp,
     TMP: runnerTmp,
@@ -1749,91 +1826,162 @@ async function runEvidenceOperation(
     [EVIDENCE_SANDBOX_ACTIVE_ENV]: '1',
     [EVIDENCE_TEMP_ROOT_ENV]: runnerTmp,
     CI: '1',
-    OPENSSL_CONF: preparedRuntime.environment.OPENSSL_CONF ?? '/dev/null',
+    OPENSSL_CONF: runtime.preparedRuntime.environment.OPENSSL_CONF ?? '/dev/null',
   };
-  const sandbox = evidenceSandboxCommand(
-    snapshotRoot,
-    [runnerTmp, runnerHome],
-    [preparedRuntime.command, ...replayCommand.slice(1)],
-    sandboxRuntimeAccess,
-    systemToolAccess.roots,
-    systemToolAccess.literals,
-    systemToolAccess.mapExecutableLiterals,
+  const sandbox = evidenceSandboxCommand({
+    cwd: options.snapshotRoot,
+    writableRoots: [runnerTmp, runnerHome],
+    argv: [runtime.preparedRuntime.command, ...runtime.replayCommand.slice(1)],
+    runtimeAccess: runtime.sandboxRuntimeAccess,
+    systemToolRoots: runtime.systemToolAccess.roots,
+    systemToolLiterals: runtime.systemToolAccess.literals,
+    systemToolMapExecutableLiterals: runtime.systemToolAccess.mapExecutableLiterals,
+  });
+  return { sandbox, env };
+}
+
+function operationPath(runtime: PreparedOperationRuntime): string {
+  return uniqueSorted([
+    ...runtime.systemToolAccess.executableDirectories,
+    dirname(runtime.preparedRuntime.command),
+    ...runtime.preparedChildRuntimes.map((entry) => dirname(entry.prepared.command)),
+  ]).join(':') + ':/usr/bin:/bin';
+}
+
+async function executePreparedOperation(
+  options: RunEvidenceOperationOptions,
+  runtime: PreparedOperationRuntime,
+  startedAt: string,
+): Promise<EvidenceExecutionResult> {
+  const ignored = dependencyRelativePaths(options.changedFiles);
+  const snapshotDigestBefore = snapshotContentDigest(options.snapshotRoot, ignored);
+  const runner = operationRunner(options, runtime);
+  const capture = await captureEvidenceCommand(options, runner);
+  const finishedAt = new Date().toISOString();
+  const snapshotDigestAfter = snapshotContentDigest(options.snapshotRoot, ignored);
+  const snapshotUnchanged = snapshotDigestBefore === snapshotDigestAfter;
+  const runtimeUnchanged = operationRuntimeUnchanged(runtime);
+  const sandboxDenied = isEvidenceSandboxRuntimeFailure(
+    runner.sandbox.command,
+    {
+      reason: capture.result.reason,
+      exitCode: capture.result.exitCode,
+      stderr: capture.stderrDiagnosticHead,
+    },
+    runner.sandbox.brokered,
   );
-  const ignoredDependencies = dependencyRelativePaths(changedFiles);
-  const snapshotDigestBefore = snapshotContentDigest(snapshotRoot, ignoredDependencies);
+  const outputSummary = summarizeEvidenceExecution(
+    options.operation,
+    capture.result,
+    { snapshotUnchanged, runtimeUnchanged, sandboxDenied },
+  );
+  return {
+    startedAt,
+    finishedAt,
+    result: capture.result,
+    snapshotDigestBefore,
+    snapshotDigestAfter,
+    snapshotUnchanged,
+    runtimeUnchanged,
+    sandboxDenied,
+    outputDigest: capture.outputDigest,
+    outputSummary,
+  };
+}
+
+async function captureEvidenceCommand(
+  options: RunEvidenceOperationOptions,
+  runner: ReturnType<typeof operationRunner>,
+): Promise<{
+  result: EvidenceCommandResult;
+  outputDigest: string;
+  stderrDiagnosticHead: string;
+}> {
   const stdoutHash = createHash('sha256');
   const stderrHash = createHash('sha256');
   let stderrDiagnosticHead = '';
-  let result: {
-    reason: string;
-    exitCode: number;
-    stdout?: string;
-    stderr?: string;
-  };
-  result = await superviseCommand(sandbox.command, sandbox.args, {
-      cwd: executionCwd,
-      env,
-      timeoutMs: operation.timeoutMs,
-      killGraceMs: 1000,
-      killConfirmMs: 2000,
-      captureOutput: {
-        stdoutMaxBytes: operation.maxOutputBytes,
-        stderrMaxBytes: operation.maxOutputBytes,
+  const result = await superviseCommand(runner.sandbox.command, runner.sandbox.args, {
+    cwd: options.executionCwd,
+    env: runner.env,
+    timeoutMs: options.operation.timeoutMs,
+    killGraceMs: 1000,
+    killConfirmMs: 2000,
+    captureOutput: {
+      stdoutMaxBytes: options.operation.maxOutputBytes,
+      stderrMaxBytes: options.operation.maxOutputBytes,
+    },
+    label: `review evidence ${options.provider.id}:${options.operation.id}`,
+    stdout: { write(chunk: string) { stdoutHash.update(chunk); } },
+    stderr: {
+      write(chunk: string) {
+        stderrHash.update(chunk);
+        const remaining = MAX_EVIDENCE_RUNTIME_DIAGNOSTIC_CHARS - stderrDiagnosticHead.length;
+        if (remaining > 0) stderrDiagnosticHead += chunk.slice(0, remaining);
       },
-      label: `review evidence ${provider.id}:${operation.id}`,
-      stdout: { write(chunk: string) { stdoutHash.update(chunk); } },
-      stderr: {
-        write(chunk: string) {
-          stderrHash.update(chunk);
-          const remaining = MAX_EVIDENCE_RUNTIME_DIAGNOSTIC_CHARS - stderrDiagnosticHead.length;
-          if (remaining > 0) stderrDiagnosticHead += chunk.slice(0, remaining);
-        },
-      },
+    },
   });
-  const finishedAt = new Date().toISOString();
-  const snapshotDigestAfter = snapshotContentDigest(snapshotRoot, ignoredDependencies);
-  const snapshotUnchanged = snapshotDigestBefore === snapshotDigestAfter;
-  let runtimeUnchanged = false;
+  return {
+    result,
+    outputDigest: sha256(`${stdoutHash.digest('hex')}:${stderrHash.digest('hex')}`),
+    stderrDiagnosticHead,
+  };
+}
+
+function operationRuntimeUnchanged(runtime: PreparedOperationRuntime): boolean {
   try {
-    runtimeUnchanged = evidenceRuntimeReadAccess(command).identityDigest === runtimeAccess.identityDigest &&
-      systemToolAccess.verifyUnchanged() &&
-      preparedRuntime.verifyUnchanged() &&
-      preparedChildRuntimes.every((entry) =>
+    return evidenceRuntimeReadAccess(runtime.command).identityDigest === runtime.runtimeAccess.identityDigest &&
+      runtime.systemToolAccess.verifyUnchanged() &&
+      runtime.preparedRuntime.verifyUnchanged() &&
+      runtime.preparedChildRuntimes.every((entry) =>
         evidenceRuntimeReadAccess(entry.command).identityDigest === entry.sourceAccess.identityDigest &&
         entry.prepared.verifyUnchanged());
   } catch {
-    runtimeUnchanged = false;
+    return false;
   }
-  const combined = [result.stdout ?? '', result.stderr ?? ''].filter(Boolean).join('\n');
-  const outputSummary = boundText(combined, operation.maxOutputBytes);
-  const sandboxDenied = isEvidenceSandboxRuntimeFailure(sandbox.command, {
-    reason: result.reason,
-    exitCode: result.exitCode,
-    stderr: stderrDiagnosticHead,
-  }, sandbox.brokered);
-  let status: EvidenceRecordStatus;
-  const exitStatus = result.reason === 'exit' ? result.exitCode : undefined;
-  if (result.reason !== 'exit') {
-    status = 'runtime-incomplete';
-  } else if (!snapshotUnchanged || !runtimeUnchanged || sandboxDenied) {
-    status = 'runtime-incomplete';
-  } else {
-    const matched = operation.expectedExit === 'zero'
-      ? result.exitCode === 0
-      : result.exitCode === operation.expectedExitCode;
-    status = matched ? 'verified-pass' : 'verified-failure';
+}
+
+function evidenceStatus(
+  operation: EvidenceOperation,
+  execution: EvidenceExecutionResult,
+): EvidenceRecordStatus {
+  if (execution.result.reason !== 'exit' ||
+      !execution.snapshotUnchanged || !execution.runtimeUnchanged || execution.sandboxDenied) {
+    return 'runtime-incomplete';
   }
-  const errorText = result.reason !== 'exit'
-    ? `runner incomplete: ${result.reason}`
-    : !snapshotUnchanged
-      ? 'runner incomplete: evidence operation mutated its isolated candidate snapshot'
-      : !runtimeUnchanged
-        ? 'runner incomplete: executable runtime libraries changed during evidence execution'
-      : sandboxDenied
-        ? 'runner incomplete: sandbox-exec denied or could not initialize the operation'
-        : '';
-  const summary = boundText([outputSummary, errorText].filter(Boolean).join('\n'), operation.maxOutputBytes);
+  const matched = operation.expectedExit === 'zero'
+    ? execution.result.exitCode === 0
+    : execution.result.exitCode === operation.expectedExitCode;
+  return matched ? 'verified-pass' : 'verified-failure';
+}
+
+function summarizeEvidenceExecution(
+  operation: EvidenceOperation,
+  result: EvidenceCommandResult,
+  integrity: Pick<EvidenceExecutionResult, 'snapshotUnchanged' | 'runtimeUnchanged' | 'sandboxDenied'>,
+): string {
+  const output = boundText(
+    [result.stdout ?? '', result.stderr ?? ''].filter(Boolean).join('\n'),
+    operation.maxOutputBytes,
+  );
+  let error = '';
+  if (result.reason !== 'exit') error = `runner incomplete: ${result.reason}`;
+  else if (!integrity.snapshotUnchanged) {
+    error = 'runner incomplete: evidence operation mutated its isolated candidate snapshot';
+  } else if (!integrity.runtimeUnchanged) {
+    error = 'runner incomplete: executable runtime libraries changed during evidence execution';
+  } else if (integrity.sandboxDenied) {
+    error = 'runner incomplete: sandbox-exec denied or could not initialize the operation';
+  }
+  return boundText([output, error].filter(Boolean).join('\n'), operation.maxOutputBytes);
+}
+
+function evidenceRecord(
+  options: RunEvidenceOperationOptions,
+  runtime: PreparedOperationRuntime,
+  execution: EvidenceExecutionResult,
+): ReviewEvidenceRecord {
+  const { provider, operation, binding } = options;
+  const status = evidenceStatus(operation, execution);
   return {
     id: `${provider.id}:${operation.id}`,
     providerId: provider.id,
@@ -1846,119 +1994,23 @@ async function runEvidenceOperation(
     environment: provider.executionContext.runner === 'host-seatbelt'
       ? `${provider.executionContext.lane}/host-seatbelt-${process.platform}-snapshot`
       : `isolated-${process.platform}-snapshot`,
-    commandDigest,
-    executionIdentityDigest,
-    snapshotDigestBefore,
-    snapshotDigestAfter,
-    replayCommand,
+    commandDigest: runtime.commandDigest,
+    executionIdentityDigest: runtime.executionIdentityDigest,
+    snapshotDigestBefore: execution.snapshotDigestBefore,
+    snapshotDigestAfter: execution.snapshotDigestAfter,
+    replayCommand: runtime.replayCommand,
     seed: operation.seed,
     iterations: operation.iterations,
-    startedAt,
-    finishedAt,
-    exitStatus,
-    outputDigest: sha256(`${stdoutHash.digest('hex')}:${stderrHash.digest('hex')}`),
-    outputSummary: summary,
+    startedAt: execution.startedAt,
+    finishedAt: execution.finishedAt,
+    exitStatus: execution.result.reason === 'exit' ? execution.result.exitCode : undefined,
+    outputDigest: execution.outputDigest,
+    outputSummary: execution.outputSummary,
     candidateDigest: binding.candidateDigest,
     baseDigest: binding.baseDigest,
     scopeDigest: binding.scopeDigest,
-    fresh: snapshotUnchanged && runtimeUnchanged && status !== 'runtime-incomplete',
+    fresh: execution.snapshotUnchanged && execution.runtimeUnchanged && status !== 'runtime-incomplete',
   };
-}
-
-function evidenceSandboxCommand(
-  cwd: string,
-  writableRoots: string[],
-  argv: string[],
-  runtimeAccess: EvidenceRuntimeReadAccess,
-  systemToolRoots: string[] = [],
-  systemToolLiterals: string[] = [],
-  systemToolMapExecutableLiterals: string[] = [],
-): { command: string; args: string[]; brokered: boolean } {
-  if (process.platform === 'darwin' && existsSync('/usr/bin/sandbox-exec')) {
-    const readableCwd = realpathSync(cwd);
-    const realWritableRoots = writableRoots.map((root) => realpathSync(root));
-    const allowedWrites = realWritableRoots.map((root) =>
-      `(allow file-write* (subpath ${JSON.stringify(root)}))`);
-    const allowedWritableRootLiterals = realWritableRoots.flatMap((root) => [
-      `(allow file-read* (literal ${JSON.stringify(root)}))`,
-      `(allow file-read-metadata file-test-existence (literal ${JSON.stringify(root)}))`,
-    ]);
-    const allowedReads = uniqueSorted([
-      readableCwd,
-      ...realWritableRoots,
-      ...runtimeAccess.roots,
-      ...systemToolRoots,
-    ]).map((root) => `(allow file-read* (subpath ${JSON.stringify(root)}))`);
-    const allowedReadMetadata = uniqueSorted([
-      readableCwd,
-      ...realWritableRoots,
-      ...runtimeAccess.roots,
-      ...systemToolRoots,
-    ]).map((root) =>
-      `(allow file-read-metadata file-test-existence (path-ancestors ${JSON.stringify(root)}))`);
-    // Bun and script launchers open ancestor directories while changing from
-    // the operation cwd into an authorized runtime root. Permit traversal of
-    // those directories without granting reads of sibling file contents.
-    const allowedAncestorDirectories = uniqueSorted([
-      readableCwd,
-      ...runtimeAccess.roots,
-      ...systemToolRoots,
-    ]).flatMap((root) => [
-      `(allow file-read-data (literal ${JSON.stringify(root)}))`,
-      `(allow file-read-data (path-ancestors ${JSON.stringify(root)}))`,
-    ]);
-    const runtimeLiteralReads = uniqueSorted([...runtimeAccess.literals, ...systemToolLiterals])
-      .map((file) => `(allow file-read* (literal ${JSON.stringify(file)}))`);
-    const runtimeExecutableMaps = uniqueSorted([
-      ...runtimeAccess.mapExecutableLiterals,
-      ...systemToolMapExecutableLiterals,
-    ])
-      .map((file) => `(allow file-map-executable (literal ${JSON.stringify(file)}))`);
-    const runtimeExecutableMapRoots = uniqueSorted(runtimeAccess.mapExecutableRoots)
-      .map((root) => `(allow file-map-executable (subpath ${JSON.stringify(root)}))`);
-    const systemToolExecutableMapRoots = uniqueSorted(systemToolRoots)
-      .map((root) => `(allow file-map-executable (subpath ${JSON.stringify(root)}))`);
-    const runtimeLiteralMetadata = uniqueSorted([...runtimeAccess.literals, ...systemToolLiterals])
-      .map((file) =>
-        `(allow file-read-metadata file-test-existence (path-ancestors ${JSON.stringify(file)}))`);
-    const deniedSystemMachServices = SYSTEM_SANDBOX_MACH_SERVICES
-      .map((name) => `(global-name ${JSON.stringify(name)})`);
-    const profile = [
-      '(version 1)',
-      '(deny default)',
-      '(import "system.sb")',
-      '(deny network*)',
-      '(deny network-outbound (literal "/private/var/run/syslog"))',
-      '(deny mach-lookup)',
-      `(deny mach-lookup ${deniedSystemMachServices.join(' ')} (local-name "com.apple.cfprefsd.agent"))`,
-      `(if (defined? 'system-socket) (deny system-socket))`,
-      '(deny ipc-posix-shm-read* (ipc-posix-name "apple.shm.notification_center") (ipc-posix-name-prefix "apple.cfprefs."))',
-      '(allow process-exec)',
-      '(allow process-fork)',
-      '(allow signal (target self))',
-      '(allow signal (target children))',
-      '(allow sysctl-read)',
-      '(allow file-read* (literal "/dev/null"))',
-      '(allow file-write* (literal "/dev/null"))',
-      `(allow file-read* (literal ${JSON.stringify(argv[0])}))`,
-      ...runtimeLiteralMetadata,
-      ...runtimeLiteralReads,
-      ...runtimeExecutableMaps,
-      ...runtimeExecutableMapRoots,
-      ...systemToolExecutableMapRoots,
-      ...allowedAncestorDirectories,
-      ...allowedReadMetadata,
-      ...allowedReads,
-      ...allowedWritableRootLiterals,
-      ...allowedWrites,
-    ].join(' ');
-    return {
-      command: '/usr/bin/sandbox-exec',
-      args: ['-p', profile, '--', ...argv],
-      brokered: false,
-    };
-  }
-  throw new Error('review evidence runner requires a supported OS network/filesystem sandbox');
 }
 
 export type EvidenceRuntimeReadAccess = {
@@ -2102,22 +2154,6 @@ export function evidenceRuntimeReadAccess(executable: string): EvidenceRuntimeRe
       missingWeakLinks,
     })),
   };
-}
-
-export function isEvidenceSandboxRuntimeFailure(
-  sandboxCommand: string,
-  result: { reason: string; exitCode: number; stderr?: string },
-  brokered = false,
-): boolean {
-  if ((!brokered && sandboxCommand !== '/usr/bin/sandbox-exec') || result.reason !== 'exit') return false;
-  const stderr = result.stderr ?? '';
-  const brokerFailed = brokered && result.exitCode === 71 &&
-    /^evidence sandbox broker (?:rejected request|timed out|response)/im.test(stderr);
-  const sandboxInitializationFailed = result.exitCode === 71 &&
-    /^(?:sandbox-exec:|sandbox_init:)/im.test(stderr);
-  const dynamicLoaderFailedBeforeMain = result.exitCode !== 0 &&
-    /^dyld\[\d+\]:/m.test(stderr);
-  return brokerFailed || sandboxInitializationFailed || dynamicLoaderFailedBeforeMain;
 }
 
 export function runtimeLibraryLiteralPaths(
@@ -2608,6 +2644,9 @@ function executionContextIncompleteRecord(
   const expected = `${provider.executionContext.runner}/${provider.executionContext.sandboxOwner}`;
   const actual = unavailable.actual;
   const lane = provider.executionContext.runner === 'host-seatbelt' ? provider.executionContext.lane : 'none';
+  const remediation = provider.executionContext.runner === 'host-seatbelt'
+    ? `run the named deterministic host lane ${lane}; do not execute this provider inside sealed review evidence`
+    : 'run review/code on a supported macOS Seatbelt host; Linux and Windows do not currently execute sealed review evidence';
   const outputSummary = [
     `contract owner=${provider.owner}`,
     `actual=${actual}`,
@@ -2615,7 +2654,7 @@ function executionContextIncompleteRecord(
     `scope=${binding.scopeDigest}`,
     `executionContext=${stableJson(provider.executionContext)}`,
     `detail=${unavailable.detail}`,
-    `fix=run the named deterministic host lane ${lane}; do not execute this provider inside sealed review evidence`,
+    `fix=${remediation}`,
   ].join('; ');
   return {
     id: `${provider.id}:${operation.id}`,

--- a/goldband-loop/workflows/review-evidence.ts
+++ b/goldband-loop/workflows/review-evidence.ts
@@ -1106,6 +1106,7 @@ function validateReviewEvidenceManifest(
   binding?: CandidateBinding,
 ): ReviewEvidenceManifest {
   const item = asObject(value, 'review evidence manifest');
+  assertAllowedKeys(item, ['schemaVersion', 'behaviorMatrix', 'providers', 'authorizations'], 'review evidence manifest');
   if (item.schemaVersion !== REVIEW_EVIDENCE_MANIFEST_SCHEMA_VERSION) {
     throw new Error(
       `review evidence manifest schema incompatibility: observed ${String(item.schemaVersion)}, supported ${REVIEW_EVIDENCE_MANIFEST_SCHEMA_VERSION}; migrate the source manifest explicitly and supply lifecycle, applicability, and executionContext without guessed defaults`,
@@ -1118,22 +1119,13 @@ function validateReviewEvidenceManifest(
   if (!Array.isArray(item.authorizations)) throw new Error('review evidence manifest.authorizations must be an array');
   const behaviorMatrix = item.behaviorMatrix.map(validateBehaviorCell);
   const providers = item.providers.map(validateEvidenceProvider);
-  const authorizations = item.authorizations.map((value) => {
-    const auth = asObject(value, 'evidence authorization');
-    return {
-      id: requiredId(auth.id, 'authorization.id'),
-      operation: requiredString(auth.operation, 'authorization.operation'),
-      scope: requiredString(auth.scope, 'authorization.scope'),
-      approvedBy: requiredString(auth.approvedBy, 'authorization.approvedBy'),
-      approvedAt: validDate(auth.approvedAt, 'authorization.approvedAt'),
-      expiresAt: validDate(auth.expiresAt, 'authorization.expiresAt'),
-    };
-  });
+  const authorizations = item.authorizations.map(validateEvidenceAuthorization);
   assertUnique(behaviorMatrix.map((cell) => cell.id), 'behavior cell');
   assertUnique(providers.map((provider) => provider.id), 'evidence provider');
   assertUnique(authorizations.map((authorization) => authorization.id), 'evidence authorization');
   const cellIds = new Set(behaviorMatrix.map((cell) => cell.id));
   const providerIds = new Set(providers.map((provider) => provider.id));
+  assertAuthorizationReferences(authorizations, providers);
   for (const cell of behaviorMatrix) {
     for (const providerId of cell.providerIds) {
       if (!providerIds.has(providerId)) throw new Error(`behavior cell ${cell.id} references unknown provider ${providerId}`);
@@ -1168,8 +1160,49 @@ function validateReviewEvidenceManifest(
   return { schemaVersion: 2, behaviorMatrix, providers, authorizations };
 }
 
+function validateEvidenceAuthorization(value: unknown): ReviewEvidenceManifest['authorizations'][number] {
+  const item = asObject(value, 'evidence authorization');
+  assertAllowedKeys(item, ['id', 'operation', 'scope', 'approvedBy', 'approvedAt', 'expiresAt'], 'evidence authorization');
+  const authorization = {
+    id: requiredId(item.id, 'authorization.id'),
+    operation: requiredString(item.operation, 'authorization.operation'),
+    scope: requiredString(item.scope, 'authorization.scope'),
+    approvedBy: requiredString(item.approvedBy, 'authorization.approvedBy'),
+    approvedAt: validDate(item.approvedAt, 'authorization.approvedAt'),
+    expiresAt: validDate(item.expiresAt, 'authorization.expiresAt'),
+  };
+  if (Date.parse(authorization.expiresAt) <= Date.parse(authorization.approvedAt)) {
+    throw new Error(`evidence authorization ${authorization.id} must expire after approval`);
+  }
+  return authorization;
+}
+
+function assertAuthorizationReferences(
+  authorizations: ReviewEvidenceManifest['authorizations'],
+  providers: EvidenceProvider[],
+): void {
+  const operations = providers.flatMap((provider) => provider.operations);
+  for (const operation of operations.filter((entry) => entry.authorizationId)) {
+    const matches = authorizations.filter((authorization) =>
+      authorization.id === operation.authorizationId && authorization.operation === operation.id
+    );
+    if (matches.length !== 1) {
+      throw new Error(`network operation ${operation.id} authorization is missing or mismatched`);
+    }
+  }
+  for (const authorization of authorizations) {
+    const matches = operations.filter((operation) =>
+      operation.id === authorization.operation && operation.authorizationId === authorization.id
+    );
+    if (matches.length !== 1) {
+      throw new Error(`evidence authorization ${authorization.id} must be referenced by exactly one operation ${authorization.operation}`);
+    }
+  }
+}
+
 function validateBehaviorCell(value: unknown): BehaviorCell {
   const item = asObject(value, 'behavior cell');
+  assertAllowedKeys(item, ['id', 'behavior', 'kind', 'input', 'preconditions', 'expected', 'risk', 'disposition', 'providerIds', 'reason'], 'behavior cell');
   const kind = requiredString(item.kind, 'behavior cell.kind');
   if (!['normal', 'branch', 'exception', 'boundary'].includes(kind)) {
     throw new Error(`invalid behavior cell kind: ${kind}`);
@@ -1178,7 +1211,8 @@ function validateBehaviorCell(value: unknown): BehaviorCell {
   if (!RISKS.has(risk)) throw new Error(`invalid behavior cell risk: ${risk}`);
   const disposition = requiredString(item.disposition, 'behavior cell.disposition') as CellDisposition;
   if (!DISPOSITIONS.has(disposition)) throw new Error(`invalid behavior cell disposition: ${disposition}`);
-  const providerIds = optionalIdArray(item.providerIds, 'behavior cell.providerIds') ?? [];
+  const providerIds = requiredIdList(item.providerIds, 'behavior cell.providerIds');
+  assertUnique(providerIds, 'behavior cell provider');
   const reason = optionalString(item.reason);
   if (['not-applicable', 'unsupported', 'manual'].includes(disposition) && !reason) {
     throw new Error(`behavior cell ${String(item.id)} disposition ${disposition} requires a reason`);
@@ -1202,6 +1236,7 @@ function validateBehaviorCell(value: unknown): BehaviorCell {
 
 function validateEvidenceProvider(value: unknown): EvidenceProvider {
   const item = asObject(value, 'evidence provider');
+  assertAllowedKeys(item, ['id', 'owner', 'kind', 'lifecycle', 'cellIds', 'applicability', 'executionContext', 'transitionBinding', 'operations'], 'evidence provider');
   const kind = requiredString(item.kind, 'evidence provider.kind') as EvidenceProviderKind;
   if (!KINDS.has(kind)) throw new Error(`invalid evidence provider kind: ${kind}`);
   if (!Array.isArray(item.operations) || item.operations.length === 0) {
@@ -1214,6 +1249,7 @@ function validateEvidenceProvider(value: unknown): EvidenceProvider {
   const applicability = validateEvidenceApplicability(item.applicability);
   const executionContext = validateEvidenceExecutionContext(item.executionContext);
   const operations = item.operations.map(validateEvidenceOperation);
+  const cellIds = requiredUniqueIdArray(item.cellIds, 'evidence provider.cellIds');
   const transitionBinding =
     item.transitionBinding === undefined ? undefined : validateTransitionEvidenceBinding(item.transitionBinding);
   if (lifecycle === 'persistent' && transitionBinding) {
@@ -1227,7 +1263,7 @@ function validateEvidenceProvider(value: unknown): EvidenceProvider {
     owner: requiredString(item.owner, 'evidence provider.owner'),
     kind,
     lifecycle,
-    cellIds: requiredIdArray(item.cellIds, 'evidence provider.cellIds'),
+    cellIds,
     applicability,
     executionContext,
     transitionBinding,
@@ -1237,9 +1273,14 @@ function validateEvidenceProvider(value: unknown): EvidenceProvider {
 
 function validateEvidenceApplicability(value: unknown): EvidenceApplicability {
   const item = asObject(value, 'evidence provider.applicability');
+  assertAllowedKeys(item, ['kind', 'pathPrefixes', 'reason'], 'evidence provider.applicability');
   const kind = requiredString(item.kind, 'evidence provider.applicability.kind');
   if (kind === 'paths') {
-    const pathPrefixes = requiredStringArray(item.pathPrefixes, 'evidence provider.applicability.pathPrefixes');
+    if (!Array.isArray(item.pathPrefixes) || item.pathPrefixes.length === 0) {
+      throw new Error('evidence provider.applicability.pathPrefixes must be a non-empty string array');
+    }
+    const pathPrefixes = item.pathPrefixes.map(validateApplicabilityPathPrefix);
+    assertUniqueValues(pathPrefixes, 'evidence applicability path prefixes');
     if (item.reason !== undefined) {
       throw new Error('path-scoped evidence provider applicability cannot declare a global reason');
     }
@@ -1257,8 +1298,20 @@ function validateEvidenceApplicability(value: unknown): EvidenceApplicability {
   throw new Error(`invalid evidence provider applicability kind: ${kind}`);
 }
 
+function validateApplicabilityPathPrefix(value: unknown): string {
+  if (typeof value !== 'string' || value.trim() !== value || value === '') {
+    throw new Error('evidence applicability path prefix must be a normalized repo-relative path');
+  }
+  const segments = value.split('/');
+  if (value.startsWith('/') || /^[A-Za-z]:\//.test(value) || value.includes('\\') || segments.some((segment) => !segment || segment === '.' || segment === '..')) {
+    throw new Error(`invalid evidence applicability path prefix: ${value}`);
+  }
+  return value;
+}
+
 function validateEvidenceExecutionContext(value: unknown): EvidenceExecutionContext {
   const item = asObject(value, 'evidence provider.executionContext');
+  assertAllowedKeys(item, ['sandboxOwner', 'runner', 'lane'], 'evidence provider.executionContext');
   const sandboxOwner = requiredString(item.sandboxOwner, 'evidence provider.executionContext.sandboxOwner');
   const runner = requiredString(item.runner, 'evidence provider.executionContext.runner');
   if (sandboxOwner === 'review-runtime' && runner === 'sealed') {
@@ -1279,6 +1332,7 @@ function validateEvidenceExecutionContext(value: unknown): EvidenceExecutionCont
 
 function validateTransitionEvidenceBinding(value: unknown): TransitionEvidenceBinding {
   const item = asObject(value, 'evidence provider.transitionBinding');
+  assertAllowedKeys(item, ['repository', 'baseDigest', 'candidateDigest', 'scopeDigest', 'operationContractDigest'], 'evidence provider.transitionBinding');
   const result = {
     repository: requiredString(item.repository, 'transitionBinding.repository'),
     baseDigest: requiredString(item.baseDigest, 'transitionBinding.baseDigest'),
@@ -1295,14 +1349,14 @@ function validateTransitionEvidenceBinding(value: unknown): TransitionEvidenceBi
 
 function validateEvidenceOperation(value: unknown): EvidenceOperation {
   const item = asObject(value, 'evidence operation');
+  assertAllowedKeys(item, ['id', 'target', 'argv', 'expectedExit', 'expectedExitCode', 'timeoutMs', 'maxOutputBytes', 'network', 'authorizationId', 'evidenceLevel', 'requiredSystemTools', 'seed', 'iterations'], 'evidence operation');
   const target = requiredString(item.target, 'evidence operation.target');
   if (target !== 'base' && target !== 'candidate') throw new Error(`invalid evidence operation target: ${target}`);
   const expectedExit = requiredString(item.expectedExit, 'evidence operation.expectedExit');
   if (expectedExit !== 'zero' && expectedExit !== 'nonzero') {
     throw new Error(`invalid evidence operation.expectedExit: ${expectedExit}`);
   }
-  const network = requiredString(item.network, 'evidence operation.network');
-  if (network !== 'deny' && network !== 'authorized') throw new Error(`invalid evidence operation.network: ${network}`);
+  const { network, authorizationId } = validateOperationNetwork(item);
   const evidenceLevel = requiredString(item.evidenceLevel, 'evidence operation.evidenceLevel') as EvidenceLevel;
   if (!LEVELS.has(evidenceLevel)) throw new Error(`invalid evidence level: ${evidenceLevel}`);
   if (
@@ -1317,15 +1371,7 @@ function validateEvidenceOperation(value: unknown): EvidenceOperation {
   if (argv[0]!.includes('/') || argv[0]!.includes('\\')) {
     throw new Error('evidence operation executable must be a PATH-resolved command name');
   }
-  const requiredSystemTools = optionalStringArray(
-    item.requiredSystemTools,
-    'evidence operation.requiredSystemTools',
-  );
-  for (const tool of requiredSystemTools) {
-    if (!/^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/.test(tool)) {
-      throw new Error(`invalid evidence system tool name: ${tool}`);
-    }
-  }
+  const requiredSystemTools = validateRequiredSystemTools(item.requiredSystemTools);
   const timeoutMs = boundedInteger(item.timeoutMs, 'evidence operation.timeoutMs', 100, 15 * 60 * 1000);
   const maxOutputBytes = boundedInteger(
     item.maxOutputBytes,
@@ -1350,8 +1396,8 @@ function validateEvidenceOperation(value: unknown): EvidenceOperation {
     expectedExitCode,
     timeoutMs,
     maxOutputBytes,
-    network: network as EvidenceOperation['network'],
-    authorizationId: optionalString(item.authorizationId),
+    network,
+    authorizationId,
     evidenceLevel,
     requiredSystemTools: uniqueSorted(requiredSystemTools),
     seed: optionalString(item.seed),
@@ -1359,6 +1405,30 @@ function validateEvidenceOperation(value: unknown): EvidenceOperation {
       ? undefined
       : boundedInteger(item.iterations, 'evidence operation.iterations', 1, 1_000_000),
   };
+}
+
+function validateOperationNetwork(item: Record<string, unknown>): Pick<EvidenceOperation, 'network' | 'authorizationId'> {
+  const network = requiredString(item.network, 'evidence operation.network');
+  if (network !== 'deny' && network !== 'authorized') throw new Error(`invalid evidence operation.network: ${network}`);
+  const authorizationId = optionalString(item.authorizationId);
+  if (network === 'authorized' && !authorizationId) {
+    throw new Error(`network operation ${String(item.id)} requires typed authorization`);
+  }
+  if (network === 'deny' && authorizationId) {
+    throw new Error(`network-denied operation ${String(item.id)} cannot carry authorization`);
+  }
+  return { network, authorizationId };
+}
+
+function validateRequiredSystemTools(value: unknown): string[] {
+  const tools = optionalStringArray(value, 'evidence operation.requiredSystemTools');
+  assertUniqueValues(tools, 'evidence operation requiredSystemTools');
+  for (const tool of tools) {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/.test(tool)) {
+      throw new Error(`invalid evidence system tool name: ${tool}`);
+    }
+  }
+  return tools;
 }
 
 function validateProviderContract(provider: EvidenceProvider): void {
@@ -3173,6 +3243,12 @@ function asObject(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+function assertAllowedKeys(value: Record<string, unknown>, allowed: readonly string[], label: string): void {
+  const allowedKeys = new Set(allowed);
+  const unknown = Object.keys(value).filter((key) => !allowedKeys.has(key)).sort();
+  if (unknown.length > 0) throw new Error(`${label} contains unknown fields: ${unknown.join(', ')}`);
+}
+
 function requiredString(value: unknown, label: string): string {
   if (typeof value !== 'string' || value.trim() === '') throw new Error(`${label} must be a non-empty string`);
   return value.trim();
@@ -3205,6 +3281,17 @@ function requiredIdArray(value: unknown, label: string): string[] {
   return requiredStringArray(value, label).map((entry) => requiredId(entry, label));
 }
 
+function requiredUniqueIdArray(value: unknown, label: string): string[] {
+  const ids = requiredIdArray(value, label);
+  assertUnique(ids, label);
+  return ids;
+}
+
+function requiredIdList(value: unknown, label: string): string[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an ID array`);
+  return value.map((entry) => requiredId(entry, label));
+}
+
 function optionalIdArray(value: unknown, label: string): string[] | undefined {
   if (value === undefined || value === null) return undefined;
   if (!Array.isArray(value)) throw new Error(`${label} must be an ID array`);
@@ -3226,6 +3313,10 @@ function validDate(value: unknown, label: string): string {
 
 function assertUnique(values: string[], label: string): void {
   if (new Set(values).size !== values.length) throw new Error(`${label} IDs must be unique`);
+}
+
+function assertUniqueValues(values: string[], label: string): void {
+  if (new Set(values).size !== values.length) throw new Error(`${label} must be unique`);
 }
 
 function assertSha256(value: unknown, label: string): void {

--- a/goldband-loop/workflows/review-evidence.ts
+++ b/goldband-loop/workflows/review-evidence.ts
@@ -431,7 +431,7 @@ export async function executeEvidencePlan(
   const tempRoot = mkdtempSync(join(tempParent, 'review-evidence-'));
   const records: ReviewEvidenceRecord[] = [];
   const preparedRuntimes = new Map<string, PreparedEvidenceRuntime>();
-  const workspace = resolveReviewWorkspace(ctx.cwd);
+  const workspace = verifiedReviewWorkspace(ctx.cwd, input.diff, binding.redactedUntrackedFiles);
   let outputBytes = 0;
   try {
     const selectedCells = effectiveEvidenceCells(manifest, binding.changedFiles, onlyCellIds);
@@ -2482,6 +2482,35 @@ function materializeRedactedUntrackedFiles(
     mkdirSync(dirname(destination), { recursive: true });
     writeFileSync(destination, content, { mode: mode === '100755' ? 0o755 : 0o644, flag: 'wx' });
   }
+}
+
+function verifyRedactedUntrackedProjection(
+  repo: string,
+  diff: string,
+  expected: CandidateBinding['redactedUntrackedFiles'],
+): void {
+  const expectedByPath = new Map(expected.map((entry) => [entry.path, entry]));
+  const observedPaths = skippedUntrackedSections(diff).map((entry) => entry.path).sort();
+  if (stableJson(observedPaths) !== stableJson([...expectedByPath.keys()].sort())) {
+    throw new Error('review evidence redacted untracked projection does not match candidate diff');
+  }
+  for (const { path } of skippedUntrackedSections(diff)) {
+    const { content, mode } = readBoundedRedactedUntrackedFile(repo, path);
+    const observed = { path, digest: sha256(content), size: content.length, mode };
+    if (stableJson(observed) !== stableJson(expectedByPath.get(path))) {
+      throw new Error(`review evidence redacted untracked file changed after candidate binding: ${path}`);
+    }
+  }
+}
+
+function verifiedReviewWorkspace(
+  cwd: string,
+  diff: string,
+  expected: CandidateBinding['redactedUntrackedFiles'],
+): ReturnType<typeof resolveReviewWorkspace> {
+  const workspace = resolveReviewWorkspace(cwd);
+  verifyRedactedUntrackedProjection(workspace.repositoryRoot, diff, expected);
+  return workspace;
 }
 
 function readBoundedRedactedUntrackedFile(

--- a/goldband.manifest.json
+++ b/goldband.manifest.json
@@ -173,7 +173,7 @@
       "actions": [
         {
           "id": "code",
-          "description": "Evidence-first code review with authoritative lineage and scoped closure.",
+          "description": "Evidence-first code review.",
           "runtime": "typed",
           "owner": "review-runtime",
           "dispatch": "trusted-launcher",
@@ -181,7 +181,8 @@
           "promptContract": {
             "relevantContext": [
               "Claude executes bin/goldband review code --host claude. On Codex, read ~/.codex/skills/goldband/.workflow-launcher.json and execute its exact argvPrefix plus review code --host codex.",
-              "Forward scope, evidence/closure files, or Work Map IDs; runtime owns acceptance lineage and defaults."
+              "Forward scope or Work Map IDs; runtime owns lineage.",
+              "Missing/new contract: use goldband review contract help, init, validate."
             ],
             "hardBoundaries": [
               "Use only the installed launcher. Missing marker, runtime, or rule is an install failure; report the error.",

--- a/goldband.review-evidence.json
+++ b/goldband.review-evidence.json
@@ -148,9 +148,9 @@
       "id": "evidence-system-log-deny",
       "behavior": "The macOS process startup baseline cannot reopen network, system socket, or Mach service output channels for evidence commands.",
       "kind": "boundary",
-      "input": "an evidence command attempts to connect to the local system log socket",
+      "input": "an evidence command attempts to connect to the local system log socket or look up a baseline Mach service",
       "preconditions": "the common system process baseline is imported before Goldband-specific denies",
-      "expected": "the connection fails with an authorization error and no candidate bytes leave through the system log",
+      "expected": "the socket connection and global-name Mach lookup are denied, every imported common Mach allow clause has an exact deny contract including registration and XPC prefixes, and no candidate bytes leave through the live-probed channels",
       "risk": "high",
       "disposition": "automated",
       "providerIds": ["review-evidence-tests"]
@@ -300,7 +300,9 @@
           "goldband.review-evidence.json",
           "schemas/review-evidence-manifest.schema.json",
           "goldband-loop/workflows/review-evidence.ts",
-          "goldband-loop/test/review-evidence.test.ts"
+          "goldband-loop/workflows/review-evidence-sandbox.ts",
+          "goldband-loop/test/review-evidence.test.ts",
+          "goldband-loop/test/review-evidence-platform.test.ts"
         ]
       },
       "executionContext": {
@@ -312,7 +314,7 @@
         {
           "id": "candidate-green",
           "target": "candidate",
-          "argv": ["bun", "test", "--cwd", "goldband-loop", "test/review-evidence.test.ts"],
+          "argv": ["bun", "test", "--cwd", "goldband-loop", "test/review-evidence.test.ts", "test/review-evidence-platform.test.ts"],
           "requiredSystemTools": ["codesign", "false", "git", "install_name_tool", "node", "otool", "ruby", "sandbox-exec", "tar", "true", "which", "xcrun"],
           "expectedExit": "zero",
           "timeoutMs": 120000,

--- a/plugin-assets/claude-code-plugin/rules/coding-style.md
+++ b/plugin-assets/claude-code-plugin/rules/coding-style.md
@@ -81,6 +81,17 @@ Advisory-only checks for now:
   `${XDG_CONFIG_HOME:-$HOME/.config}/goldband/git-hooks`; `core.hooksPath`
   never points at the Goldband source checkout.
 - Manual and CI checks scan first-party tracked code.
+- `goldband-loop` runs the same 50-line, complexity-12, and four-parameter
+  rules through `lint:complexity`. Its existing debt is a checked-in vector by
+  file and rule: a change may not worsen that sorted magnitude vector, and any reduction must
+  update the baseline in the same review. The gate compares the candidate vector
+  with the authoritative push-before SHA, merge-base, or parent of the most recent
+  baseline-changing commit; missing Git history fails closed outside the one-time
+  baseline bootstrap. The `off` level in its Biome config
+  prevents duplicate diagnostics during `lint:source`; the dedicated gate
+  explicitly activates and enforces all three rules. The vector is identity-free:
+  simultaneous repairs can offset another function's regression, so reviewers
+  must inspect baseline reductions until stable function identity is available.
 - Claude and Codex PostToolUse checks are advisory; they do not block edits.
 - `.goldband-no-style-gate` is a visible repository opt-out.
   `GOLDBAND_STYLE_GATE=0` is a logged temporary bypass.

--- a/rules/coding-style.md
+++ b/rules/coding-style.md
@@ -81,6 +81,17 @@ Advisory-only checks for now:
   `${XDG_CONFIG_HOME:-$HOME/.config}/goldband/git-hooks`; `core.hooksPath`
   never points at the Goldband source checkout.
 - Manual and CI checks scan first-party tracked code.
+- `goldband-loop` runs the same 50-line, complexity-12, and four-parameter
+  rules through `lint:complexity`. Its existing debt is a checked-in vector by
+  file and rule: a change may not worsen that sorted magnitude vector, and any reduction must
+  update the baseline in the same review. The gate compares the candidate vector
+  with the authoritative push-before SHA, merge-base, or parent of the most recent
+  baseline-changing commit; missing Git history fails closed outside the one-time
+  baseline bootstrap. The `off` level in its Biome config
+  prevents duplicate diagnostics during `lint:source`; the dedicated gate
+  explicitly activates and enforces all three rules. The vector is identity-free:
+  simultaneous repairs can offset another function's regression, so reviewers
+  must inspect baseline reductions until stable function identity is available.
 - Claude and Codex PostToolUse checks are advisory; they do not block edits.
 - `.goldband-no-style-gate` is a visible repository opt-out.
   `GOLDBAND_STYLE_GATE=0` is a logged temporary bypass.

--- a/schemas/review-behavior-matrix.schema.json
+++ b/schemas/review-behavior-matrix.schema.json
@@ -8,6 +8,22 @@
     "type": "object",
     "additionalProperties": false,
     "required": ["id", "behavior", "kind", "input", "preconditions", "expected", "risk", "disposition", "providerIds"],
+    "allOf": [
+      {
+        "if": {
+          "properties": {
+            "disposition": { "enum": ["manual", "not-applicable", "unsupported"] }
+          },
+          "required": ["disposition"]
+        },
+        "then": { "required": ["reason"] },
+        "else": {
+          "properties": {
+            "providerIds": { "minItems": 1 }
+          }
+        }
+      }
+    ],
     "properties": {
       "id": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$" },
       "behavior": { "type": "string", "minLength": 1 },

--- a/schemas/review-evidence-manifest.schema.json
+++ b/schemas/review-evidence-manifest.schema.json
@@ -19,6 +19,16 @@
             "if": { "properties": { "lifecycle": { "const": "transition" } }, "required": ["lifecycle"] },
             "then": { "required": ["transitionBinding"] },
             "else": { "not": { "required": ["transitionBinding"] } }
+          },
+          {
+            "if": { "properties": { "kind": { "const": "property-fuzz" } }, "required": ["kind"] },
+            "then": {
+              "properties": {
+                "operations": {
+                  "items": { "required": ["seed", "iterations"] }
+                }
+              }
+            }
           }
         ],
         "properties": {
@@ -26,7 +36,12 @@
           "owner": { "type": "string", "minLength": 1 },
           "kind": { "enum": ["regression", "static", "project-gate", "property-fuzz", "runtime-integration"] },
           "lifecycle": { "enum": ["persistent", "transition"] },
-          "cellIds": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string" } },
+          "cellIds": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$" }
+          },
           "applicability": {
             "oneOf": [
               {
@@ -35,7 +50,16 @@
                 "required": ["kind", "pathPrefixes"],
                 "properties": {
                   "kind": { "const": "paths" },
-                  "pathPrefixes": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } }
+                  "pathPrefixes": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "pattern": "^(?!/)(?![A-Za-z]:/)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$))(?=\\S(?:.*\\S)?$)[^/]+(?:/[^/]+)*$"
+                    }
+                  }
                 }
               },
               {
@@ -116,7 +140,7 @@
                 }
               ],
               "properties": {
-                "id": { "type": "string" },
+                "id": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$" },
                 "target": { "enum": ["base", "candidate"] },
                 "argv": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
                 "expectedExit": { "enum": ["zero", "nonzero"] },
@@ -124,7 +148,7 @@
                 "timeoutMs": { "type": "integer", "minimum": 100, "maximum": 900000 },
                 "maxOutputBytes": { "type": "integer", "minimum": 1, "maximum": 65536 },
                 "network": { "enum": ["deny", "authorized"] },
-                "authorizationId": { "type": "string" },
+                "authorizationId": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$" },
                 "evidenceLevel": { "enum": ["fixture", "local", "sandboxed-service", "live-provider", "device-platform", "production-readback"] },
                 "requiredSystemTools": {
                   "type": "array",
@@ -146,10 +170,10 @@
         "additionalProperties": false,
         "required": ["id", "operation", "scope", "approvedBy", "approvedAt", "expiresAt"],
         "properties": {
-          "id": { "type": "string" },
-          "operation": { "type": "string" },
-          "scope": { "type": "string" },
-          "approvedBy": { "type": "string" },
+          "id": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$" },
+          "operation": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$" },
+          "scope": { "type": "string", "minLength": 1 },
+          "approvedBy": { "type": "string", "minLength": 1 },
           "approvedAt": { "type": "string", "format": "date-time" },
           "expiresAt": { "type": "string", "format": "date-time" }
         }

--- a/scripts/check-goldband-loop-inventory.mjs
+++ b/scripts/check-goldband-loop-inventory.mjs
@@ -502,6 +502,10 @@ function assertInstalledRuntimeSupportFiles(...runtimeRoots) {
     path.join('review', 'findings-schema.md'),
     path.join('review', 'checklist.md'),
     path.join('review', 'greptile-triage.md'),
+    path.join('review', 'review-evidence-manifest.md'),
+    path.join('review', 'examples', 'minimal-local-gate.json'),
+    path.join('review', 'schemas', 'review-evidence-manifest.schema.json'),
+    path.join('review', 'schemas', 'review-behavior-matrix.schema.json'),
     path.join('cross-review', 'core.cjs'),
     path.join('cross-review', 'cli.cjs'),
   ];

--- a/scripts/check-review-contracts.ts
+++ b/scripts/check-review-contracts.ts
@@ -58,6 +58,8 @@ try {
     source.inputs.map((entry: { path?: string }) => entry.path),
   );
   for (const required of [
+    'docs/review-evidence-manifest.md',
+    'examples/review-evidence/minimal-local-gate.json',
     'goldband-loop/bin/goldband.ts',
     'goldband-loop/bunfig.toml',
     'goldband-loop/design/dist/design',
@@ -72,6 +74,8 @@ try {
     'goldband-loop/review/shared-rubric.md',
     'hooks/scripts/lib/rules-resolver.js',
     'rules/manifest.json',
+    'schemas/review-behavior-matrix.schema.json',
+    'schemas/review-evidence-manifest.schema.json',
   ]) {
     assert.ok(
       sourcePaths.has(required),

--- a/scripts/lib/workflow-distribution-contract.mjs
+++ b/scripts/lib/workflow-distribution-contract.mjs
@@ -11,9 +11,13 @@ const OPTIONAL_GENERATED_SOURCE_INPUTS = new Set([
 ]);
 
 export const SOURCE_INPUTS = [
+  'docs/review-evidence-manifest.md',
+  'examples/review-evidence/minimal-local-gate.json',
   'goldband.manifest.json',
   'hooks/scripts/lib/rules-resolver.js',
   'rules',
+  'schemas/review-behavior-matrix.schema.json',
+  'schemas/review-evidence-manifest.schema.json',
   'shell/install',
   'scripts/generate-goldband-surfaces.mjs',
   'scripts/lib/workflow-distribution-contract.mjs',

--- a/scripts/test-goldband-loop-source-gates.mjs
+++ b/scripts/test-goldband-loop-source-gates.mjs
@@ -8,6 +8,7 @@ const loopPackage = readJson(path.join(loopRoot, 'package.json'));
 
 const expectedScripts = {
   'lint:source': 'biome lint',
+  'lint:complexity': 'check-source-complexity.ts',
   typecheck: 'tsc --noEmit',
   'lint:exports': 'knip',
 };
@@ -41,6 +42,51 @@ for (const configFile of configFiles) {
   );
 }
 
+const biomeConfig = readJson(path.join(loopRoot, 'biome.json'));
+assert.equal(
+  biomeConfig.linter?.rules?.complexity?.noExcessiveLinesPerFunction?.options
+    ?.maxLines,
+  50,
+  'Goldband Loop must retain the 50-line function contract',
+);
+assert.equal(
+  biomeConfig.linter?.rules?.complexity?.noExcessiveCognitiveComplexity?.options
+    ?.maxAllowedComplexity,
+  12,
+  'Goldband Loop must retain the cognitive-complexity contract',
+);
+assert.equal(
+  biomeConfig.linter?.rules?.complexity?.useMaxParams?.options?.max,
+  4,
+  'Goldband Loop must retain the four-parameter contract',
+);
+assert.ok(
+  fs.existsSync(
+    path.join(loopRoot, 'config', 'source-complexity-baseline.json'),
+  ),
+  'Goldband Loop must commit its monotonic complexity baseline',
+);
+
+const complexityGate = fs.readFileSync(
+  path.join(loopRoot, 'scripts', 'check-source-complexity.ts'),
+  'utf8',
+);
+assert.match(
+  complexityGate,
+  /baselineTransitionFailures[\s\S]*?candidate baseline exceeds predecessor/,
+  'complexity gate must compare the candidate baseline with its predecessor',
+);
+assert.match(
+  complexityGate,
+  /GITHUB_BASE_REF[\s\S]*?merge-base/,
+  'complexity gate must resolve the GitHub merge-base authority',
+);
+assert.match(
+  complexityGate,
+  /git[\s\S]*?log[\s\S]*?BASELINE_REPOSITORY_PATH/,
+  'local complexity checks must trace the last baseline-changing commit',
+);
+
 const workflow = fs.readFileSync(
   path.join(root, '.github', 'workflows', 'validate.yml'),
   'utf8',
@@ -49,6 +95,16 @@ assert.match(
   workflow,
   /name: Check Goldband Loop source quality[\s\S]*?run: cd goldband-loop && bun run check:source/,
   'validate CI must run the Goldband Loop source gate after dependencies are installed',
+);
+assert.match(
+  workflow,
+  /config-contracts:[\s\S]*?actions\/checkout@v4[\s\S]*?fetch-depth: 0[\s\S]*?name: Check Goldband Loop source quality/,
+  'source-quality CI must fetch predecessor history for the monotonic baseline',
+);
+assert.match(
+  workflow,
+  /name: Check Goldband Loop source quality[\s\S]*?GOLDBAND_COMPLEXITY_BASE_REF: \$\{\{ github\.event\.before \}\}/,
+  'push CI must bind complexity comparison to the pre-push SHA',
 );
 
 const rootFileSelector = fs.readFileSync(
@@ -61,7 +117,9 @@ assert.match(
   'the root exclusion must point to the actual Goldband Loop source gate',
 );
 
-console.log('ok - Goldband Loop owns lint, typecheck, and unused-export gates');
+console.log(
+  'ok - Goldband Loop owns lint, complexity debt, typecheck, and unused-export gates',
+);
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));

--- a/scripts/test-workflow-integration-fixture.sh
+++ b/scripts/test-workflow-integration-fixture.sh
@@ -1,3 +1,12 @@
+copy_distribution_fixture_inputs() {
+  cp -R "$ROOT_DIR/scripts" "$TMP_ROOT/scripts"
+  mkdir -p "$TMP_ROOT/docs" "$TMP_ROOT/examples/review-evidence" "$TMP_ROOT/schemas"
+  cp "$ROOT_DIR/docs/review-evidence-manifest.md" "$TMP_ROOT/docs/review-evidence-manifest.md"
+  cp "$ROOT_DIR/examples/review-evidence/minimal-local-gate.json" "$TMP_ROOT/examples/review-evidence/minimal-local-gate.json"
+  cp "$ROOT_DIR/schemas/review-evidence-manifest.schema.json" "$TMP_ROOT/schemas/review-evidence-manifest.schema.json"
+  cp "$ROOT_DIR/schemas/review-behavior-matrix.schema.json" "$TMP_ROOT/schemas/review-behavior-matrix.schema.json"
+}
+
 create_minimal_real_setup_fixture() {
   local loop_dir="$1"
   mkdir -p "$loop_dir/bin" "$loop_dir/browse/dist" "$loop_dir/generated" "$loop_dir/lib" "$loop_dir/review" "$loop_dir/workflows" "$loop_dir/scripts"
@@ -51,6 +60,7 @@ EOF_BROWSE
 
 write_minimal_review_assets() {
   local loop_dir="$1"
+  mkdir -p "$loop_dir/review/examples" "$loop_dir/review/schemas"
   cat > "$loop_dir/review/checklist.md" <<'EOF_CHECKLIST'
 # test checklist
 EOF_CHECKLIST
@@ -69,4 +79,8 @@ EOF_GREPTILE
   cat > "$loop_dir/review/TODOS-format.md" <<'EOF_TODOS'
 # test todos format
 EOF_TODOS
+  cp "$ROOT_DIR/docs/review-evidence-manifest.md" "$loop_dir/review/review-evidence-manifest.md"
+  cp "$ROOT_DIR/examples/review-evidence/minimal-local-gate.json" "$loop_dir/review/examples/minimal-local-gate.json"
+  cp "$ROOT_DIR/schemas/review-evidence-manifest.schema.json" "$loop_dir/review/schemas/review-evidence-manifest.schema.json"
+  cp "$ROOT_DIR/schemas/review-behavior-matrix.schema.json" "$loop_dir/review/schemas/review-behavior-matrix.schema.json"
 }

--- a/scripts/test-workflow-integration.sh
+++ b/scripts/test-workflow-integration.sh
@@ -18,7 +18,7 @@ copy_repo_subset() {
   cp -R "$ROOT_DIR/git-hooks" "$TMP_ROOT/git-hooks"
   cp -R "$ROOT_DIR/codex" "$TMP_ROOT/codex"
   cp -R "$ROOT_DIR/mcp" "$TMP_ROOT/mcp"
-  cp -R "$ROOT_DIR/scripts" "$TMP_ROOT/scripts"
+  copy_distribution_fixture_inputs
   cp -R "$ROOT_DIR/.claude-plugin" "$TMP_ROOT/.claude-plugin"
   cp -R "$ROOT_DIR/shell" "$TMP_ROOT/shell"
   chmod +x "$TMP_ROOT/install.sh"

--- a/shell/install/workflow.sh
+++ b/shell/install/workflow.sh
@@ -150,6 +150,14 @@ install_workflow_claude_command_selector() {
     link_component "$src" "$dest" "Goldband workflow selector command"
 }
 
+print_review_platform_notice() {
+    case "$(uname -s 2>/dev/null || true)" in
+        Darwin) return 0 ;;
+    esac
+    echo -e "${YELLOW}注意：此平台可使用其他 Goldband Loop workflows，但 review/code executable sealed evidence 只支援 macOS Seatbelt。${NC}" >&2
+    echo -e "${YELLOW}需要執行 evidence 的 review 會 fail closed 為 runtime-incomplete，不會啟動 semantic review 或取得 completion authority。${NC}" >&2
+}
+
 install_workflow_host() {
     local host="$1"
     local profile="${2:-standard}"
@@ -194,6 +202,7 @@ install_workflow_host() {
     cleanup_workflow_user_entries
     write_workflow_installed_versions "$host" "$version"
     write_workflow_installed_contracts "$host" "$repo_dir"
+    print_review_platform_notice
     if ! is_windows_host; then
         install_shell_launchers
     fi


### PR DESCRIPTION
## Summary

- add the review evidence manifest authoring guide, example, schemas, and installed runtime help
- harden source/platform evidence gates and preserve fail-closed runtime classification
- restore installer and container distribution coverage for the new authoring assets
- verify redacted untracked candidate bytes before platform-specific execution admission

## Verification

- `bash scripts/test-workflow-integration.sh`
- `bun run check:source`
- targeted review evidence/platform/authoring/install tests
- `bash -n goldband-loop/setup scripts/test-workflow-integration.sh scripts/test-workflow-integration-fixture.sh`
- `npm run lint:style:staged`

Local nested Seatbelt operations correctly reported `runtime-incomplete` under the managed outer sandbox. The supported GitHub macOS, Linux, and Windows lanes remain the merge authority.