### PR TITLE
Fix review evidence recovery and macOS self-tests; simplify onboarding docs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -259,6 +259,18 @@ jobs:
         run: npm install -g @openai/codex
       - name: Install Goldband Loop dependencies
         run: cd goldband-loop && bun install --frozen-lockfile
+      - name: Review evidence - review-evidence-tests
+        run: bun test --cwd goldband-loop test/review-evidence.test.ts test/review-evidence-platform.test.ts
+        env:
+          GOLDBAND_REQUIRE_REVIEW_HOST_BOUNDARY: "1"
+      - name: Review evidence - work-map-review-tests
+        run: bun test --cwd goldband-loop test/work-map-review.test.ts
+        env:
+          GOLDBAND_REQUIRE_REVIEW_HOST_BOUNDARY: "1"
+      - name: Review evidence - installed-runtime-tests
+        run: bun test --cwd goldband-loop test/codex-review-launcher-install.test.ts test/review-receipt-authority-install.test.ts
+        env:
+          GOLDBAND_REQUIRE_REVIEW_HOST_BOUNDARY: "1"
       - name: Build installer-owned Goldband Loop artifacts
         run: cd goldband-loop && bun run build
       - name: Test managed worktree Seatbelt enforcement on macOS

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,6 +116,17 @@ records remote identity; moves, path reuse, clones, remote changes, and
 ambiguity fail closed until explicit re-import. Review never mutates repository
 manifests.
 
+Goldband's three macOS sandbox self-test providers are an explicit exception to
+local execution. `workflows/review-ci-evidence.ts` owns their fixed GitHub Actions
+recipe and read-only public API adapter, bundled by the existing Claude and
+Codex runtime installers. No new binary, skill, token store, or artifact import
+surface is introduced. The adapter binds an exact materialized Git tree to the
+remote commit and latest run/attempt/step, then the existing runtime signs the
+CI provenance. This is trusted writable CI checkout evidence, not a local
+sealed-snapshot or network-isolation attestation. Missing or unsuccessful CI
+keeps review incomplete. Only the three unchanged operations can migrate from
+the previous host lane; the signed finding lineage and closure checks remain.
+
 The resolved contract declares stable behavior cells and typed providers. The
 runtime validates every disposition and reciprocal provider/cell
 ownership, materializes a fresh read-only candidate snapshot per operation,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,36 @@
 # Contributing
 
+## Development Setup and Tests
+
+From the repository root, install test dependencies and run the aggregate suite:
+
+```bash
+npm run bootstrap:test
+npm test
+```
+
+Run bootstrap after cloning, changing lockfiles, or an installer migration. It
+installs dependencies for the root, `mcp/server`, and `goldband-loop`, and cleans
+retired generated assets only when their ownership is verified. `npm test`
+checks the environment, runs the package-owned suites, and prints a per-suite
+summary; it does not install dependencies. `bun run test` is an alternative
+entrypoint. Bare `bun test` at the repo root bypasses that orchestration and
+should not be used as repository verification.
+
+List suites or select checks relevant to your change:
+
+```bash
+npm run test:repo:list
+npm run test:plugin-distribution
+npm run test:app-support
+npm run test:hook-router
+npm run test:cross-review
+npm run lint:style
+```
+
+For workflow runtime source changes, also follow
+[the runtime development guide](goldband-loop/README.md#development).
+
 ## Plugin Distribution Changes
 
 When changing any source asset that feeds the Claude Code plugin, regenerate the
@@ -26,3 +57,13 @@ diff, and packaged hook runtime smoke. Do not replace it with
 `node scripts/check-plugin-distribution.mjs --skip-cli` for local pre-commit
 verification; `--skip-cli` is only the structural CI fallback when the Claude
 CLI path is being checked separately.
+
+## Codex Plugin and Claude App Adapter Changes
+
+After changing sources that feed these distributions, regenerate their assets
+and verify the result:
+
+```bash
+npm run sync:app-support
+npm run test:app-support
+```

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,5 +1,72 @@
 # goldband Operations
 
+## Additional Install Options
+
+Run these commands from the complete Goldband checkout. The common installation
+paths are in the [README](README.md#安裝).
+
+| Need | Entry point |
+| --- | --- |
+| Claude core guardrails through the installer | `./install.sh pack-quality` |
+| Goldband Loop for Claude Code | `./install.sh workflow` |
+| Goldband Loop for Codex | `./install.sh workflow-codex` |
+| All installer options | `./install.sh help` |
+| Codex portable plugin subset | [Repository marketplace](.agents/plugins/marketplace.json) |
+| Claude Desktop app subset | [Local extension](app-adapters/claude-desktop/) |
+| Claude web/mobile app subset | [Remote connector template](app-adapters/claude-remote/goldband-connector.template.json) |
+
+Plugins, app adapters, and full installer setups provide different features;
+see [distribution boundaries](ARCHITECTURE.md#system-shape). Avoid installing
+both the Claude core plugin and installer-managed Claude core assets.
+
+The workflow installer installs and verifies Playwright Chromium. For an offline
+or CI setup that does not need browser workflows, use
+`GOLDBAND_SKIP_PLAYWRIGHT=1` with your chosen install command. This explicitly
+skips browser setup; it does not provide a working browser workflow.
+
+After updating, rerun your original installation command and `./install.sh status`.
+Status checks the installed source inputs, artifact integrity, and dispatch
+behavior. Stale or corrupt workflow installations require reinstalling; pulling
+new source alone is insufficient.
+
+## Managed Worktrees
+
+Use a managed worktree when an agent needs an isolated working copy. Run
+`create` from a clean source worktree on a normal branch:
+
+```bash
+goldband worktree create task-name
+```
+
+This opens a managed shell in a detached worktree. Inside that shell, start one
+agent without a nested OS sandbox:
+
+```bash
+claude --settings '{"sandbox":{"enabled":false}}'
+# Or:
+codex --sandbox danger-full-access
+```
+
+These flags are for the Goldband-managed shell only: Goldband's outer sandbox
+protects Git metadata and the source worktree. Normal permission prompts and
+Goldband hooks remain active. macOS uses Seatbelt; Linux uses bubblewrap.
+Unavailable boundaries fail closed, and Windows has no claimed hard enforcement.
+
+After the agent finishes, exit the managed shell, then integrate from the source
+worktree:
+
+```bash
+goldband worktree finish task-name -m "feat: integrate task"
+```
+
+`finish` validates and integrates the candidate, creates the commit, and removes
+the managed worktree only after successful completion. Validation or integration
+failure preserves the worktree for investigation. See the
+[managed worktree architecture](ARCHITECTURE.md#managed-worktree-runtime) for the
+full isolation and commit contract. The host user remains able to manage Git
+outside this boundary; these controls do not isolate a malicious same-user host
+process.
+
 ## Codex Portable Baseline Check
 
 Run this before publishing changes to tracked Codex config or rules:

--- a/README.en.md
+++ b/README.en.md
@@ -1,306 +1,103 @@
 # goldband
 
-> Local engineering guardrails, installer assets, and workflow runtime support
-> for Claude Code and Codex.
+Local engineering tools for Claude Code and Codex, with shared development rules, tool configuration, and workflows.
 
 English | [中文](README.md)
 
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+## What It Does
 
-## What This Is
+- Installs shared development rules, hooks, and skills to reduce repeated project setup.
+- Manages local Claude Code and Codex configuration, with installation checks and uninstall commands.
+- Optionally adds Goldband Loop for code review, investigation, planning, QA, and other workflows.
 
-goldband is a local engineering pack for Claude Code and Codex. It keeps shared
-policy, hooks, rules, commands, portable skills, Codex config, and the optional
-Goldband Loop workflow runtime in one checkout.
+## Before Installing
 
-This repo has two layers:
+- Have Git, Node.js, and the Claude Code or Codex CLI you intend to use available.
+- Installer-based Claude configuration also needs `jq`; Codex configuration checks require **Python 3.11 or later**.
+- Use a complete Git checkout; do not download only `install.sh`.
+- Goldband Loop also requires **Bun 1.3.11 or later**. Browser workflows require Playwright Chromium, which the installer installs and verifies.
+- Use Bash on macOS/Linux and Git Bash or WSL on Windows. There is no native PowerShell installer. Individual workflow limits are described below.
 
-- root `goldband`: installer, Claude/Codex adapters, shared policy, hooks,
-  rules, commands, portable skills, plugin/app distribution.
-- `goldband-loop/`: first-party workflow runtime for public review,
-  investigation, QA, browser, planning, and related capability actions;
-  unfinished high-risk work stays in a hidden experimental inventory.
+The installer changes tool configuration, hooks, and skills in your home directory. Choose either the Claude plugin or the installer's Claude core setup to avoid loading duplicate assets.
 
-For detailed ownership and runtime contracts, see
-[ARCHITECTURE.md](ARCHITECTURE.md).
+## Install
 
-### `review/code` platform boundary
-
-When adding an evidence contract to another project, run
-`goldband review contract help` to locate the installed guide, public example,
-and JSON Schema. `review contract init` creates a non-overwriting, fail-closed
-scaffold at the canonical repository root. After declaring project-owned
-behaviors and providers, use `review contract validate --manifest <path>` to
-invoke the production runtime validator without executing evidence, changing
-the contract store, or claiming review/deployment completion. See the
-[manifest authoring guide](docs/review-evidence-manifest.md) for the complete
-field and safety contract.
-
-| Platform | Goldband Loop installation | Executable sealed evidence | `review/code` result |
-| --- | --- | --- | --- |
-| macOS | Supported | Runs under Seatbelt | May start semantic review after evidence is complete |
-| Linux | Other workflow capabilities are supported | **Unsupported** | Emits typed `runtime-incomplete`, starts no semantic review, and grants no completion or closure authority |
-| Windows | Some capabilities install through Git Bash/WSL | **Unsupported** | Fails closed with the same incomplete result |
-
-Linux Bubblewrap currently owns only the managed-worktree boundary. It is not a
-sealed `review/code` evidence runner and does not imply review parity. Run a
-contract that requires executable evidence on a supported macOS Seatbelt host.
-
-`review/code` first resolves a non-downgradable evidence contract. A repository
-Review uses the canonical Git repository root as the shared coordinate for
-diffs, snapshots, scopes, and contracts. Starting in a tracked subdirectory
-records only an execution offset and cannot change the baseline. The reviewed
-base's repo-root `goldband.review-evidence.json` is authoritative; only when the
-base has no manifest may an explicitly imported runtime-owned per-repository
-contract become the baseline (`goldband review contract import --manifest
-<path>`). Working-tree, index, and caller-supplied manifests are complete
-monotonic candidate extensions, never replacement authorities. `inspect`
-reports the repo root, invocation offset, base/candidate tracking state,
-sources, and digests. Manifest schema v2 is required. The only v1 transition is
-a committed v1 base paired with a v2 candidate, and it is accepted only when
-changing the base version marker alone passes the complete v2 validation. Every
-other v1 input fails closed with explicit migration guidance; safety fields are
-never inferred.
-
-After resolution, the runtime
-runs every typed check in an independent read-only, default-deny read/write/network snapshot,
-validates pre/post tree digests, reciprocal provider/cell ownership, and exact RED exits, and validates
-evidence completeness and candidate provenance before one semantic review. If
-an operation uses a script launcher, its manifest must invoke the interpreter explicitly. A Mach-O runtime
-with non-system dependencies executes from a private sealed projection: Goldband rewrites only attested
-load commands, ad-hoc signs and re-attests the transformed bytes, and leaves the original host package tree
-unreadable. The macOS profile exactly re-denies inherited syslog, Mach service, and shared-memory channels
-in addition to broad network and system-socket access.
-An explicit `pythonRuntime` contract supports Python 3.14 with `uv`,
-`pyproject.toml`, and `uv.lock`. Goldband creates a per-operation frozen/offline
-environment and completes interpreter, stdlib, path, and dependency-integrity
-preflight before the project gate. Python and uv are selected only from bounded
-system/Homebrew roots and inspected inside Seatbelt. For registry packages, installed
-`WHEEL` tags must uniquely select the used lockfile wheel filename and hash; unrelated cache entries do not affect identity. Preparation failure is typed
-`runtime-incomplete` and prevents semantic dispatch; only a gate mismatch after
-preflight becomes `verified-failure`.
-If
-that review finds an issue and the candidate is repaired,
-`--closure-artifact <initial-artifact>` performs one closure pass over only the
-repair delta, original finding IDs, and rerun evidence. New or changed affected
-cells in the repaired manifest are rerun, and `closed` requires fresh passing
-evidence. Closure also requires a receipt issued by the installed runtime authority for the complete
-initial payload, review scope, and Work Map claim attempt; prior-attempt replay is rejected. This
-boundary distrusts reviewed code, model output, and artifact input, while trusting the Goldband
-installer/runtime under the same OS account. Isolating a malicious same-user host process requires
-an OS-backed key or privileged helper.
-Closure receipts use at-most-once semantics: after repair binding and Work Map causality
-validation, an atomic claim consumes the receipt. A crash or later failure requires a new
-initial review instead of replaying that receipt. Prompt-redacted untracked files remain
-digest-bound and executable through a separate snapshot-only channel.
-
-Cross-run review authority is owned by a signed installed-runtime acceptance
-lineage. A new manifest may add coverage but cannot remove, reverse, or weaken
-inherited required cells, and an open finding forces scoped closure. Projects
-may commit typed minimum evidence requirements or attributable waivers in
-`goldband.review-policy.json` on the base commit; model prose and candidate-only
-files have no waiver authority. `No new findings` is reported separately from
-contract completeness, prior blockers, closure, and completion authority. A
-zero-finding initial review cannot trigger closure. Fixture, local, live, device, and production
-evidence levels remain distinct, and a green gate is never reported as overall
-deployment readiness.
-
-## Install Paths
-
-| Need | Recommended path |
-| --- | --- |
-| Claude Code core guardrails | Claude plugin: `goldband@goldband` |
-| Codex full setup | `./install.sh codex-full` |
-| Claude Code + Codex | `./install.sh all-tools` |
-| Claude Code + Codex + Goldband Loop | `./install.sh all-with-workflow` |
-| Codex portable plugin subset | repo marketplace: `.agents/plugins/marketplace.json` |
-| Claude Desktop app subset | `app-adapters/claude-desktop/dist/goldband-local-extension.mcpb` |
-| Claude web/mobile app subset | `app-adapters/claude-remote/goldband-connector.template.json` |
-
-The Claude plugin is the main Claude Code core-guardrails path. It does not
-include Goldband Loop, Playwright/browser/iOS tooling, or Codex full setup. Use
-the installer when you need the workflow runtime.
-
-## Quickstart
-
-Claude Code plugin:
+Clone the project:
 
 ```bash
 git clone https://github.com/leo110047/goldband.git
 cd goldband
+```
+
+Choose one installation path:
+
+| Need | Installation |
+| --- | --- |
+| Claude Code core guardrails | Claude plugin commands below |
+| Full Codex configuration | `./install.sh codex-full` |
+| Full Claude Code and Codex configuration | `./install.sh all-tools` |
+| Both tools plus Goldband Loop workflows | `./install.sh all-with-workflow` |
+
+To install the Claude plugin:
+
+```bash
 claude plugin marketplace add ./
 claude plugin install goldband@goldband --scope user
+```
+
+The Claude plugin does not include Goldband Loop. For workflows on a single tool, the Codex portable plugin, or Claude Desktop/web/mobile integrations, see [additional install options](OPERATIONS.md#additional-install-options).
+
+Check installation status, then restart Claude Code/Codex:
+
+```bash
 ./install.sh status
 ```
 
-Codex or dual-tool setup:
+Your selected components should report `[OK]`. If status reports stale, corrupt, or duplicate assets, follow its remediation instructions first.
 
-```bash
-git clone https://github.com/leo110047/goldband.git
-cd goldband
-./install.sh all-tools
-./install.sh status
+## Try a Workflow
+
+After installing Goldband Loop, start by checking your local installation. Enter the following in the corresponding tool's conversation:
+
+```text
+Claude Code: /goldband system health
+Codex:       $goldband system health
 ```
 
-Goldband Loop workflow runtime:
+See the [workflow catalog](docs/generated/capabilities.md) for other actions.
 
-```bash
-./install.sh all-with-workflow
-```
+Code review requires a verification contract for the target project; begin with the [review quick start](docs/review-evidence-manifest.md#quick-start). Formal review requiring locally sandboxed test execution currently supports macOS only; Linux/Windows report incomplete when this evidence is unavailable. Successful installation or tests do not imply that review or deployment is complete.
 
-Native PowerShell installation is not maintained. On Windows, use Git Bash or
-WSL from a full git checkout and run the same POSIX commands.
+## Update and Uninstall
 
-## Common Commands
-
-```bash
-./install.sh status            # Check install state
-./install.sh pack-quality      # Claude Code core quality pack, no workflow runtime
-./install.sh codex-full        # Codex full setup
-./install.sh all-tools         # Claude Code + Codex
-./install.sh all-with-workflow # Claude Code + Codex + Goldband Loop
-./install.sh uninstall         # Remove installer-managed assets
-```
-
-Uninstall the plugin:
-
-```bash
-claude plugin uninstall goldband@goldband
-```
-
-Update:
+Update the source in your original checkout:
 
 ```bash
 git pull --ff-only
-./install.sh status
 ```
 
-After updating, rerun the install profile you use, such as `pack-quality`,
-`all-tools`, or `all-with-workflow`.
+Then update using your original installation method:
 
-## Important Boundaries
+- **Installer**: rerun the command you originally selected from the table above, such as `./install.sh codex-full` for Codex.
+- **Claude plugin**: run `claude plugin update goldband@goldband`.
 
-- Use a full git checkout; do not copy `install.sh` by itself.
-- Claude plugin, Codex plugin, Claude app adapters, and installer full setup are
-  different distribution surfaces. Do not describe one as replacing another.
-- `./install.sh status` reads back install state. If the plugin and
-  installer-managed Claude assets both exist, it reports duplicate assets.
-- Hooks, rules, the cross-review gate, and sandbox are guardrails and evidence
-  gates, not a security boundary against a same-permission host user. Managed
-  worktrees are a narrower exception: an OS sandbox blocks Git-metadata writes
-  by the agent process, while the host user remains able to manage and finish
-  the work outside that sandbox.
-- `all-with-workflow` installs and verifies the Goldband Loop browser runtime.
-  Offline or CI runs can explicitly set `GOLDBAND_SKIP_PLAYWRIGHT=1` to skip
-  browser workflows.
+Run `./install.sh status` afterward and restart your tool.
 
-## Workflow Entry Points
-
-After installing Goldband Loop:
-
-- Claude Code: `/goldband <capability> <action>`
-- Codex: `$goldband <capability> <action>`
-
-The supported capability/action list is generated in
-[docs/generated/capabilities.md](docs/generated/capabilities.md).
-
-Parallel agent worktrees use two user-triggered commands:
+To uninstall, choose the command matching your installation method:
 
 ```bash
-goldband worktree create task-name
-# Start one agent in the managed shell; Goldband remains the outer hard boundary.
-claude --settings '{"sandbox":{"enabled":false}}'
-codex --sandbox danger-full-access
-# Exit when done.
-goldband worktree finish task-name -m "feat: integrate task"
+./install.sh uninstall                       # Remove installer-managed components
+claude plugin uninstall goldband@goldband    # Remove the Claude plugin
 ```
 
-`create` requires a clean source worktree on a normal branch and creates a
-detached worktree without a task branch. Working files stay writable inside the
-managed shell, while the OS sandbox keeps Git indexes, objects, and refs
-read-only together with broker runtime and Git config/hook inputs. Run `finish`
-only after leaving the managed shell. The broker uses a pinned Git executable,
-isolated config environment, and the source-owned hook contract recorded by
-`create`; a collision between source ignored content and the candidate tree
-stops integration. Goldband removes the worktree only after validation,
-integration, and durable-commit readback all succeed. macOS uses Seatbelt,
-Linux uses bubblewrap, and unavailable boundaries fail closed. Windows does not
-currently claim hard enforcement. Disable the agent's inner OS sandbox as shown
-above to avoid unsupported nesting; normal permission prompts and Goldband hooks
-remain active, while the outer managed boundary continues to deny Git writes.
+## Documentation and Help
 
-## Development
-
-The repo-root default aggregate test entrypoint is:
-
-```bash
-npm run bootstrap:test # after the first clone, lockfile changes, or installer migrations
-npm test
-# or
-bun run test
-```
-
-`bootstrap:test` installs the dependencies declared by the root, `mcp/server`,
-and `goldband-loop`, then removes entries from ignored host skill roots only
-when a tracked retired inventory or managed marker proves ownership. Unknown
-same-prefix skills are preserved. `npm test` itself does not access the network or
-silently mutate the checkout. It checks dependencies, the minimum Bun version,
-and legacy artifacts before running an explicit set of package-owned suites and
-printing a final per-suite summary. List the suites with:
-
-```bash
-npm run test:repo:list
-```
-
-Do not treat bare `bun test` at the repo root as repository verification. It
-bypasses package-owned test contracts, recursively scans files, and has no
-per-package summary.
-
-Common targeted gates:
-
-```bash
-npm run test:plugin-distribution
-npm run test:app-support
-npm run test:hook-router
-npm run test:cross-review
-npm run lint:style
-```
-
-After changing sources that feed the Claude plugin:
-
-```bash
-node scripts/sync-plugin-assets.mjs
-npm run test:plugin-distribution
-```
-
-After changing Codex plugin or Claude app adapter sources:
-
-```bash
-npm run sync:app-support
-npm run test:app-support
-```
-
-For contributor workflow details, see [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Documentation Map
-
-- [ARCHITECTURE.md](ARCHITECTURE.md): root goldband, Claude/Codex surfaces,
-  Goldband Loop ownership, and runtime contracts.
-- [OPERATIONS.md](OPERATIONS.md): install operations, Codex overlays, style
-  gate, MCP, telemetry.
-- [CONTRIBUTING.md](CONTRIBUTING.md): development flow and plugin distribution
-  checks.
-- [docs/generated/capabilities.md](docs/generated/capabilities.md): Goldband
-  Loop capability/action catalog.
-- [goldband-loop/README.md](goldband-loop/README.md): workflow runtime entry
-  point.
-- [mcp/README.md](mcp/README.md): MCP templates and first-party
-  `goldband-mcp`.
-- [sandbox/THREAT-MODEL.md](sandbox/THREAT-MODEL.md): what the container
-  sandbox does and does not protect.
-- [docs/knowledge-system.md](docs/knowledge-system.md): local knowledge layer.
-- [docs/DECISIONS.md](docs/DECISIONS.md): decision records.
+- [Operations and troubleshooting](OPERATIONS.md): additional install options, managed worktrees, MCP, and maintenance.
+- [Goldband Loop](goldband-loop/README.md): workflow configuration and usage.
+- [Contributing](CONTRIBUTING.md): development setup, tests, and distribution updates.
+- [Architecture](ARCHITECTURE.md): component ownership, isolation, and verification mechanisms.
+- [Report an issue](https://github.com/leo110047/goldband/issues): include your platform, installation method, and relevant error output, with keys and other sensitive data removed.
 
 ## License
 
-MIT License.
+[MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ digests；`remove` 只移除 central entry。manifest contract 使用 `schemaVer
 必須在只改版本號後就能通過完整 v2 驗證；其他 v1 輸入會 fail closed 並回報
 migration 指引，不會猜測安全欄位的預設值。
 
+Goldband 自身三組需要建立 Seatbelt 邊界的自測，改由既有 `push dev` macOS CI
+執行，審查讀回相同 commit／tree 的指定 step 結果。未提交或尚無 CI 證據時仍
+回報未完成；不在外層隔離內重跑這三組自測，也不把 CI 當成本機 sealed evidence。
+Claude 與 Codex 共用此 runtime adapter，須經各自既有 installer 更新後才生效。
+詳見 [CI 證據契約](docs/review-evidence-manifest.md#goldband-自身的-macos-ci-自測)。
+
 解析完成後，runtime 在隔離、
 預設以每個 operation 各自獨立、唯讀且 read/write/network default-deny 的 snapshot 執行 typed checks，
 並驗證執行前後 tree digest、provider/cell 雙向 ownership 與 exact RED exit，確認 evidence completeness 與

--- a/README.md
+++ b/README.md
@@ -1,314 +1,103 @@
 # goldband
 
-> Claude Code / Codex 的本機工程守則、安裝器與 workflow runtime 配套。
+Claude Code 與 Codex 的本機工程配套，集中管理開發守則、工具設定與工作流程。
 
-[English](README.en.md) | 中文（目前主入口）
+[English](README.en.md) | 中文
 
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+## 能做什麼
 
-## 這是什麼
+- 安裝共用開發守則、hooks 與 skills，減少每個專案重複設定。
+- 管理 Claude Code／Codex 的本機設定，提供安裝狀態檢查與移除入口。
+- 選裝 Goldband Loop，使用程式碼審查、問題調查、規劃、QA 等工作流程。
 
-goldband 是給 Claude Code 和 Codex 用的本機工程配套。它把 shared policy、
-hooks、rules、commands、portable skills、Codex config，以及可選的
-Goldband Loop workflow runtime 裝到同一個 checkout 管理。
+## 安裝前
 
-這個 repo 分兩層：
+- 準備 Git、Node.js，以及要使用的 Claude Code 或 Codex CLI。
+- 使用 installer 安裝 Claude 設定另需 `jq`；Codex 設定檢查需要 Python **3.11 以上**。
+- 使用完整 Git checkout；請勿只下載 `install.sh`。
+- Goldband Loop 另需 Bun **1.3.11 以上**。瀏覽器工作流程需要 Playwright Chromium，安裝器會處理其安裝與驗證。
+- macOS／Linux 使用 Bash；Windows 請用 Git Bash 或 WSL，沒有原生 PowerShell 安裝器。各工作流程的平台限制見下方說明。
 
-- root `goldband`：安裝器、Claude/Codex adapters、shared policy、hooks、
-  rules、commands、portable skills、plugin/app distribution。
-- `goldband-loop/`：first-party workflow runtime，提供 review、investigate、
-  QA、browser、planning 等公開 capability actions；未完成的高風險能力另列為
-  hidden experimental inventory。
+Installer 會修改家目錄內的工具設定、hooks 與 skills。Claude plugin 與 installer 的 Claude 核心設定請擇一安裝，避免重複載入。
 
-更細的 ownership 和 runtime contract 看 [ARCHITECTURE.md](ARCHITECTURE.md)。
+## 安裝
 
-## 安裝路徑
-
-| 需求 | 建議路徑 |
-| --- | --- |
-| Claude Code core guardrails | Claude plugin：`goldband@goldband` |
-| Codex full setup | `./install.sh codex-full` |
-| Claude Code + Codex | `./install.sh all-tools` |
-| Claude Code + Codex + Goldband Loop | `./install.sh all-with-workflow` |
-| Codex portable plugin subset | repo marketplace：`.agents/plugins/marketplace.json` |
-| Claude Desktop app subset | `app-adapters/claude-desktop/dist/goldband-local-extension.mcpb` |
-| Claude web/mobile app subset | `app-adapters/claude-remote/goldband-connector.template.json` |
-
-Claude plugin 是 Claude Code core guardrails 的主路徑；它不包含
-Goldband Loop、Playwright/browser/iOS tooling、或 Codex full setup。需要
-workflow runtime 時，使用 installer。
-
-## Quickstart
-
-Claude Code plugin：
+先取得專案：
 
 ```bash
 git clone https://github.com/leo110047/goldband.git
 cd goldband
+```
+
+依需求選一種方式：
+
+| 需求 | 安裝方式 |
+| --- | --- |
+| Claude Code 核心守則 | 下方 Claude plugin 指令 |
+| Codex 完整設定 | `./install.sh codex-full` |
+| Claude Code 與 Codex 完整設定 | `./install.sh all-tools` |
+| 兩個工具與 Goldband Loop 工作流程 | `./install.sh all-with-workflow` |
+
+Claude plugin 安裝指令：
+
+```bash
 claude plugin marketplace add ./
 claude plugin install goldband@goldband --scope user
+```
+
+Claude plugin 不含 Goldband Loop。只想替單一工具加裝工作流程，或需要 Codex portable plugin、Claude Desktop／web／mobile 整合，請看[其他安裝選項](OPERATIONS.md#additional-install-options)。
+
+安裝後檢查狀態，並重新啟動 Claude Code／Codex：
+
+```bash
 ./install.sh status
 ```
 
-Codex 或雙工具安裝：
+所選組件應顯示 `[OK]`；若顯示過時、損壞或重複安裝，先依輸出指引處理。
 
-```bash
-git clone https://github.com/leo110047/goldband.git
-cd goldband
-./install.sh all-tools
-./install.sh status
+## 第一次使用工作流程
+
+安裝 Goldband Loop 後，可先檢查本機安裝狀態。在對應工具的對話中輸入：
+
+```text
+Claude Code: /goldband system health
+Codex:       $goldband system health
 ```
 
-需要 Goldband Loop workflow runtime：
+其他用途與指令見[工作流程清單](docs/generated/capabilities.md)。
 
-```bash
-./install.sh all-with-workflow
-```
+程式碼審查需要先為目標專案設定驗證契約；請從[審查入門](docs/review-evidence-manifest.md#quick-start)開始。需要本機隔離執行測試的正式審查目前僅支援 macOS；Linux／Windows 缺少這類證據時會回報未完成。測試或安裝成功也不代表審查、部署已完成。
 
-Windows 不維護 native PowerShell installer。請用 Git Bash 或 WSL 從完整
-git checkout 執行同一組 POSIX 指令。
+## 更新與移除
 
-## 常用命令
-
-```bash
-./install.sh status            # 檢查安裝狀態
-./install.sh pack-quality      # Claude Code core quality pack，不含 workflow runtime
-./install.sh codex-full        # Codex full setup
-./install.sh all-tools         # Claude Code + Codex
-./install.sh all-with-workflow # Claude Code + Codex + Goldband Loop
-./install.sh uninstall         # 移除 installer-managed assets
-```
-
-Plugin 移除：
-
-```bash
-claude plugin uninstall goldband@goldband
-```
-
-更新：
+在原本的 checkout 更新來源：
 
 ```bash
 git pull --ff-only
-./install.sh status
 ```
 
-更新後重跑原本的安裝組合，例如 `pack-quality`、`all-tools` 或
-`all-with-workflow`。
+接著依原本的安裝方式更新：
 
-## 重要邊界
+- **Installer**：重跑上表中原本使用的安裝指令，例如 Codex 使用者執行 `./install.sh codex-full`。
+- **Claude plugin**：執行 `claude plugin update goldband@goldband`。
 
-- 請使用完整 git checkout；不要只複製 `install.sh`。
-- Claude plugin、Codex plugin、Claude app adapters、installer full setup 是不同
-  distribution surface，不要互相宣稱替代。
-- `./install.sh status` 會 read back 安裝狀態；若 plugin 和 installer-managed
-  Claude assets 同時存在，它會回報 duplicate asset。
-- Workflow status 會分開驗證 installer-owned source-input digest、trusted
-  runtime artifact manifest 與 bounded dispatch probe；source 已更新、installed
-  bytes/inventory 被修改，或 launcher 行為不符宣告時都會非零失敗並要求重裝。
-- hooks、rules、cross-review gate、sandbox 是防誤操作與 evidence gate，不是
-  抵抗同權限 host 使用者的安全邊界。managed worktree 是較窄的例外：它用
-  OS sandbox 限制 agent process 的 Git metadata 寫入；host 使用者仍可在
-  sandbox 外管理與完成工作。
-- `all-with-workflow` 會安裝並驗證 Goldband Loop browser runtime；離線或 CI
-  可用 `GOLDBAND_SKIP_PLAYWRIGHT=1` 明確跳過 browser workflows。
+更新後執行 `./install.sh status`，再重新啟動工具。
 
-## Workflow 入口
-
-安裝 Goldband Loop 後：
-
-- Claude Code：`/goldband <capability> <action>`
-- Codex：`$goldband <capability> <action>`
-
-目前支援的 capability/action 清單以
-[docs/generated/capabilities.md](docs/generated/capabilities.md) 為準。
-
-### `review/code` 平台邊界
-
-第一次在其他專案建立 evidence contract 時，先執行
-`goldband review contract help` 找到 installed guide、public example 與 JSON
-Schema。`review contract init` 會在 canonical repo root 建立不覆寫既有檔案的
-fail-closed scaffold；完成 project-owned behavior/provider 後，以
-`review contract validate --manifest <path>` 呼叫正式 runtime validator。Validate
-不執行 evidence、不寫入 contract store，也不代表 review 或 deploy 已完成。完整欄位與
-安全邊界見 [manifest authoring guide](docs/review-evidence-manifest.md)。
-
-| 平台 | Goldband Loop 安裝 | executable sealed evidence | `review/code` 結果 |
-| --- | --- | --- | --- |
-| macOS | 支援 | 由 Seatbelt 執行 | evidence complete 後才可啟動 semantic review |
-| Linux | 支援其他 workflow 能力 | **不支援** | typed `runtime-incomplete`；不啟動 semantic review，也沒有 completion/closure authority |
-| Windows | Git Bash/WSL 可安裝部分能力 | **不支援** | 與 Linux 相同，fail closed |
-
-Linux 的 Bubblewrap 目前只負責 managed worktree boundary，**不是**
-`review/code` 的 sealed evidence runner，也不代表 review parity。若 effective
-contract 需要執行 executable evidence，請在受支援的 macOS Seatbelt host 執行。
-
-`review/code` 會先解析不可降級的 evidence contract。Repo 內的
-review 以 canonical Git repo root 作為 diff、snapshot、scope 與 contract 的
-共同座標；從 tracked subdirectory 啟動只會留下 execution offset，不會改變
-baseline。reviewed base 的 repo-root `goldband.review-evidence.json` 是
-authoritative baseline；base 沒有 manifest 時，才會使用使用者明確以
-`goldband review contract import --manifest <path>` 註冊的 runtime-owned
-per-repository contract。working-tree、index 或 caller 傳入的 manifest 都只能是
-完整、monotonic 的 candidate extension，不能取代或縮小 baseline。`inspect`
-可讀回 repo root、invocation offset、base/candidate tracking state、sources 與
-digests；`remove` 只移除 central entry。manifest contract 使用 `schemaVersion:
-2`。唯一的 v1 過渡路徑是已提交的 v1 base 搭配 v2 candidate，而且該 base
-必須在只改版本號後就能通過完整 v2 驗證；其他 v1 輸入會 fail closed 並回報
-migration 指引，不會猜測安全欄位的預設值。
-
-Goldband 自身三組需要建立 Seatbelt 邊界的自測，改由既有 `push dev` macOS CI
-執行，審查讀回相同 commit／tree 的指定 step 結果。未提交或尚無 CI 證據時仍
-回報未完成；不在外層隔離內重跑這三組自測，也不把 CI 當成本機 sealed evidence。
-Claude 與 Codex 共用此 runtime adapter，須經各自既有 installer 更新後才生效。
-詳見 [CI 證據契約](docs/review-evidence-manifest.md#goldband-自身的-macos-ci-自測)。
-
-解析完成後，runtime 在隔離、
-預設以每個 operation 各自獨立、唯讀且 read/write/network default-deny 的 snapshot 執行 typed checks，
-並驗證執行前後 tree digest、provider/cell 雙向 ownership 與 exact RED exit，確認 evidence completeness 與
-candidate provenance 後，才啟動一次 semantic review。script launcher 必須在 manifest 明確寫出 interpreter；
-repository-owned manifest 只接受 `persistent` provider；一次性的 RED/GREEN
-`transition` evidence 必須綁定 exact repository、base、candidate、scope 與
-operation contract digest，且只存在當次 artifact。Provider applicability 必須
-明確選擇非空 path prefixes 或附理由的 `global`，execution context 也必須宣告
-sandbox owner 與 runner；path applicability 會同時縮小 provider 與 effective
-behavior cells，無關的 high-risk cells 不會被誤算成 coverage gap。明確傳入的
-transition manifest 與 persisted review artifact 都會用當前 candidate binding
-走 production validator。需要 provider-owned Seatbelt 的 operation 在 sealed
-review runner 會先產生 typed `runtime-incomplete`，不會把 nested sandbox exit
-誤報成 candidate failure，也不具 completion/closure authority。
-macOS sandbox 會載入 Apple 的 common system process baseline，並精確重新封鎖 baseline 的 syslog、Mach service、
-shared-memory、network 與 system socket 通道。含非系統 dylib 的 Mach-O runtime 會先複製到私有 sealed projection，
-將已驗證的 load commands 改寫到 projection、ad-hoc sign 並重新雜湊最終 bytes；operation 不能讀原始 host package tree，
-也不能修改 projection。明確宣告 `pythonRuntime` 的 operation 另支援 Python 3.14 + `uv`：runtime 會在 operation
-專屬目錄以 frozen/offline lockfile 建立 candidate-bound environment，先完成 interpreter、stdlib、path 與
-dependency integrity preflight；準備失敗是 typed `runtime-incomplete` 且不啟動 semantic host，preflight 後的 gate
-exit mismatch 才是 `verified-failure`。Python／uv 只從 bounded system／Homebrew roots 選取並在 Seatbelt
-內檢查；registry package 會以安裝後的 `WHEEL` tag 唯一選出 lock 內實際使用的 wheel filename/hash，無法唯一對應就 fail closed，未使用 cache entry 不影響 identity。除此之外只允許 candidate 與必要 dependency roots，
-不會因此允許任意 HOME、其他 workspace 或 `/tmp` 內容。初審有 findings 且
-候選內容修正後，可用 `--closure-artifact <initial-artifact>` 做一次只看 repair
-delta、原 finding IDs 與 rerun evidence 的 closure；修正版 manifest 新增或修改的
-affected cells 也會重跑，且沒有 fresh passing evidence 就不能標成 `closed`。初審無
-findings 時不會啟動 closure；closure 也必須讀回 installed runtime authority 簽發的 receipt，caller
-只靠修改 JSON、跨 Work Map scope 或重播舊 claim attempt 都會 fail closed。這個邊界把 reviewed
-candidate、model output 與 artifact input 視為不可信，但信任同一 OS account 下的 Goldband installer/runtime；
-若同一 host user 已惡意控制 authority store，需另加 privileged helper 或 OS-backed key 才能隔離。
-Closure receipt 採 at-most-once：repair binding 與 Work Map 因果鏈驗證完成後會以 atomic claim 消耗；
-claim 後若 process crash 或後續失敗，必須重新做 initial review，不能重播同一 receipt。
-若 authoritative artifact 的 `hostCallCount=0` 且只有 deterministic findings，同一
-`--closure-artifact` 入口會明確路由成 pre-semantic evidence repair，而不是 semantic closure。
-它保留原 lineage、receipt、finding IDs 與 contract authority，只重跑受修復或 monotonic strengthening
-影響的 typed cells；evidence 仍不完整時維持零 host calls 與未關閉 blockers，通過後才執行該
-lineage 唯一一次 initial semantic review。新 artifact 會讀得出 predecessor digests 與 affected cells。
-被 secret redaction 隱藏的 untracked 檔仍會以 digest 綁定並經非 prompt 通道放入 executable snapshot。Fixture/local/live/device/production evidence 會分開標示，green gate 不會
-被解讀成整體 deploy readiness。
-
-跨次 review 由 installed runtime 的 signed acceptance lineage 管理。新
-manifest 只能增加 coverage，不能刪除、反轉或降低既有 required cells；`manual`／`unsupported`
-可以 strengthening 成有 typed provider 的 disposition，反向或不同 evidence 模式間的替換仍會被拒絕。
-有未關閉 finding 時，只能依 artifact state 走 evidence repair 或 scoped closure。空的 initial candidate 會在建立 lineage 前被拒絕；
-standalone lineage 會綁定正規化 changed-file scope，舊 signed record 也只有在
-authoritative artifact 證明 scope 相同時才會遷移；若 artifact 無法驗證，signed
-candidate digest 完全相同仍會保留 blocker，但不會讓無關候選繼承不可判定的 broad scope。
-同一 collection scope 下，只要新 initial candidate 與未關閉 changed-file scope 有重疊，
-包含新增或移除修復檔，都必須走 closure；排序後的 per-path authority locks 讓 overlap
-scan 到 finalize 保持原子性，而完全 disjoint 的 scope 仍可獨立執行。
-專案可在 base commit 提交 typed
-`goldband.review-policy.json`，設定 minimum evidence level 或有歸責、期限的
-waiver；model prose 與 candidate 臨時檔沒有 waiver 權限。`No new findings`
-也不等於完成，report 會分開列出 contract completeness、prior blockers、closure
-與 completion authority。
-
-平行 agent worktree 使用兩個 user-triggered 指令：
+移除時也依安裝方式擇一：
 
 ```bash
-goldband worktree create task-name
-# managed shell 內擇一啟動；外層 Goldband sandbox 仍是 hard boundary
-claude --settings '{"sandbox":{"enabled":false}}'
-codex --sandbox danger-full-access
-# 完成後 exit
-goldband worktree finish task-name -m "feat: integrate task"
+./install.sh uninstall                       # 移除 installer 管理的組件
+claude plugin uninstall goldband@goldband    # 移除 Claude plugin
 ```
 
-`create` 只接受乾淨、位於正常 branch 的 source worktree，並建立 detached
-worktree；不建立 task branch。managed shell 內工作檔可寫，但 Git index、
-objects、refs、broker runtime 與 Git config/hook inputs 由 OS sandbox 保持唯讀。
-`finish` 必須在退出 managed shell 後執行；broker 使用固定 Git executable、隔離
-config environment 與 create 時記錄的 source-owned hook contract，且 source 的
-ignored content 若與 candidate tree 衝突就停止。只有驗證、整合與 durable commit
-都成功才會移除 worktree。macOS 使用 Seatbelt、Linux 使用 bubblewrap；boundary
-不可用時會 fail closed。Windows 目前不宣稱有 hard enforcement。agent 的內建 OS
-sandbox 必須依上例停用，避免 macOS 不支援的 nested sandbox；一般 permission
-prompts 與 Goldband hooks 不會因此停用，Git 寫入權仍由外層 managed boundary
-封鎖。
+## 文件與協助
 
-## 開發
+- [操作與疑難排解](OPERATIONS.md)：其他安裝選項、managed worktree、MCP 與維運。
+- [Goldband Loop](goldband-loop/README.md)：工作流程的設定與使用。
+- [開發與貢獻](CONTRIBUTING.md)：開發環境、測試與套件更新流程。
+- [架構說明](ARCHITECTURE.md)：元件分工與隔離、驗證機制。
+- [回報問題](https://github.com/leo110047/goldband/issues)：請附使用平台、安裝方式及相關錯誤輸出，移除金鑰等敏感資訊。
 
-Repo root 的預設聚合測試入口是：
+## 授權
 
-```bash
-npm run bootstrap:test # 首次 clone、更新 lockfile 或 installer migration 後執行
-npm test
-# or
-bun run test
-```
-
-`bootstrap:test` 會安裝 root、`mcp/server` 與 `goldband-loop` 各自宣告的
-dependencies，並只清除舊 installer 留在 ignored host skill roots 下的
-generated entries；ownership 必須由 tracked retired inventory 或 managed marker
-證明，同前綴的未知 skill 會保留。`npm test` 本身不會連網或偷偷修改 checkout；
-它會先檢查 dependencies、Bun minimum 與 legacy artifacts，再跑一組明確列出的
-package-owned suites，最後輸出 per-suite summary。查看清單：
-
-```bash
-npm run test:repo:list
-```
-
-不要把 repo root 裸跑 `bun test` 當作 repo 驗證；那會繞過子專案自己的測試
-合約，改成讓 Bun 遞迴掃檔，輸出也沒有 per-package summary。
-
-常用 targeted gates：
-
-```bash
-npm run test:plugin-distribution
-npm run test:app-support
-npm run test:hook-router
-npm run test:cross-review
-npm run lint:style
-```
-
-改到會餵進 Claude plugin 的來源後：
-
-```bash
-node scripts/sync-plugin-assets.mjs
-npm run test:plugin-distribution
-```
-
-改到 Codex plugin 或 Claude app adapter 來源後：
-
-```bash
-npm run sync:app-support
-npm run test:app-support
-```
-
-更多貢獻流程看 [CONTRIBUTING.md](CONTRIBUTING.md)。
-
-## 文件地圖
-
-- [ARCHITECTURE.md](ARCHITECTURE.md)：root goldband、Claude/Codex surfaces、
-  Goldband Loop 的 ownership 和 runtime contract。
-- [OPERATIONS.md](OPERATIONS.md)：安裝維運、Codex overlay、style gate、MCP、
-  telemetry。
-- [CONTRIBUTING.md](CONTRIBUTING.md)：開發流程與 plugin distribution checks。
-- [docs/generated/capabilities.md](docs/generated/capabilities.md)：Goldband Loop
-  capability/action catalog。
-- [goldband-loop/README.md](goldband-loop/README.md)：workflow runtime 入口。
-- [mcp/README.md](mcp/README.md)：MCP templates 和 first-party
-  `goldband-mcp`。
-- [sandbox/THREAT-MODEL.md](sandbox/THREAT-MODEL.md)：container sandbox 的保護
-  範圍與不保護項目。
-- [docs/knowledge-system.md](docs/knowledge-system.md)：local knowledge layer。
-- [docs/DECISIONS.md](docs/DECISIONS.md)：重要決策紀錄。
-
-## License
-
-MIT License.
+[MIT License](LICENSE)。

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2452,3 +2452,37 @@ Revisit triggers:
   that justify a curated preset with a named owner and compatibility policy.
 - The manifest model moves to a declarative source capable of generating both
   the runtime validator and JSON Schema without losing graph semantics.
+
+
+## 2026-09-08 — CI owns Goldband's macOS sandbox self-tests
+
+Supersedes the self-test execution choice in “Same-host execution for
+provider-owned review evidence”; other local evidence boundaries remain.
+
+The named host lane still wrapped each test process in the runtime's Seatbelt
+profile. Tests creating a different inner profile failed with `sandbox_apply`,
+and installed-runtime tests lost their temporary environment inside the sealed
+runtime, failed with EPERM and timed out. Identical nested profiles can work,
+but the actual tests require different profiles; broadening individual allowed
+operations did not provide a valid boundary for these tests.
+
+Use the existing public `push dev` macOS CI job for the three existing provider
+operations. Add explicit steps before candidate build scripts, keep the full
+workflow suite, and read only exact commit/tree/run/attempt/step metadata through
+a fixed GitHub API adapter. The trusted runtime pins the entire workflow recipe.
+GitHub's native commit tree is checked as well as local Git to reject replacement
+objects or a misleading local HEAD. No new runner service, token handling,
+evidence upload, caller-supplied JSON, or unsandboxed local fallback is added.
+
+This explicitly accepts trusted writable CI execution for these self-tests;
+it does not attest an immutable checkout, exit code, network denial, or overall
+pipeline success. Non-success or unavailable metadata stays runtime-incomplete.
+The operation network field does not grant the consumer candidate-controlled
+network actions; the CI workflow owns its network environment. Only the three
+unchanged operations have a one-way transport migration. Existing signed
+receipts, finding IDs and closure obligations remain authoritative.
+
+Consequences: uncommitted candidates cannot obtain CI evidence, and a changed
+workflow requires a reviewed runtime recipe update. Local unit and installed
+fixture tests validate the adapter but cannot substitute for a live candidate
+CI run. Both existing installers bundle the shared consumer and guide.

--- a/docs/review-evidence-manifest.md
+++ b/docs/review-evidence-manifest.md
@@ -190,6 +190,42 @@ Global provider 每次都適用，必須說明原因。不要為了省下 path d
 
 如果正式 producer／consumer handoff 不存在，runtime 會回報 `runtime-incomplete`，不會把 nested sandbox failure 當成 candidate failure。
 
+### Goldband 自身的 macOS CI 自測
+
+Goldband 的 `review-evidence-tests`、`work-map-review-tests` 與
+`installed-runtime-tests` 使用固定 CI lane：
+
+```json
+{ "sandboxOwner": "provider", "runner": "github-actions", "lane": "goldband-macos-review-host" }
+```
+
+這不是通用 CI 設定介面。Shared runtime 的 `review-ci-evidence.ts` 擁有三組
+provider／原始 argv 與受信任 workflow digest；Claude、Codex 的 installer
+都將此 adapter 納入既有 runtime bundle，沒有新增 launcher、token 或上傳入口。
+
+Consumer 只以唯讀 GitHub API 查詢公開的 `leo110047/goldband`：既有
+`validate.yml`、`push dev`、同一 commit、最新 run 及精確 attempt 的三個獨立
+step。它同時比對完整 materialized candidate 的 Git tree、本機 commit tree
+與 GitHub 原生 commit tree，並在讀回 job 後重新核對 run attempt。
+Workflow 必須符合已安裝 runtime 內的固定 digest；修改執行配方時必須一起
+審查並更新該 digest，不能從 candidate 自行接受新的配方。
+
+證據表示指定 commit 在受信任 macOS CI 的**可寫 checkout** 上執行指定測試
+step 成功。它不宣稱唯讀 snapshot、命令 exit code、OS network deny 或完整
+CI pipeline 成功。CI 可使用網路；operation 的 `network: deny` 不授權 consumer
+替 candidate 執行外部操作，且不代表 CI 的網路隔離政策。Consumer 的平台
+metadata 查詢由固定 adapter 擁有，不執行 candidate 的 argv 或接受手寫結果。
+
+未提交的 candidate、缺少結果、API 失敗、step 失敗／跳過／timeout、配方不符
+或重跑競態都會留下 `runtime-incomplete`。只有符合條件的成功結果可以標記
+`verified-pass`；失敗的 step metadata 不足以宣稱原命令的 `verified-failure`。
+因此尚未推送並跑完 CI 時，semantic host 仍會被 evidence completeness 擋住。
+
+既有三組 provider 可由舊 `macos-review-contract-host` 單向遷移到此固定 lane，
+但不得改掉 operation、降低證據等級或移除 cell。舊 receipt／lineage／finding
+保留，仍須透過原有 evidence-repair／closure 驗證 fresh evidence；契約遷移本身
+不會關閉 finding。其他 providers 仍使用原本的 sealed 或 host-seatbelt runner。
+
 ## Operations
 
 Operation 的主要欄位：

--- a/goldband-loop/README.md
+++ b/goldband-loop/README.md
@@ -170,7 +170,7 @@ skill discovery.
 ## Requirements
 
 - Git
-- Bun v1.0+
+- Bun v1.3.11+
 - Node.js where required by the host or platform
 - Playwright Chromium for browser-backed workflows
 

--- a/goldband-loop/config/source-complexity-baseline.json
+++ b/goldband-loop/config/source-complexity-baseline.json
@@ -679,11 +679,11 @@
     "workflows/review-evidence.ts": {
       "lint/complexity/noExcessiveCognitiveComplexity": [
         45,
-        38,
         37,
         32,
         30,
         29,
+        28,
         27,
         27,
         23,
@@ -701,9 +701,9 @@
       ],
       "lint/complexity/noExcessiveLinesPerFunction": [
         94,
-        89,
         87,
         78,
+        72,
         67,
         61,
         56,

--- a/goldband-loop/test/codex-review-launcher-install.test.ts
+++ b/goldband-loop/test/codex-review-launcher-install.test.ts
@@ -662,10 +662,25 @@ describe("Codex trusted workflow launcher install", () => {
 				const repairRepo = join(fixture, "pre-semantic-repair-repo");
 				mkdirSync(repairRepo, { recursive: true });
 				expect(spawnSync("git", ["init", "-q"], { cwd: repairRepo }).status).toBe(0);
+				const repairInitialManifest = installedUnsupportedManifest();
+				const unrelatedProvider = {
+					...installedHighRiskReviewEvidenceManifest().providers[0],
+					id: "unrelated-gate",
+					cellIds: ["unrelated-static"],
+					applicability: { kind: "paths", pathPrefixes: ["unrelated"] },
+				};
+				repairInitialManifest.providers.push(unrelatedProvider);
+				repairInitialManifest.behaviorMatrix.push(
+					{ ...repairInitialManifest.behaviorMatrix[0], id: "unrelated-manual",
+						behavior: "The unrelated manual boundary is checked.", disposition: "manual" },
+					{ ...installedHighRiskReviewEvidenceManifest().behaviorMatrix[0], id: "unrelated-static",
+						behavior: "The unrelated static boundary is checked.", providerIds: ["unrelated-gate"] },
+				);
+
 				writeFileSync(join(repairRepo, "review-me.txt"), "baseline\n");
 				writeFileSync(
 					join(repairRepo, "goldband.review-evidence.json"),
-					`${JSON.stringify(installedUnsupportedManifest())}\n`,
+					`${JSON.stringify(repairInitialManifest)}\n`,
 				);
 				expect(spawnSync("git", ["add", "."], { cwd: repairRepo }).status).toBe(0);
 				expect(spawnSync("git", [
@@ -694,7 +709,13 @@ describe("Codex trusted workflow launcher install", () => {
 				expect(lineCount(hostCallLog)).toBe(deterministicHostCallsBefore);
 
 				const repairedManifest = join(fixture, "pre-semantic-repaired-contract.json");
-				writeFileSync(repairedManifest, `${JSON.stringify(installedHighRiskReviewEvidenceManifest())}\n`);
+				const repairContract = installedHighRiskReviewEvidenceManifest();
+				repairContract.behaviorMatrix.push(
+					{ ...repairInitialManifest.behaviorMatrix[1], providerIds: ["unrelated-gate"] },
+					repairInitialManifest.behaviorMatrix[2],
+				);
+				repairContract.providers.push({ ...unrelatedProvider, cellIds: ["unrelated-static", "unrelated-manual"] });
+				writeFileSync(repairedManifest, `${JSON.stringify(repairContract)}\n`);
 				writeFileSync(
 					join(repairRepo, "candidate.patch"),
 					installedCandidatePatch("deterministic evidence repaired"),
@@ -721,9 +742,12 @@ describe("Codex trusted workflow launcher install", () => {
 							transition: "evidence-repair",
 							runId: deterministicArtifact.runId,
 							receiptId: deterministicArtifact.runtimeReceipt.id,
-							findingIds: ["D-001"],
+							findingIds: ["D-001", "D-002"],
+							affectedCellIds: ["installed-review", "unrelated-manual", "unrelated-static"],
 						},
 					});
+					expect(repairedArtifact.evidence.records.map((record) => record.id)).toEqual(["installed-gate:pass"]);
+					expect(repairedArtifact.findings).toMatchObject([{ id: "S-001", classification: "semantic-concern" }]);
 					expect(lineCount(hostCallLog)).toBe(deterministicHostCallsBefore + 1);
 					writeFileSync(
 						join(repairRepo, "candidate.patch"),

--- a/goldband-loop/test/review-evidence.test.ts
+++ b/goldband-loop/test/review-evidence.test.ts
@@ -44,6 +44,8 @@ import {
   type ReviewEvidenceManifest,
 } from '../workflows/review-evidence';
 import { getWorkflow } from '../workflows/registry';
+import { readReviewCiResult, reviewCandidateTree, collectReviewCiEvidence, validateReviewCiProvenance } from '../workflows/review-ci-evidence';
+import { assertReviewContractNotWeaker } from '../workflows/review-lineage';
 import { runWorkflow } from '../workflows/runtime';
 import {
   buildClosureReviewPrompt,
@@ -978,7 +980,8 @@ describe('review evidence contracts', () => {
   test('repairs deterministic-only lineage before the first semantic host call', async () => {
     if (!hostBoundaryPrerequisite(process.platform === 'darwin', 'platform=darwin')) return;
     const repo = gitFixture();
-    const state = join(repo, '.state');
+    const state = mkdtempSync(join(tmpdir(), 'review-repair-state-'));
+    roots.push(state);
     const diffFile = join(repo, 'candidate.diff');
     const evidenceFile = join(repo, 'evidence.json');
     const unsupported = manifest();
@@ -988,7 +991,25 @@ describe('review evidence contracts', () => {
       providerIds: [],
       reason: 'The deterministic provider is not wired yet.',
     };
-    unsupported.providers = [];
+    unsupported.behaviorMatrix.push({
+      ...unsupported.behaviorMatrix[0]!,
+      id: 'unrelated-manual',
+      behavior: 'The unrelated manual boundary is checked.',
+      disposition: 'manual',
+      reason: 'The unrelated path needs its existing provider binding.',
+    });
+    unsupported.providers = [{
+      ...manifest().providers[0]!,
+      id: 'unrelated-provider',
+      cellIds: ['unrelated-static'],
+      applicability: { kind: 'paths', pathPrefixes: ['unrelated'] },
+    }];
+    unsupported.behaviorMatrix.push({
+      ...manifest().behaviorMatrix[0]!,
+      id: 'unrelated-static',
+      behavior: 'The unrelated static boundary is checked.',
+      providerIds: ['unrelated-provider'],
+    });
     writeFileSync(evidenceFile, `${JSON.stringify(unsupported)}\n`);
     writeFileSync(diffFile, 'diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-old();\n+bad();\n');
 
@@ -1004,7 +1025,7 @@ describe('review evidence contracts', () => {
       file.endsWith('-review-evidence.json'))!;
     const initialArtifact = JSON.parse(readFileSync(initialArtifactFile, 'utf8')) as InitialReviewArtifact;
     expect(initialArtifact.hostCallCount).toBe(0);
-    expect(initialArtifact.findings.map((finding) => finding.id)).toEqual(['D-001']);
+    expect(initialArtifact.findings.map((finding) => finding.id), JSON.stringify(initialArtifact.findings)).toEqual(['D-001', 'D-002']);
 
     writeFileSync(diffFile, 'diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-old();\n+still-bad();\n');
     const incompleteRecovery = await runWorkflow(getWorkflow('review/code'), {
@@ -1024,9 +1045,24 @@ describe('review evidence contracts', () => {
     const incompleteArtifact = JSON.parse(
       readFileSync(incompleteArtifactFile, 'utf8'),
     ) as InitialReviewArtifact;
-    expect(incompleteArtifact.findings.map((finding) => finding.id)).toEqual(['D-001']);
+    expect(incompleteArtifact.findings.map((finding) => finding.id)).toEqual(['D-001', 'D-002']);
 
     const repaired = manifest();
+    repaired.providers[0]!.operations[0] = {
+      ...operation('pass', ['node', '-e',
+        "process.exit(require('node:fs').readFileSync('a.ts', 'utf8').includes('fixed') ? 0 : 1)",
+      ], 'candidate', 'zero'),
+      requiredSystemTools: ['node'],
+    };
+    repaired.behaviorMatrix.push(
+      { ...unsupported.behaviorMatrix[1]!, providerIds: ['unrelated-provider'] },
+      unsupported.behaviorMatrix[2]!,
+    );
+    repaired.providers.push({
+      ...unsupported.providers[0]!,
+      cellIds: ['unrelated-static', 'unrelated-manual'],
+    });
+    reviewEvidenceManifestSchema.validate(repaired);
     writeFileSync(evidenceFile, `${JSON.stringify(repaired)}\n`);
     writeFileSync(diffFile, 'diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-old();\n+good();\n');
     const recovery = await runWorkflow(getWorkflow('review/code'), {
@@ -1041,12 +1077,18 @@ describe('review evidence contracts', () => {
 
     expect(String(recovery.output)).toContain('Phase: evidence-repair.');
     expect(String(recovery.output)).toContain('Semantic host calls: 1.');
-    expect(String(recovery.output)).toContain('completion-authorized: true');
+    expect(String(recovery.output)).toContain('completion-authorized: false');
     const recoveredArtifactFile = recovery.artifacts.find((file) =>
       file.endsWith('-review-evidence.json'))!;
     const recoveredArtifact = validateInitialReviewArtifact(
       JSON.parse(readFileSync(recoveredArtifactFile, 'utf8')),
     );
+    expect(recoveredArtifact.evidence.completeness.complete).toBe(true);
+    expect(recoveredArtifact.findings).toMatchObject([
+      { classification: 'verified-failure', blocking: true },
+      { classification: 'semantic-concern' },
+    ]);
+    expect(recoveredArtifact.evidence.records.map((entry) => entry.id)).toEqual(['provider-a:pass']);
     expect(recoveredArtifact).toMatchObject({
       phase: 'initial',
       hostCallCount: 1,
@@ -1054,9 +1096,44 @@ describe('review evidence contracts', () => {
         transition: 'evidence-repair',
         runId: incompleteArtifact.runId,
         receiptId: incompleteArtifact.runtimeReceipt.id,
-        findingIds: ['D-001'],
+        findingIds: ['D-001', 'D-002'],
+        affectedCellIds: ['behavior-a', 'unrelated-manual', 'unrelated-static'],
       },
     });
+    const closureContext = {
+      ...context(repo),
+      options: { mode: 'mock' as const, goldbandHome: state, closureArtifactFile: recoveredArtifactFile },
+    };
+    expect(readClosureArtifact(closureContext)).toEqual(recoveredArtifact);
+    const corruptFile = join(repo, 'corrupt.json');
+    for (const corrupt of [
+      (value: InitialReviewArtifact) => { value.evidence.records = []; },
+      (value: InitialReviewArtifact) => { value.evidence.records[0]!.fresh = false; },
+      (value: InitialReviewArtifact) => { value.evidence.records[0]!.cellIds = ['unrelated-static']; },
+      (value: InitialReviewArtifact) => { value.findings[0]!.summary = 'forged'; },
+      (value: InitialReviewArtifact) => { value.runtimeReceipt.signature = '0'.repeat(64); },
+    ]) {
+      const value = structuredClone(recoveredArtifact);
+      corrupt(value);
+      writeFileSync(corruptFile, JSON.stringify(value));
+      expect(() => readClosureArtifact({
+        ...closureContext,
+        options: { ...closureContext.options, closureArtifactFile: corruptFile },
+      })).toThrow();
+    }
+    writeFileSync(diffFile, 'diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-old();\n+fixed();\n');
+    const closure = await runWorkflow(getWorkflow('review/code'), {
+      mode: 'mock', host: 'mock', cwd: repo, goldbandHome: state,
+      diffFile: 'candidate.diff', evidenceManifestFile: 'evidence.json',
+      closureArtifactFile: recoveredArtifactFile,
+    });
+    expect(String(closure.output)).toContain('Phase: closure.');
+    expect(String(closure.output)).toContain('completion-authorized: true');
+    const closureArtifact = JSON.parse(readFileSync(closure.artifacts.find((file) =>
+      file.endsWith('-review-closure.json'))!, 'utf8'));
+    expect(closureArtifact.affectedCellIds).toEqual(['behavior-a', 'unrelated-manual', 'unrelated-static']);
+    expect(closureArtifact.evidence.records.map((entry) => entry.id)).toEqual(['provider-a:pass']);
+    expect(closureArtifact.results.map((entry) => entry.status)).toEqual(['closed', 'closed']);
   });
 
   test('partial evidence repair preserves unresolved deterministic finding identity', async () => {
@@ -2138,12 +2215,16 @@ describe('review evidence contracts', () => {
 
   test('root external-runner enforcement remains fail closed when its provider applies', async () => {
     const repo = gitFixture();
+    mkdirSync(join(repo, 'goldband-loop/workflows'), { recursive: true });
+    writeFileSync(join(repo, 'goldband-loop/workflows/review-evidence.ts'), 'old();\n');
+    git(repo, ['add', '.']); git(repo, ['commit', '-m', 'provider scope']);
+    writeFileSync(join(repo, 'goldband-loop/workflows/review-evidence.ts'), 'fixed();\n');
     const rootManifest = reviewEvidenceManifestSchema.validate(
       JSON.parse(readFileSync(join(import.meta.dir, '../../goldband.review-evidence.json'), 'utf8')),
     );
     const input = {
       source: 'git diff',
-      diff: 'diff --git a/goldband-loop/workflows/review-evidence.ts b/goldband-loop/workflows/review-evidence.ts',
+      diff: git(repo, ['diff', '--binary']),
       changedFiles: ['goldband-loop/workflows/review-evidence.ts'],
     };
     const evidence = await executeEvidencePlan(
@@ -3354,3 +3435,203 @@ function initialArtifact(): InitialReviewArtifact {
     },
   };
 }
+
+
+describe('candidate-bound GitHub review evidence', () => {
+  const revision = 'a'.repeat(40);
+  const tree = 'b'.repeat(40);
+  const providerId = 'review-evidence-tests';
+  function apiFixture(revisionValue = revision, treeValue = tree) {
+    const revision = revisionValue; const tree = treeValue;
+    const run = { id: 10, run_attempt: 2, head_sha: revision, path: '.github/workflows/validate.yml',
+      event: 'push', head_branch: 'dev', repository: { full_name: 'leo110047/goldband' },
+      head_repository: { full_name: 'leo110047/goldband' }, status: 'completed' };
+    const step = { name: `Review evidence - ${providerId}`, status: 'completed', conclusion: 'success' };
+    const job = { id: 20, run_id: 10, head_sha: revision, name: 'macOS Seatbelt review evidence contracts',
+      status: 'completed', conclusion: 'failure', steps: [step] };
+    const replies: Record<string, any> = {
+      [`git/commits/${revision}`]: { sha: revision, tree: { sha: tree } },
+      [`actions/workflows/validate.yml/runs?head_sha=${revision}&event=push&branch=dev&per_page=100`]: { workflow_runs: [run] },
+      'actions/runs/10/attempts/2/jobs?per_page=100': { total_count: 1, jobs: [job] },
+      'actions/runs/10': structuredClone(run),
+    };
+    const calls: string[] = [];
+    const read = async (path: string) => { calls.push(path); if (!(path in replies)) throw new Error(`unexpected API ${path}`); return replies[path]; };
+    return { run, step, job, replies, calls, read };
+  }
+  test('accepts only the exact step and attempt, independently of a later unrelated job failure', async () => {
+    const api = apiFixture();
+    const proof = await readReviewCiResult(revision, tree, providerId, api.read);
+    expect(proof).toMatchObject({ revision, tree, runId: 10, attempt: 2, jobId: 20, conclusion: 'success' });
+    expect(api.calls).toEqual(Object.keys(api.replies));
+    expect(() => validateReviewCiProvenance(proof, providerId)).not.toThrow();
+    expect(() => validateReviewCiProvenance({ ...proof, runId: -1 }, providerId)).toThrow();
+  });
+  test('rejects a replacement tree even when the local commit identity has a green run', async () => {
+    const api = apiFixture();
+    await expect(readReviewCiResult(revision, 'c'.repeat(40), providerId, api.read)).rejects.toThrow('commit tree');
+    expect(api.calls).toHaveLength(1);
+  });
+  test('does not reuse an older green run when the newest attempt is pending', async () => {
+    const api = apiFixture();
+    api.replies[Object.keys(api.replies)[1]!].workflow_runs.push({ ...api.run, id: 11, status: 'in_progress' });
+    await expect(readReviewCiResult(revision, tree, providerId, api.read)).rejects.toThrow('still running');
+  });
+  for (const conclusion of ['failure', 'cancelled', 'skipped', 'timed_out', 'neutral']) {
+    test(`does not promote CI ${conclusion} to verified execution`, async () => {
+      const api = apiFixture(); api.step.conclusion = conclusion;
+      await expect(readReviewCiResult(revision, tree, providerId, api.read)).rejects.toThrow('no successful execution');
+    });
+  }
+  test('rejects wrong run provenance, ambiguous steps, truncated jobs, and concurrent reruns', async () => {
+    for (const field of ['event', 'head_branch', 'path', 'head_sha']) {
+      const api = apiFixture(); (api.run as any)[field] = 'wrong';
+      await expect(readReviewCiResult(revision, tree, providerId, api.read)).rejects.toThrow('does not match');
+    }
+    let api = apiFixture(); api.job.steps.push({ ...api.step });
+    await expect(readReviewCiResult(revision, tree, providerId, api.read)).rejects.toThrow('no successful execution');
+    api = apiFixture(); api.replies['actions/runs/10/attempts/2/jobs?per_page=100'].total_count = 101;
+    await expect(readReviewCiResult(revision, tree, providerId, api.read)).rejects.toThrow('truncated');
+    api = apiFixture(); api.replies['actions/runs/10'].run_attempt = 3;
+    await expect(readReviewCiResult(revision, tree, providerId, api.read)).rejects.toThrow('changed while');
+  });
+  test('materialized tree matches native Git with modes, symlinks, sorting and empty directories', () => {
+    const repo = gitFixture();
+    mkdirSync(join(repo, 'a-dir')); mkdirSync(join(repo, 'a-dir', 'empty'));
+    writeFileSync(join(repo, 'a-dir', 'unicode-中'), 'content');
+    writeFileSync(join(repo, 'a-dir.txt'), 'prefix ordering');
+    chmodSync(join(repo, 'check.mjs'), 0o755); symlinkSync('a.ts', join(repo, 'link'));
+    git(repo, ['add', '.']); git(repo, ['commit', '-m', 'tree']);
+    const snapshot = mkdtempSync(join(tmpdir(), 'review-ci-tree-')); roots.push(snapshot);
+    const archive = spawnSync('git', ['archive', 'HEAD'], { cwd: repo });
+    expect(spawnSync('tar', ['-xf', '-', '-C', snapshot], { input: archive.stdout }).status).toBe(0);
+    expect(reviewCandidateTree(snapshot)).toBe(git(repo, ['rev-parse', 'HEAD^{tree}']).trim());
+    writeFileSync(join(snapshot, 'a.ts'), 'different');
+    expect(reviewCandidateTree(snapshot)).not.toBe(git(repo, ['rev-parse', 'HEAD^{tree}']).trim());
+  });
+  test('only permits the three named one-way runner migrations while preserving the operation contract', () => {
+    const after = reviewEvidenceManifestSchema.validate(JSON.parse(readFileSync(join(import.meta.dir, '../../goldband.review-evidence.json'), 'utf8')));
+    const before = structuredClone(after);
+    const providers = before.providers.filter((provider) => provider.executionContext.runner === 'github-actions');
+    expect(providers).toHaveLength(3);
+    for (const provider of providers) provider.executionContext = { sandboxOwner: 'provider', runner: 'host-seatbelt', lane: 'macos-review-contract-host' };
+    expect(() => assertReviewContractNotWeaker(before, after)).not.toThrow();
+    expect(() => assertReviewContractNotWeaker(after, before)).toThrow('contract laundering blocked');
+    for (const mutate of [
+      (p: any) => { p.executionContext.lane = 'other'; },
+      (p: any) => { p.operations[0].argv = ['true']; },
+      (p: any) => { p.operations[0].expectedExit = 'nonzero'; },
+      (p: any) => { p.operations[0].evidenceLevel = 'fixture'; },
+      (p: any) => { p.operations[0].network = 'authorized'; },
+    ]) {
+      const changed = structuredClone(after); mutate(changed.providers.find((p) => p.id === providerId));
+      expect(() => assertReviewContractNotWeaker(before, changed)).toThrow('contract laundering blocked');
+    }
+  });
+  test('producer signs CI provenance, rejects tampering, and closes only the original matching failure', async () => {
+    const repo = gitFixture();
+    git(repo, ['remote', 'add', 'origin', 'https://github.com/leo110047/goldband.git']);
+    mkdirSync(join(repo, '.github/workflows'), { recursive: true });
+    copyFileSync(join(import.meta.dir, '../../.github/workflows/validate.yml'), join(repo, '.github/workflows/validate.yml'));
+    git(repo, ['add', '.']); git(repo, ['commit', '-m', 'CI recipe']);
+    let value = manifest();
+    const rootManifest = JSON.parse(readFileSync(join(import.meta.dir, '../../goldband.review-evidence.json'), 'utf8'));
+    const provider = rootManifest.providers.find((p: any) => p.id === providerId);
+    provider.cellIds = ['behavior-a']; provider.applicability = { kind: 'global', reason: 'CI producer fixture' };
+    value.providers = [provider]; value.behaviorMatrix[0]!.providerIds = [providerId];
+    value = reviewEvidenceManifestSchema.validate(value);
+    const input = { source: 'git diff', diff: '', changedFiles: [] };
+    const binding = createCandidateBinding(repo, input, value);
+    const api = apiFixture(git(repo, ['rev-parse', 'HEAD']).trim(), git(repo, ['rev-parse', 'HEAD^{tree}']).trim());
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, options: RequestInit) => {
+      expect(String(url)).toStartWith('https://api.github.com/repos/leo110047/goldband/');
+      expect(options.redirect).toBe('error');
+      expect(options.headers).not.toHaveProperty('Authorization');
+      return Response.json(await api.read(String(url).split('/goldband/')[1]!));
+    }) as typeof fetch;
+    const state = mkdtempSync(join(tmpdir(), 'review-ci-state-')); roots.push(state);
+    const ctx = { ...context(repo), options: { mode: 'mock' as const, goldbandHome: state } };
+    try {
+      const evidence = await executeEvidencePlan(ctx, input, value, binding);
+      expect(evidence.completeness).toMatchObject({ complete: true, hostEligible: true });
+      expect(evidence.records[0]).toMatchObject({ status: 'verified-pass', fresh: true });
+      expect(evidence.records[0]!.exitStatus).toBeUndefined();
+      expect(evidence.records[0]!.snapshotDigestBefore).toBeUndefined();
+      const artifact = initialArtifact(); artifact.evidence = evidence; artifact.binding = binding; artifact.diff = '';
+      artifact.findings[0]!.evidenceIds = [evidence.records[0]!.id];
+      expect(validateInitialReviewArtifact(artifact)).toBe(artifact);
+      const { runtimeReceipt: _receipt, ...payload } = artifact;
+      const file = join(state, 'ci-artifact.json');
+      writeInitialReviewArtifact(file, payload, ctx);
+      const readCtx = { ...ctx, options: { ...ctx.options, closureArtifactFile: file } };
+      expect(readClosureArtifact(readCtx)!.evidence.records[0]!.ciProvenance).toEqual(evidence.records[0]!.ciProvenance);
+      const corrupt = JSON.parse(readFileSync(file, 'utf8'));
+      corrupt.evidence.records[0].ciProvenance.runId += 1;
+      writeFileSync(file, JSON.stringify(corrupt));
+      expect(() => readClosureArtifact(readCtx)).toThrow();
+      const fabricated = structuredClone(artifact); fabricated.evidence.records[0]!.exitStatus = 0;
+      expect(() => validateInitialReviewArtifact(fabricated)).toThrow('cannot claim a local exit');
+
+      const original = structuredClone(artifact);
+      original.evidence.manifest.providers[0]!.executionContext = { sandboxOwner: 'provider', runner: 'host-seatbelt', lane: 'macos-review-contract-host' };
+      original.binding = { ...createCandidateBinding(repo, input, original.evidence.manifest), candidateDigest: 'e'.repeat(64) };
+      original.evidence.binding = original.binding;
+      original.findings[0]!.classification = 'verified-failure';
+      original.evidence.records[0] = { ...original.evidence.records[0]!, status: 'verified-failure', exitStatus: 1,
+        ciProvenance: undefined, candidateDigest: original.binding.candidateDigest, environment: 'host-seatbelt-darwin-snapshot', snapshotDigestBefore: 'f'.repeat(64), snapshotDigestAfter: 'f'.repeat(64), replayCommand: provider.operations[0].argv };
+      const closure = buildClosureInput(original, binding, '', value);
+      const result = [{ findingId: 'F-001', status: 'closed' as const, summary: 'same operation passed on its CI host', evidenceIds: [evidence.records[0]!.id] }];
+      expect(validateClosureResults(result, closure, evidence)[0]).toMatchObject({ findingId: 'F-001', status: 'closed' });
+      const missing = structuredClone(evidence); missing.records[0]!.status = 'runtime-incomplete'; missing.records[0]!.fresh = false;
+      expect(() => validateClosureResults(result, closure, missing)).toThrow();
+      const weaker = structuredClone(evidence); weaker.manifest.providers[0]!.operations[0]!.argv = ['true'];
+      expect(() => validateClosureResults(result, closure, weaker)).toThrow('unchanged original failed operation');
+    } finally { globalThis.fetch = originalFetch; }
+  });
+  test('subdirectory CI incomplete evidence survives signed artifact readback', async () => {
+    const repo = gitFixture(); const cwd = join(repo, 'goldband-loop');
+    mkdirSync(cwd); writeFileSync(join(cwd, 'tracked.ts'), 'tracked();');
+    git(repo, ['add', '.']); git(repo, ['commit', '-m', 'subdirectory']);
+    const value = manifest();
+    const rootManifest = JSON.parse(readFileSync(join(import.meta.dir, '../../goldband.review-evidence.json'), 'utf8'));
+    const provider = rootManifest.providers.find((p: any) => p.id === providerId);
+    provider.cellIds = ['behavior-a']; provider.applicability = { kind: 'global', reason: 'CI producer fixture' };
+    value.providers = [provider]; value.behaviorMatrix[0]!.providerIds = [providerId];
+    const validated = reviewEvidenceManifestSchema.validate(value);
+    const input = { source: 'git diff', diff: '', changedFiles: [] };
+    const binding = createCandidateBinding(cwd, input, validated);
+    const state = mkdtempSync(join(tmpdir(), 'review-ci-subdir-state-')); roots.push(state);
+    const ctx = { ...context(cwd), options: { mode: 'mock' as const, goldbandHome: state } };
+    const evidence = await executeEvidencePlan(ctx, input, validated, binding);
+    expect(evidence.completeness.hostEligible).toBe(false);
+    expect(evidence.records[0]!.outputSummary).toContain('invocation directory');
+    expect(evidence.records[0]!.ciProvenance).toBeUndefined();
+    const artifact = initialArtifact(); artifact.binding = binding; artifact.evidence = evidence; artifact.diff = '';
+    artifact.findings = [{ ...artifact.findings[0]!, id: 'D-001', category: 'deterministic-evidence',
+      classification: 'runtime-incomplete', evidenceIds: [evidence.records[0]!.id] }]; artifact.hostCallCount = 0;
+    const { runtimeReceipt: _receipt, ...payload } = artifact;
+    const file = join(state, 'subdir-artifact.json'); writeInitialReviewArtifact(file, payload, ctx);
+    const restored = readClosureArtifact({ ...ctx, options: { ...ctx.options, closureArtifactFile: file } })!;
+    expect(restored.evidence.completeness.hostEligible).toBe(false);
+    expect(restored.findings[0]).toMatchObject({ id: artifact.findings[0]!.id, classification: 'runtime-incomplete' });
+  });
+  test('producer reports absent candidate CI as incomplete, without a nested sandbox or fabricated exit', async () => {
+    const repo = gitFixture();
+    let value = manifest();
+    const rootManifest = JSON.parse(readFileSync(join(import.meta.dir, '../../goldband.review-evidence.json'), 'utf8'));
+    const provider = rootManifest.providers.find((p: any) => p.id === providerId);
+    provider.cellIds = ['behavior-a']; provider.applicability = { kind: 'global', reason: 'CI producer fixture' };
+    value.providers = [provider]; value.behaviorMatrix[0]!.providerIds = [providerId];
+    value = reviewEvidenceManifestSchema.validate(value);
+    const input = { source: 'git diff', diff: '', changedFiles: [] };
+    const evidence = await executeEvidencePlan(context(repo), input, value, createCandidateBinding(repo, input, value));
+    expect(evidence.completeness).toMatchObject({ complete: false, hostEligible: false });
+    expect(evidence.records[0]).toMatchObject({ status: 'runtime-incomplete', fresh: false, environment: 'github-actions/macos-writable-checkout' });
+    expect(evidence.records[0]!.exitStatus).toBeUndefined();
+    expect(evidence.records[0]!.snapshotDigestBefore).toBeUndefined();
+    expect(evidence.records[0]!.ciProvenance).toBeUndefined();
+    expect(evidence.records[0]!.outputSummary).toContain('CI evidence incomplete');
+    await expect(collectReviewCiEvidence(repo, repo, provider, 'goldband-loop')).rejects.toThrow('invocation directory');
+  });
+});

--- a/goldband-loop/test/review-receipt-authority-install.test.ts
+++ b/goldband-loop/test/review-receipt-authority-install.test.ts
@@ -106,6 +106,23 @@ describe("review receipt authority provisioning", () => {
 			providers: [],
 			authorizations: [],
 		};
+		const unrelatedProvider = {
+			id: "unrelated-gate", owner: "fixture", kind: "static", lifecycle: "persistent",
+			cellIds: ["unrelated-static"],
+			applicability: { kind: "paths", pathPrefixes: ["unrelated"] },
+			executionContext: { sandboxOwner: "review-runtime", runner: "sealed" },
+			operations: [{ id: "pass", target: "candidate", argv: ["true"], expectedExit: "zero",
+				timeoutMs: 1000, maxOutputBytes: 1024, network: "deny", evidenceLevel: "fixture",
+				requiredSystemTools: ["true"] }],
+		};
+		unsupportedManifest.providers.push(unrelatedProvider);
+		unsupportedManifest.behaviorMatrix.push(
+			{ ...unsupportedManifest.behaviorMatrix[0], id: "unrelated-manual",
+				behavior: "The unrelated manual boundary is checked.", disposition: "manual" },
+			{ ...unsupportedManifest.behaviorMatrix[0], id: "unrelated-static",
+				behavior: "The unrelated static boundary is checked.", disposition: "static",
+				providerIds: ["unrelated-gate"], reason: undefined },
+		);
 			writeFileSync(join(repo, "goldband.review-evidence.json"), `${JSON.stringify(unsupportedManifest)}\n`);
 			expect(spawnSync("git", ["config", "user.email", "test@example.com"], { cwd: repo }).status).toBe(0);
 			expect(spawnSync("git", ["config", "user.name", "Goldband Test"], { cwd: repo }).status).toBe(0);
@@ -152,8 +169,12 @@ describe("review receipt authority provisioning", () => {
 			"  exit 0",
 			"fi",
 			'printf "%s\\n" claude >> "$GOLDBAND_TEST_HOST_CALL_LOG"',
-			"cat >/dev/null",
-			'printf \'%s\\n\' \'{"result":"{\\"findings\\":[]}","usage":{"input_tokens":1,"output_tokens":1}}\'',
+			"prompt=\"$(cat)\"",
+			"if printf '%s' \"$prompt\" | grep -q CLOSURE_INPUT_START; then",
+			"printf '%s\\n' '{\"result\":\"{\\\"results\\\":[{\\\"findingId\\\":\\\"S-001\\\",\\\"status\\\":\\\"closed\\\",\\\"summary\\\":\\\"repair verified\\\",\\\"evidenceIds\\\":[\\\"claude-repair-gate:candidate-green\\\"]}]}\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}'",
+			"else",
+			"printf '%s\\n' '{\"result\":\"{\\\"findings\\\":[{\\\"id\\\":\\\"F-001\\\",\\\"file\\\":\\\"candidate.txt\\\",\\\"line\\\":1,\\\"severity\\\":\\\"medium\\\",\\\"summary\\\":\\\"fixture concern\\\",\\\"evidence\\\":\\\"fixture semantic observation\\\",\\\"failureScenario\\\":\\\"fixture path\\\",\\\"suggestedVerification\\\":\\\"rerun gate\\\",\\\"classification\\\":\\\"semantic-concern\\\",\\\"blocking\\\":false,\\\"evidenceIds\\\":[\\\"claude-repair-gate:candidate-green\\\"],\\\"behaviorCellIds\\\":[\\\"unsupported-runtime\\\"]}]}\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}'",
+			"fi",
 		].join("\n"));
 		chmodSync(fakeClaude, 0o755);
 		const repairedManifest = structuredClone(unsupportedManifest);
@@ -183,6 +204,8 @@ describe("review receipt authority provisioning", () => {
 				requiredSystemTools: ["true"],
 			}],
 		}];
+		repairedManifest.behaviorMatrix[1].providerIds = ["unrelated-gate"];
+		repairedManifest.providers.push({ ...unrelatedProvider, cellIds: ["unrelated-static", "unrelated-manual"] });
 		const repairedManifestFile = join(root, "repaired-manifest.json");
 		writeFileSync(repairedManifestFile, `${JSON.stringify(repairedManifest)}\n`);
 		writeFileSync(join(repo, "candidate.txt"), "review repaired\n");
@@ -209,8 +232,25 @@ describe("review receipt authority provisioning", () => {
 			transition: "evidence-repair",
 			runId: artifact.runId,
 			receiptId: artifact.runtimeReceipt.id,
-			findingIds: ["D-001"],
+			findingIds: ["D-001", "D-002"],
+			affectedCellIds: ["unrelated-manual", "unrelated-static", "unsupported-runtime"],
 		});
 		expect(readFileSync(hostCalls, "utf8").trim()).toBe("claude");
+		expect(repairedArtifact.evidence.records.map((record) => record.id)).toEqual(["claude-repair-gate:candidate-green"]);
+		expect(repairedArtifact.findings).toMatchObject([{ id: "S-001", classification: "semantic-concern" }]);
+		writeFileSync(join(repo, "candidate.txt"), "semantic concern repaired\n");
+		const closure = spawnSync(process.execPath, [
+			...reviewArgs, "--evidence-manifest", repairedManifestFile,
+			"--closure-artifact", repairedArtifactPath,
+		], {
+			...reviewOptions,
+			env: { ...reviewOptions.env, PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+				GOLDBAND_TEST_HOST_CALL_LOG: hostCalls },
+		});
+		expect(closure.status, closure.stderr).toBe(0);
+		expect(closure.stdout).toContain("Phase: closure.");
+		expect(closure.stdout).toContain("[closed] S-001");
+		expect(readFileSync(hostCalls, "utf8").trim().split("\n")).toEqual(["claude", "claude"]);
+
 	}, 30_000);
 });

--- a/goldband-loop/workflows/review-ci-evidence.ts
+++ b/goldband-loop/workflows/review-ci-evidence.ts
@@ -1,0 +1,216 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { lstatSync, readdirSync, readFileSync, readlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import type { ReviewEvidenceManifest } from './review-evidence';
+
+type Provider = ReviewEvidenceManifest['providers'][number];
+const REPOSITORY = 'leo110047/goldband';
+const WORKFLOW = '.github/workflows/validate.yml';
+export const REVIEW_CI_LANE = 'goldband-macos-review-host';
+// Trusted runtime policy, deliberately not loaded from the candidate manifest.
+const WORKFLOW_DIGEST = 'f4fbe58bcacb001e441f6ad6427d2e7c43b48ae419b4a0657d527e62cb5a433f';
+const RECIPES: Record<string, { operation: string; files: string[] }> = {
+  'review-evidence-tests': { operation: 'candidate-green', files: ['test/review-evidence.test.ts', 'test/review-evidence-platform.test.ts'] },
+  'work-map-review-tests': { operation: 'candidate-work-map-review', files: ['test/work-map-review.test.ts'] },
+  'installed-runtime-tests': { operation: 'candidate-installed-runtime', files: ['test/codex-review-launcher-install.test.ts', 'test/review-receipt-authority-install.test.ts'] },
+};
+
+export type ReviewCiProvenance = {
+  repository: string;
+  workflow: string;
+  workflowDigest: string;
+  revision: string;
+  tree: string;
+  runId: number;
+  attempt: number;
+  jobId: number;
+  step: string;
+  conclusion: 'success';
+};
+
+function hash(value: string | Buffer, algorithm = 'sha256'): string {
+  return createHash(algorithm).update(value).digest('hex');
+}
+
+export function isReviewCiProvider(provider: Provider): boolean {
+  const recipe = Object.hasOwn(RECIPES, provider.id) ? RECIPES[provider.id] : undefined;
+  const operation = provider.operations[0];
+  return Boolean(recipe && provider.operations.length === 1 && operation &&
+    operation.id === recipe.operation && operation.target === 'candidate' &&
+    operation.expectedExit === 'zero' && operation.evidenceLevel === 'local' &&
+    JSON.stringify(operation.argv) === JSON.stringify(['bun', 'test', '--cwd', 'goldband-loop', ...recipe.files]));
+}
+
+export function isReviewCiMigration(before: Provider, after: Provider): boolean {
+  return before.id === after.id && isReviewCiProvider(before) && isReviewCiProvider(after) &&
+    before.executionContext.runner === 'host-seatbelt' &&
+    before.executionContext.sandboxOwner === 'provider' &&
+    before.executionContext.lane === 'macos-review-contract-host' &&
+    after.executionContext.runner === 'github-actions' &&
+    after.executionContext.sandboxOwner === 'provider' && after.executionContext.lane === REVIEW_CI_LANE;
+}
+
+// Hash the materialized candidate as Git does, without invoking candidate filters,
+// hooks, an index, or writing to the user's repository. Empty directories are not Git entries.
+export function reviewCandidateTree(root: string): string {
+  const entries = readdirSync(root).map((name) => candidateTreeEntry(root, name))
+    .filter((entry) => entry !== undefined).sort((a, b) => Buffer.compare(a.sort, b.sort));
+  const content = Buffer.concat(entries.map((entry) => entry.content));
+  return hash(Buffer.concat([Buffer.from(`tree ${content.length}\0`), content]), 'sha1');
+}
+
+function candidateTreeEntry(root: string, name: string) {
+  const path = join(root, name);
+  const stat = lstatSync(path);
+  const directory = stat.isDirectory();
+  let mode: string;
+  let digest: string;
+  if (directory) {
+    mode = '40000';
+    digest = reviewCandidateTree(path);
+    if (digest === hash('tree 0\0', 'sha1')) return undefined;
+  } else {
+    ({ mode, digest } = candidateBlob(path));
+  }
+  return { sort: Buffer.from(name + (directory ? '/' : '')), content: Buffer.concat([Buffer.from(`${mode} ${name}\0`), Buffer.from(digest, 'hex')]) };
+
+}
+
+function candidateBlob(path: string): { mode: string; digest: string } {
+  const stat = lstatSync(path);
+  if (!stat.isFile() && !stat.isSymbolicLink()) throw new Error('CI candidate contains an unsupported file type');
+  const mode = stat.isSymbolicLink() ? '120000' : (stat.mode & 0o111) ? '100755' : '100644';
+  const content = stat.isSymbolicLink() ? Buffer.from(readlinkSync(path)) : readFileSync(path);
+  return { mode, digest: hash(Buffer.concat([Buffer.from(`blob ${content.length}\0`), content]), 'sha1') };
+}
+
+function git(cwd: string, argv: string[]): string {
+  const result = spawnSync('git', argv, { cwd, encoding: 'utf8', timeout: 10_000 });
+  if (result.status !== 0) throw new Error('CI evidence cannot resolve the local candidate commit');
+  return result.stdout.trim();
+}
+
+type Json = Record<string, unknown>;
+function object(value: unknown): Json {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Invalid GitHub evidence response');
+  return value as Json;
+}
+function list(value: unknown): Json[] {
+  if (!Array.isArray(value)) throw new Error('Invalid GitHub evidence list');
+  return value.map(object);
+}
+function positive(value: unknown): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 1) throw new Error('Invalid GitHub evidence identity');
+  return Number(value);
+}
+
+async function github(path: string): Promise<Json> {
+  const response = await fetch(`https://api.github.com/repos/${REPOSITORY}/${path}`, {
+    headers: { Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28' },
+    redirect: 'error', signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) throw new Error(`GitHub evidence read failed: HTTP ${response.status}`);
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error('GitHub evidence response has no body');
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  try {
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      bytes += next.value.byteLength;
+      if (bytes > 2 * 1024 * 1024) throw new Error('GitHub evidence response exceeds limit');
+      chunks.push(next.value);
+    }
+  } finally { await reader.cancel(); }
+  return object(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+}
+
+function validateRun(run: Json, revision: string): void {
+  if (run.head_sha !== revision || run.path !== WORKFLOW || run.event !== 'push' ||
+      run.head_branch !== 'dev' || object(run.repository).full_name !== REPOSITORY ||
+      object(run.head_repository).full_name !== REPOSITORY) {
+    throw new Error('GitHub evidence run does not match the trusted repository, workflow, branch and candidate');
+  }
+  positive(run.id);
+  positive(run.run_attempt);
+}
+
+// The transport seam accepts platform responses, never a caller-authored evidence file.
+export async function readReviewCiResult(
+  revision: string, tree: string, providerId: string,
+  read: (path: string) => Promise<Json> = github,
+): Promise<ReviewCiProvenance> {
+  if (!/^[a-f0-9]{40}$/.test(revision) || !/^[a-f0-9]{40}$/.test(tree) || !Object.hasOwn(RECIPES, providerId)) {
+    throw new Error('Unsupported CI evidence candidate or provider');
+  }
+  const commit = await read(`git/commits/${revision}`);
+  if (commit.sha !== revision || object(commit.tree).sha !== tree) {
+    throw new Error('GitHub commit tree does not match the exact materialized candidate');
+  }
+  const runs = list((await read(`actions/workflows/validate.yml/runs?head_sha=${revision}&event=push&branch=dev&per_page=100`)).workflow_runs);
+  for (const run of runs) validateRun(run, revision);
+  const run = runs.sort((a, b) => positive(b.id) - positive(a.id))[0];
+  if (!run || run.status !== 'completed') throw new Error('Exact candidate CI evidence is missing or still running');
+  const runId = positive(run.id);
+  const attempt = positive(run.run_attempt);
+  const stepName = `Review evidence - ${providerId}`;
+  const jobId = await successfulReviewStep({ read, runId, attempt, revision, stepName });
+  const current = await read(`actions/runs/${runId}`);
+  validateRun(current, revision);
+  if (current.id !== runId || current.run_attempt !== attempt || current.status !== 'completed') {
+    throw new Error('CI evidence run changed while being read');
+  }
+  return { repository: REPOSITORY, workflow: WORKFLOW, workflowDigest: WORKFLOW_DIGEST,
+    revision, tree, runId, attempt, jobId, step: stepName, conclusion: 'success' };
+}
+
+export async function collectReviewCiEvidence(
+  repositoryRoot: string, candidateRoot: string, provider: Provider, executionOffset: string,
+): Promise<ReviewCiProvenance> {
+  if (!isReviewCiProvider(provider) || provider.executionContext.runner !== 'github-actions' ||
+      provider.executionContext.lane !== REVIEW_CI_LANE || executionOffset) {
+    throw new Error('Unsupported Goldband CI evidence recipe or invocation directory');
+  }
+  const remote = git(repositoryRoot, ['remote', 'get-url', 'origin']);
+  if (![`https://github.com/${REPOSITORY}.git`, `https://github.com/${REPOSITORY}`, `git@github.com:${REPOSITORY}.git`].includes(remote)) {
+    throw new Error('CI evidence requires the authoritative Goldband repository');
+  }
+  if (hash(readFileSync(join(candidateRoot, WORKFLOW))) !== WORKFLOW_DIGEST) {
+    throw new Error('CI workflow differs from the recipe trusted by this runtime; update and review the runtime recipe explicitly');
+  }
+  const revision = git(repositoryRoot, ['rev-parse', 'HEAD']);
+  const tree = reviewCandidateTree(candidateRoot);
+  if (tree !== git(repositoryRoot, ['--no-replace-objects', 'rev-parse', `${revision}^{tree}`])) {
+    throw new Error('CI evidence requires the exact candidate to be committed and tested on dev; dirty candidate has no matching CI evidence');
+  }
+  return readReviewCiResult(revision, tree, provider.id);
+}
+
+export function validateReviewCiProvenance(value: ReviewCiProvenance, providerId: string): void {
+  if (value.repository !== REPOSITORY || value.workflow !== WORKFLOW || !/^[a-f0-9]{64}$/.test(value.workflowDigest) ||
+      !/^[a-f0-9]{40}$/.test(value.revision) || !/^[a-f0-9]{40}$/.test(value.tree) ||
+      !Object.hasOwn(RECIPES, providerId) || value.step !== `Review evidence - ${providerId}` || value.conclusion !== 'success') {
+    throw new Error('Invalid persisted CI evidence provenance');
+  }
+  positive(value.runId); positive(value.attempt); positive(value.jobId);
+}
+
+async function successfulReviewStep(options: {
+  read: (path: string) => Promise<Json>; runId: number; attempt: number; revision: string; stepName: string;
+}): Promise<number> {
+  const { read, runId, attempt, revision, stepName } = options;
+  const response = await read(`actions/runs/${runId}/attempts/${attempt}/jobs?per_page=100`);
+  const jobs = list(response.jobs);
+  if (response.total_count !== jobs.length) throw new Error('CI job evidence is truncated');
+  const matches = jobs.filter((job) => job.name === 'macOS Seatbelt review evidence contracts');
+  if (matches.length !== 1) throw new Error('CI evidence job is missing or ambiguous');
+  const job = matches[0]!;
+  if (job.run_id !== runId || job.head_sha !== revision || job.status !== 'completed') throw new Error('CI evidence job identity is mismatched');
+  const steps = list(job.steps).filter((step) => step.name === stepName);
+  if (steps.length !== 1 || steps[0]!.status !== 'completed' || steps[0]!.conclusion !== 'success') {
+    throw new Error(`CI step ${stepName} has no successful execution evidence; inspect the CI run`);
+  }
+  return positive(job.id);
+}

--- a/goldband-loop/workflows/review-evidence.ts
+++ b/goldband-loop/workflows/review-evidence.ts
@@ -52,6 +52,7 @@ import {
   sealedEvidenceExecutionUnavailable,
 } from './review-evidence-sandbox';
 import { resolveReviewWorkspace, workspacePath } from './review-workspace';
+import { collectReviewCiEvidence, isReviewCiMigration, isReviewCiProvider, REVIEW_CI_LANE, validateReviewCiProvenance, type ReviewCiProvenance } from './review-ci-evidence';
 
 export { isEvidenceSandboxRuntimeFailure } from './review-evidence-sandbox';
 
@@ -176,7 +177,7 @@ type EvidenceApplicability = { kind: 'paths'; pathPrefixes: string[] } | { kind:
 
 type EvidenceExecutionContext =
   | { sandboxOwner: 'review-runtime'; runner: 'sealed' }
-  | { sandboxOwner: 'provider'; runner: 'host-seatbelt'; lane: string };
+  | { sandboxOwner: 'provider'; runner: 'host-seatbelt' | 'github-actions'; lane: string };
 
 type TransitionEvidenceBinding = {
   repository: string;
@@ -246,6 +247,7 @@ export type ReviewEvidenceRecord = {
   environment: string;
   commandDigest?: string;
   executionIdentityDigest?: string;
+  ciProvenance?: ReviewCiProvenance;
   snapshotDigestBefore?: string;
   snapshotDigestAfter?: string;
   replayCommand?: string[];
@@ -471,29 +473,10 @@ export async function executeEvidencePlan(
           throw new Error(`review evidence operation limit exceeded: ${MAX_REVIEW_EVIDENCE_OPERATIONS}`);
         }
         validateOperationAuthorization(operation, manifest);
-        if (provider.executionContext.runner === 'sealed') {
-          const unavailable = sealedEvidenceExecutionUnavailable();
-          if (unavailable) {
-            records.push(executionContextIncompleteRecord(
-              provider,
-              operation,
-              binding,
-              unavailable,
-            ));
-            continue;
-          }
-        }
-        if (provider.executionContext.runner === 'host-seatbelt') {
-          const unavailable = hostEvidenceExecutionUnavailable(ctx, provider);
-          if (unavailable) {
-            records.push(executionContextIncompleteRecord(
-              provider,
-              operation,
-              binding,
-              unavailable,
-            ));
-            continue;
-          }
+        const unavailable = evidenceExecutionUnavailable(ctx, provider);
+        if (unavailable) {
+          records.push(executionContextIncompleteRecord(provider, operation, binding, unavailable));
+          continue;
         }
         const operationKey = `${records.length}-${safePathSegment(provider.id)}-${safePathSegment(operation.id)}`;
         const operationRoot = join(
@@ -502,16 +485,13 @@ export async function executeEvidencePlan(
           operationKey,
         );
         const runnerRoot = join(tempRoot, 'runners', operationKey);
-        if (operation.target === 'base') {
-          materializeBase(workspace.repositoryRoot, operationRoot, input.changedFiles, binding.baseRef);
-        } else {
-          materializeExactCandidate(
-            { ...ctx, cwd: workspace.repositoryRoot },
-            input,
-            operationRoot,
-            binding.baseRef,
-            binding.redactedUntrackedFiles,
-          );
+        materializeOperationSnapshot({ ctx: { ...ctx, cwd: workspace.repositoryRoot }, input,
+          binding, operation, root: operationRoot });
+        if (provider.executionContext.runner === 'github-actions') {
+          records.push(await ciEvidenceRecord({ provider, operation, binding, repositoryRoot: workspace.repositoryRoot,
+            candidateRoot: operationRoot, executionOffset: workspace.invocationOffset }));
+          rmSync(operationRoot, { recursive: true, force: true });
+          continue;
         }
         if (operationNeedsDependencies(operation)) {
           projectDependencyDirectories(workspace.repositoryRoot, operationRoot, input.changedFiles);
@@ -789,11 +769,11 @@ function persistedArtifactEvidenceCells(
   artifact: InitialReviewArtifact,
   manifest: ReviewEvidenceManifest,
 ): ReviewEvidenceManifest['behaviorMatrix'] {
-  if (!artifact.predecessor) {
-    return effectiveEvidenceCells(manifest, artifact.binding.changedFiles);
-  }
-  const affected = new Set(artifact.predecessor.affectedCellIds);
-  return manifest.behaviorMatrix.filter((cell) => affected.has(cell.id));
+  return effectiveEvidenceCells(
+    manifest,
+    artifact.binding.changedFiles,
+    artifact.predecessor ? new Set(artifact.predecessor.affectedCellIds) : undefined,
+  );
 }
 
 function validatePersistedContractResolution(
@@ -907,6 +887,12 @@ function validatePersistedEvidenceRecord(
     return;
   }
   const operation = persistedRecordOperation(record, manifest);
+  const provider = manifest.providers.find((entry) => entry.id === record.providerId)!;
+  if (provider.executionContext.runner === 'github-actions') {
+    validatePersistedCiRecord(record, provider);
+    return;
+  }
+  if (record.ciProvenance !== undefined) throw new Error('Local evidence cannot claim CI provenance');
   validatePersistedCommandRecord(record, operation);
 }
 
@@ -990,6 +976,24 @@ function persistedRecordOperation(
     throw new Error(`initial evidence command record contract is invalid: ${record.id}`);
   }
   return operation;
+}
+
+function validatePersistedCiRecord(record: ReviewEvidenceRecord, provider: EvidenceProvider): void {
+  if (!isReviewCiProvider(provider) || provider.executionContext.runner !== 'github-actions' ||
+      provider.executionContext.lane !== REVIEW_CI_LANE) throw new Error('Invalid persisted CI provider');
+  if (record.commandDigest !== operationCommandDigest({ operation: provider.operations[0]!, executionOffset: '' })) {
+    throw new Error('CI command digest does not match the provider operation');
+  }
+  if (record.exitStatus !== undefined || record.snapshotDigestBefore !== undefined ||
+      record.snapshotDigestAfter !== undefined) throw new Error('CI evidence cannot claim a local exit or sealed snapshot');
+  if (record.status === 'runtime-incomplete' && !record.fresh && record.ciProvenance === undefined &&
+      record.executionIdentityDigest === undefined) return;
+  if (record.status !== 'verified-pass' || !record.fresh || !record.ciProvenance ||
+      record.environment !== 'github-actions/macos-writable-checkout') throw new Error('Invalid CI evidence status');
+  validateReviewCiProvenance(record.ciProvenance, provider.id);
+  if (record.executionIdentityDigest !== sha256(stableJson(record.ciProvenance))) {
+    throw new Error('CI execution identity does not match provenance');
+  }
 }
 
 function validatePersistedCommandRecord(
@@ -1223,6 +1227,9 @@ function sameEvidenceOperationContract(
   if (!original.providerId || !original.operationId ||
       original.providerId !== rerun.providerId || original.operationId !== rerun.operationId ||
       !original.commandDigest || original.commandDigest !== rerun.commandDigest) return false;
+  const originalProvider = originalManifest.providers.find((entry) => entry.id === original.providerId);
+  const rerunProvider = rerunManifest.providers.find((entry) => entry.id === rerun.providerId);
+  const migrated = originalProvider && rerunProvider && isReviewCiMigration(originalProvider, rerunProvider);
   const contract = (manifest: ReviewEvidenceManifest, record: ReviewEvidenceRecord) => {
     const provider = manifest.providers.find((entry) => entry.id === record.providerId);
     const operation = provider?.operations.find((entry) => entry.id === record.operationId);
@@ -1234,7 +1241,7 @@ function sameEvidenceOperationContract(
         lifecycle: provider.lifecycle,
         cellIds: provider.cellIds,
         applicability: provider.applicability,
-        executionContext: provider.executionContext,
+        executionContext: migrated ? rerunProvider.executionContext : provider.executionContext,
       },
       operation: {
         id: operation.id,
@@ -1486,7 +1493,7 @@ function validateEvidenceExecutionContext(value: unknown): EvidenceExecutionCont
     }
     return { sandboxOwner, runner };
   }
-  if (sandboxOwner === 'provider' && runner === 'host-seatbelt') {
+  if (sandboxOwner === 'provider' && (runner === 'host-seatbelt' || runner === 'github-actions')) {
     return {
       sandboxOwner,
       runner,
@@ -3085,7 +3092,7 @@ function operationExecutionIdentity(
   }));
 }
 
-function operationCommandDigest(options: RunEvidenceOperationOptions): string {
+function operationCommandDigest(options: Pick<RunEvidenceOperationOptions, 'operation' | 'executionOffset'>): string {
   const { operation } = options;
   return sha256(stableJson({
     argv: operation.argv,
@@ -3959,6 +3966,53 @@ export function selectedEvidenceProviderIds(manifest: ReviewEvidenceManifest, ch
     .filter((provider) => providerApplies(provider, changedFiles))
     .map((provider) => provider.id)
     .sort();
+}
+
+function evidenceExecutionUnavailable(ctx: WorkflowContext, provider: EvidenceProvider) {
+  if (provider.executionContext.runner === 'sealed') return sealedEvidenceExecutionUnavailable();
+  if (provider.executionContext.runner === 'host-seatbelt') return hostEvidenceExecutionUnavailable(ctx, provider);
+  return undefined;
+}
+
+function materializeOperationSnapshot(options: {
+  ctx: WorkflowContext; input: ReviewDiffInput; binding: CandidateBinding;
+  operation: EvidenceOperation; root: string;
+}): void {
+  const { ctx, input, binding, operation, root } = options;
+  if (operation.target === 'base') materializeBase(ctx.cwd, root, input.changedFiles, binding.baseRef);
+  else materializeExactCandidate(ctx, input, root, binding.baseRef, binding.redactedUntrackedFiles);
+}
+
+async function ciEvidenceRecord(options: {
+  provider: EvidenceProvider; operation: EvidenceOperation; binding: CandidateBinding;
+  repositoryRoot: string; candidateRoot: string; executionOffset: string;
+}): Promise<ReviewEvidenceRecord> {
+  const { provider, operation, binding, repositoryRoot, candidateRoot, executionOffset } = options;
+  const startedAt = new Date().toISOString();
+  const record: ReviewEvidenceRecord = {
+    id: `${provider.id}:${operation.id}`, providerId: provider.id, operationId: operation.id,
+    cellIds: [...provider.cellIds], owner: provider.owner, kind: provider.kind,
+    status: 'runtime-incomplete', evidenceLevel: operation.evidenceLevel,
+    environment: 'github-actions/macos-writable-checkout',
+    // CI records describe the fixed root recipe, including when the caller offset is rejected.
+    commandDigest: operationCommandDigest({ operation, executionOffset: '' }),
+    startedAt, finishedAt: startedAt, outputDigest: '', outputSummary: '',
+    candidateDigest: binding.candidateDigest, baseDigest: binding.baseDigest,
+    scopeDigest: binding.scopeDigest, fresh: false,
+  };
+  try {
+    const provenance = await collectReviewCiEvidence(repositoryRoot, candidateRoot, provider, executionOffset);
+    record.ciProvenance = provenance;
+    record.executionIdentityDigest = sha256(stableJson(provenance));
+    record.status = 'verified-pass';
+    record.fresh = true;
+    record.outputSummary = `Exact candidate CI step passed: https://github.com/${provenance.repository}/actions/runs/${provenance.runId}/attempts/${provenance.attempt}; step=${provenance.step}; revision=${provenance.revision}; writable CI checkout, not a sealed local execution`;
+  } catch (error) {
+    record.outputSummary = boundText(`CI evidence incomplete: ${error instanceof Error ? error.message : String(error)}`, operation.maxOutputBytes);
+  }
+  record.finishedAt = new Date().toISOString();
+  record.outputDigest = sha256(record.outputSummary);
+  return record;
 }
 
 function executionContextIncompleteRecord(

--- a/goldband-loop/workflows/review-lineage.ts
+++ b/goldband-loop/workflows/review-lineage.ts
@@ -19,6 +19,7 @@ import type {
   ReviewEvidenceManifest,
 } from './review-evidence';
 import { initialReviewArtifactDigest } from './review-evidence';
+import { isReviewCiMigration } from './review-ci-evidence';
 import type { ReviewContractResolution } from './review-contract-resolution';
 import type { ReviewClosureResult, ReviewFinding } from './types';
 
@@ -598,7 +599,7 @@ function providerContractWeakened(
     before.kind !== after.kind ||
     before.lifecycle !== after.lifecycle ||
     !applicabilityPreservedOrStrengthened(before.applicability, after.applicability) ||
-    stableJson(before.executionContext) !== stableJson(after.executionContext) ||
+    (stableJson(before.executionContext) !== stableJson(after.executionContext) && !isReviewCiMigration(before, after)) ||
     before.cellIds.some((cellId) => !after.cellIds.includes(cellId)) ||
     before.operations.some((operation) => {
       const successor = after.operations.find((item) => item.id === operation.id);

--- a/goldband-loop/workflows/review.ts
+++ b/goldband-loop/workflows/review.ts
@@ -1770,6 +1770,8 @@ function projectEvidenceRecord(record: ReviewEvidenceBundle['records'][number]) 
     evidenceLevel: record.evidenceLevel,
     commandDigest: record.commandDigest,
     exitStatus: record.exitStatus,
+    environment: record.environment,
+    ciProvenance: record.ciProvenance,
     outputDigest: record.outputDigest,
     candidateDigest: record.candidateDigest,
     seed: record.seed,
@@ -1785,6 +1787,8 @@ function projectClosureEvidenceRecord(record: ReviewEvidenceBundle['records'][nu
     status: record.status,
     commandDigest: record.commandDigest,
     exitStatus: record.exitStatus,
+    environment: record.environment,
+    ciProvenance: record.ciProvenance,
     outputDigest: record.outputDigest,
     fresh: record.fresh,
   };

--- a/goldband.review-evidence.json
+++ b/goldband.review-evidence.json
@@ -332,8 +332,8 @@
       },
       "executionContext": {
         "sandboxOwner": "provider",
-        "runner": "host-seatbelt",
-        "lane": "macos-review-contract-host"
+        "runner": "github-actions",
+        "lane": "goldband-macos-review-host"
       },
       "operations": [
         {
@@ -396,8 +396,8 @@
       },
       "executionContext": {
         "sandboxOwner": "provider",
-        "runner": "host-seatbelt",
-        "lane": "macos-review-contract-host"
+        "runner": "github-actions",
+        "lane": "goldband-macos-review-host"
       },
       "operations": [
         {
@@ -439,8 +439,8 @@
       },
       "executionContext": {
         "sandboxOwner": "provider",
-        "runner": "host-seatbelt",
-        "lane": "macos-review-contract-host"
+        "runner": "github-actions",
+        "lane": "goldband-macos-review-host"
       },
       "operations": [
         {

--- a/schemas/review-evidence-manifest.schema.json
+++ b/schemas/review-evidence-manifest.schema.json
@@ -90,7 +90,7 @@
                 "required": ["sandboxOwner", "runner", "lane"],
                 "properties": {
                   "sandboxOwner": { "const": "provider" },
-                  "runner": { "const": "host-seatbelt" },
+                  "runner": { "enum": ["host-seatbelt", "github-actions"] },
                   "lane": { "type": "string", "minLength": 1 }
                 }
               }

--- a/scripts/test-change-scope-guidance.mjs
+++ b/scripts/test-change-scope-guidance.mjs
@@ -52,6 +52,35 @@ assert.throws(
   'the negative regression must detect the removed healthiest-path default',
 );
 
+// READMEs explain the optional workflow role in their own language. They do
+// not need to repeat the internal English term "workflow runtime".
+function assertReadmeGuidance(content, required, label) {
+  const normalized = normalize(content);
+  for (const text of required) {
+    assert.ok(normalized.includes(text), `${label} is missing ${text}`);
+  }
+}
+
+for (const [file, role] of [
+  ['README.md', '選裝 Goldband Loop'],
+  ['README.en.md', 'Optionally adds Goldband Loop'],
+]) {
+  const content = read(file);
+  const required = [role, 'goldband-loop/', 'ARCHITECTURE.md'];
+  assertReadmeGuidance(content, required, file);
+  for (const removed of required) {
+    assert.throws(
+      () =>
+        assertReadmeGuidance(content.replaceAll(removed, ''), required, file),
+      { name: 'AssertionError' },
+      `${file} must reject removal of ${removed}`,
+    );
+  }
+}
+console.log(
+  '[OK] localized README guidance and missing-content regressions passed',
+);
+
 const manifest = JSON.parse(read('goldband.manifest.json'));
 const changeScope = manifest.policies.find(
   (policy) => policy.id === 'change-scope',

--- a/scripts/verify-decision-guidance.sh
+++ b/scripts/verify-decision-guidance.sh
@@ -80,14 +80,9 @@ check_contains "skills/global/security-checklist/SKILL.md" "Goldband cso workflo
 check_contains "skills/global/decision-log/SKILL.md" "### Failure Signals" "decision-log failure signals section"
 check_contains "skills/global/decision-log/SKILL.md" "### Revisit Triggers / Exit Criteria" "decision-log revisit triggers section"
 
-check_contains "README.md" "goldband-loop/" "README references Goldband Loop runtime source"
-check_contains "README.md" "workflow runtime" "README documents Goldband Loop as workflow runtime"
-check_contains "README.md" "ARCHITECTURE.md" "README points boundary details to architecture"
-check_contains "README.en.md" "goldband-loop/" "README.en references Goldband Loop runtime source"
-check_contains "README.en.md" "workflow runtime" "README.en documents Goldband Loop as workflow runtime"
-check_contains "README.en.md" "ARCHITECTURE.md" "README.en points boundary details to architecture"
 check_contains "commands/verify-config.md" "scripts/verify-decision-guidance.sh" "verify-config documents decision guidance check"
 
+# README role/link checks and their negative regressions share the guidance test owner below.
 node "$ROOT_DIR/scripts/test-change-scope-guidance.mjs" || EXIT_CODE=1
 
 if [ "$EXIT_CODE" -eq 0 ]; then


### PR DESCRIPTION
## Changes

Fix persisted evidence-repair validation so affected cells still respect candidate path applicability. Repair artifacts no longer require unrelated cells to produce evidence, while receipt validation and existing finding identities remain intact.

Run Goldband's three macOS sandbox self-test providers in explicit steps of the existing CI job. The review runtime reads successful results bound to the exact candidate commit/tree and run attempt, avoiding incompatible nested Seatbelt execution. Missing or unsuccessful CI evidence remains incomplete; CI results do not claim local sealed-snapshot execution.

Simplify the Chinese and English READMEs around installation and first use. Move development and advanced operations to the existing guides, and correct the documented prerequisites. Update the CI documentation gate to accept each language's description while preserving the role/source/architecture requirements and adding six missing-content regressions.

## Validation

- Updated both local Claude and Codex workflow installations and verified their entrypoints and installation status.
- Post-install regression run: 136 tests passed across evidence, lineage, platform, installed-runtime, and Work Map suites.
- Source checks passed; documentation checks include 38 local links, 10 registry tests, and generated-surface validation.
- Independent reviews completed; reported issues were fixed and rechecked.
- GitHub checks for the PR head must finish successfully before merge. CI evidence does not by itself close the previous formal review findings.

Related: #49
