### PR TITLE
Fix review evidence classification and launch failure guidance

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,6 +10,8 @@ English | [中文](README.md)
 - Manages local Claude Code and Codex configuration, with installation checks and uninstall commands.
 - Optionally adds Goldband Loop for code review, investigation, planning, QA, and other workflows.
 
+On review failure, Claude/Codex hooks point to the installed launch contract; incomplete environment evidence points to that run's report. Hooks do not retry automatically.
+
 ## Before Installing
 
 - Have Git, Node.js, and the Claude Code or Codex CLI you intend to use available.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Claude Code 與 Codex 的本機工程配套，集中管理開發守則、工具�
 - 管理 Claude Code／Codex 的本機設定，提供安裝狀態檢查與移除入口。
 - 選裝 Goldband Loop，使用程式碼審查、問題調查、規劃、QA 等工作流程。
 
+Review 失敗時，Claude／Codex hook 會提示讀取既有啟動契約；環境證據未完成則提示查看該次報告，不自動重跑。
+
 ## 安裝前
 
 - 準備 Git、Node.js，以及要使用的 Claude Code 或 Codex CLI。

--- a/codex/hooks/hook-router.js
+++ b/codex/hooks/hook-router.js
@@ -11,6 +11,7 @@ const {
   findHighRiskPatch,
 } = require('./high-risk-policy');
 const { recordHookTelemetry } = require('./telemetry');
+const { reviewLaunchAdvisory } = require('./review-launch-advisory');
 function loadCrossReviewGate() {
   return requireFirst([
     path.resolve(
@@ -214,6 +215,8 @@ function buildPostToolUsePatchContext(input) {
 }
 
 function evaluatePostToolUseResult(input) {
+  const reviewAdvice = reviewLaunchAdvisory(input);
+  if (reviewAdvice) return resultAdditionalContext('PostToolUse', reviewAdvice);
   return (
     buildPostToolUseFailureContext(input) || buildPostToolUsePatchContext(input)
   );

--- a/codex/hooks/review-launch-advisory.js
+++ b/codex/hooks/review-launch-advisory.js
@@ -1,0 +1,129 @@
+const REVIEW_GUIDE = 'the installed Goldband workflows/review/code.workflow.md';
+
+function isReviewCommand(command) {
+  if (typeof command !== 'string') return null;
+  // Only executable positions count; quoted documentation and grep arguments
+  // mentioning a review invocation are not review attempts.
+  const tokens =
+    command
+      .replace(/\\\r?\n/g, ' ')
+      .match(/"(?:\\.|[^"\\])*"|'[^']*'|&&|\|\||[;|\n]|[^\s;|]+/g) || [];
+  // Heredoc bodies are data, not executable segments of this advisory's parser.
+  if (tokens.some((token) => token.startsWith('<<'))) return null;
+  const segments = [[]];
+  for (const token of tokens) {
+    if (/^(?:&&|\|\||[;|\n])$/.test(token)) {
+      segments.push([]);
+    } else {
+      segments.at(-1).push(token.replace(/^(["'])(.*)\1$/s, '$2'));
+    }
+  }
+  const commands = segments.filter((segment) => segment.length > 0);
+  if (!commands.some(isReviewArgv)) return null;
+  return commands.length === 1 ? 'single' : 'compound';
+}
+
+function isReviewArgv(argv) {
+  let index = 0;
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(argv[index] || '')) index++;
+  if (['env', 'command', 'exec', 'time'].includes(argv[index])) index++;
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(argv[index] || '')) index++;
+  const name = (value) =>
+    (value || '')
+      .split(/[\\/]/)
+      .pop()
+      .replace(/\.exe$/i, '');
+  if (name(argv[index]) === 'rtk' && argv[index + 1] === 'proxy') index += 2;
+  if (['bun', 'node'].includes(name(argv[index]))) {
+    index++;
+    if (argv[index] === 'run') index++;
+  }
+  const entry = name(argv[index]);
+  return (
+    entry === 'goldband-review' ||
+    (/^goldband(?:\.[cm]?[jt]s)?$/.test(entry) &&
+      argv[index + 1] === 'review' &&
+      argv[index + 2] !== 'contract')
+  );
+}
+
+function toolResult(input) {
+  const response = input.tool_response;
+  const result = response && typeof response === 'object' ? response : {};
+  const texts = [
+    typeof response === 'string' ? response : '',
+    result.stdout,
+    result.stderr,
+    result.output,
+    input.error,
+  ].filter((value) => typeof value === 'string');
+  const exitCode =
+    result.exit_code ??
+    result.exitCode ??
+    /^Exit code (\d+)\b/.exec(input.error || '')?.[1];
+  // Codex can deliver only the command's text, with no exit-code field.
+  // Use the CLI's error prefix or a missing-launcher diagnostic in that case.
+  const launchError = texts.some(
+    (text) =>
+      /^goldband: .+/m.test(text) ||
+      /^(?:.*: )?(?:command not found|Cannot find module|Module not found|No such file or directory)[^\n]*(?:goldband|\bbun\b)/im.test(
+        text,
+      ),
+  );
+  return {
+    texts,
+    launchError,
+    failed:
+      input.hook_event_name === 'PostToolUseFailure' ||
+      (exitCode !== undefined &&
+        Number.isInteger(Number(exitCode)) &&
+        Number(exitCode) !== 0) ||
+      (exitCode === undefined && launchError),
+  };
+}
+
+function runtimeReport(text) {
+  let report = text.trim();
+  if (!report.startsWith('# review/code runtime report')) {
+    try {
+      // A host can merge launcher stderr warnings with the final JSON stdout.
+      const start = report.search(/^\{/m);
+      if (start < 0) return null;
+      const value = JSON.parse(
+        report.slice(start, report.lastIndexOf('}') + 1),
+      );
+      if (value?.workflow !== 'review/code' || typeof value.output !== 'string')
+        return null;
+      report = value.output;
+    } catch {
+      return null;
+    }
+  }
+  return report.startsWith('# review/code runtime report') ? report : null;
+}
+
+function reviewLaunchAdvisory(input) {
+  const command = isReviewCommand(input.tool_input?.command);
+  if (
+    !['PostToolUse', 'PostToolUseFailure'].includes(input.hook_event_name) ||
+    input.tool_name !== 'Bash' ||
+    input.is_interrupt === true ||
+    !command
+  )
+    return null;
+
+  const result = toolResult(input);
+  const report = result.texts.map(runtimeReport).find(Boolean);
+  if (report) {
+    return /^- runtime-evidence-incomplete: true\s*$/m.test(report)
+      ? "Goldband review started but its evidence is incomplete. Read this run's report and evidence artifact; resolve the reported environment blocker before rerunning the same candidate. This is not a successful review."
+      : null;
+  }
+  // A compound shell's exit code can belong to another command, or the review
+  // may never have run. Require a launcher diagnostic before attributing it.
+  return result.failed && (command === 'single' || result.launchError)
+    ? `Goldband review command failed. Read ${REVIEW_GUIDE} for the correct host launcher, then inspect the exact error before retrying. Preserve permission boundaries; no successful review has been established.`
+    : null;
+}
+
+module.exports = { reviewLaunchAdvisory };

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -641,9 +641,9 @@ entrypoints, skills, and repository instructions instead of lifecycle hooks.
 
 Implementation contract:
 
-- `SessionStart`, `SessionEnd`, `PreCompact`, `PostCompact`, and generic
-  `PostToolUseFailure` reminders are not registered and emit no output when
-  evaluated directly.
+- `SessionStart`, `SessionEnd`, `PreCompact`, and `PostCompact` are not registered.
+  `PostToolUseFailure` is silent except for a failed Goldband review command;
+  its advisory points to the installed launch contract without retrying or changing permissions.
 - Hook events with no implementation are not registered merely to display a
   status message.
 - Context restore remains an explicit Goldband workflow. Starting or resuming

--- a/docs/reports/plugin-expected-assets.json
+++ b/docs/reports/plugin-expected-assets.json
@@ -55,6 +55,11 @@
         "commandHooks": 3,
         "promptHooks": 0
       },
+      "PostToolUseFailure": {
+        "entries": 1,
+        "commandHooks": 1,
+        "promptHooks": 0
+      },
       "Stop": {
         "entries": 1,
         "commandHooks": 1,
@@ -106,7 +111,8 @@
       "codex/hooks/high-risk-policy.js",
       "codex/hooks/module-loader.js",
       "codex/hooks/telemetry.js",
-      "codex/hooks/telemetry-schema.cjs"
+      "codex/hooks/telemetry-schema.cjs",
+      "codex/hooks/review-launch-advisory.js"
     ],
     "reason": "Codex plugins exist but package Codex skills/apps/MCP, not Claude Code settings. Root Codex install remains install.sh."
   },

--- a/docs/review-evidence-manifest.md
+++ b/docs/review-evidence-manifest.md
@@ -262,6 +262,13 @@ Script launcher 必須把 interpreter 寫進 argv，例如：
 
 不要只寫 `scripts/check-contract.sh`。Runtime 會拒絕 path-shaped executable，避免 shebang／interpreter 與依賴邊界變成隱含 contract。
 
+### Writable build caches
+
+程式快照唯讀；`HOME`、`TMPDIR`、`TMP`、`TEMP` 是每個 operation 專屬的可寫暫存目錄。
+TypeScript 啟用 `incremental` 時，`--noEmit` 仍會寫快取；請在原 compiler 指令加上
+`--tsBuildInfoFile "$TMPDIR/typecheck.tsbuildinfo"`（須由 shell 展開，不同 project 使用不同檔名）。
+`TS5033` 寫入權限失敗屬於 `runtime-incomplete`，不能充當 RED 通過或程式缺陷證據。
+
 ### Python 3.14 + uv runtime
 
 直接 Python 指令（`python`、`python3`、`python3.14` 等數字版本，以及 `d`／`t`／`w`、`.exe` 變體，不分大小寫）缺少 `pythonRuntime` 時，validator 會在執行前拒絕。只有精確的 `python3.14` 指令與下列契約受支援；其他版本或變體必須改成受支援的宣告，不能只補欄位。
@@ -313,6 +320,9 @@ lockfile、offline artifact，或 environment/bootstrap 完整性失敗，都會
 typed `runtime-incomplete`，不執行 project gate，也不啟動 semantic host。只有
 preflight 通過後，gate 的 declared exit mismatch 才是 fresh
 `verified-failure`。
+
+缺 offline wheel 時，在審查外依 candidate 的 `uv.lock` 備齊 macOS／Python 相容的
+uv cache 後重跑；Linux container 已安裝的套件不能替代它，gate 仍維持 network deny。
 
 ## Network 與 authorizations
 

--- a/goldband-loop/scripts/test-workflows.ts
+++ b/goldband-loop/scripts/test-workflows.ts
@@ -21,6 +21,7 @@ export const MACOS_REVIEW_HOST_TEST_NAMES = [
   'review evidence contracts > applicability selects only scoped providers and excludes unrelated cells from completeness',
   'review evidence contracts > regression and property providers preserve RED/GREEN and replay metadata',
   'review evidence contracts > each operation receives an independent read-only snapshot',
+  'review evidence contracts > compiler output denial cannot satisfy RED and redirecting the cache preserves the read-only snapshot',
   'review evidence contracts > each operation receives an independent HOME and TMPDIR',
   'review evidence contracts > successful output containing sandbox is not treated as launcher failure',
   'review evidence contracts > evidence sandbox denies reads outside declared runtime and candidate roots',

--- a/goldband-loop/test/codex-review-launcher-install.test.ts
+++ b/goldband-loop/test/codex-review-launcher-install.test.ts
@@ -1069,7 +1069,7 @@ describe("Codex trusted workflow launcher install", () => {
 	test("distinguishes verified, outer-sandbox runtime-incomplete, and unverified coverage", () => {
 		const sandboxDenied = {
 			status: "runtime-incomplete",
-			outputSummary: "runner incomplete: sandbox-exec denied or could not initialize the operation",
+			outputSummary: "runner incomplete: operation initialization or compiler output access failed; keep the snapshot read-only and direct build caches to TMPDIR",
 		};
 		expect(classifyInstalledReviewPath(sandboxDenied, true))
 			.toBe("outer-sandbox-runtime-incomplete");
@@ -1355,7 +1355,7 @@ function classifyInstalledReviewPath(
 		nestedEvidenceBoundaryUnavailable &&
 		record.status === "runtime-incomplete" &&
 		record.outputSummary.includes(
-			"runner incomplete: sandbox-exec denied or could not initialize the operation",
+			"runner incomplete: operation initialization or compiler output access failed; keep the snapshot read-only and direct build caches to TMPDIR",
 		)
 	) {
 		return "outer-sandbox-runtime-incomplete";

--- a/goldband-loop/test/review-evidence.test.ts
+++ b/goldband-loop/test/review-evidence.test.ts
@@ -44,6 +44,7 @@ import {
   type ReviewEvidenceManifest,
 } from '../workflows/review-evidence';
 import { getWorkflow } from '../workflows/registry';
+import { createCompilerOutputDiagnosticCapture } from '../workflows/review-evidence-sandbox';
 import { readReviewCiResult, reviewCandidateTree, collectReviewCiEvidence, validateReviewCiProvenance } from '../workflows/review-ci-evidence';
 import { assertReviewContractNotWeaker } from '../workflows/review-lineage';
 import { runWorkflow } from '../workflows/runtime';
@@ -619,6 +620,60 @@ describe('review evidence contracts', () => {
       reason: 'exit',
       exitCode: 1,
       stderr: 'ordinary assertion failure mentioning sandbox',
+    })).toBe(false);
+  });
+
+  test('classifies TypeScript output permission failures on either stream as incomplete evidence', () => {
+    for (const stream of ['stdout', 'stderr']) {
+      for (const denial of [
+        'operation not permitted', 'EACCES: permission denied', 'read-only file system',
+        "EPERM: operation not permitted, open '/snapshot/web/.tsbuildinfo'",
+        "EACCES: permission denied, open '/snapshot/web/.tsbuildinfo'",
+        "EROFS: read-only file system, open '/snapshot/web/.tsbuildinfo'",
+      ]) {
+        expect(isEvidenceSandboxRuntimeFailure('/usr/bin/sandbox-exec', {
+          reason: 'exit', exitCode: 1,
+          [stream]: `STATIC CHECK PASS\nerror TS5033: Could not write file '/snapshot/web/.tsbuildinfo': open /snapshot/web/.tsbuildinfo: ${denial}.\n`,
+        })).toBe(true);
+      }
+    }
+    expect(isEvidenceSandboxRuntimeFailure('/broker', {
+      reason: 'exit', exitCode: 1,
+      stdout: "error TS5033: Could not write file '/snapshot/out.js': EACCES: permission denied.",
+    }, true)).toBe(true);
+  });
+
+  test('captures compiler permission diagnostics after long logs and across stream chunks', () => {
+    const diagnostic = "error TS5033: Could not write file '/snapshot/.tsbuildinfo': EPERM: operation not permitted, open '/snapshot/.tsbuildinfo'.\n";
+    for (let split = 1; split < diagnostic.length; split++) {
+      const capture = createCompilerOutputDiagnosticCapture();
+      capture.write('build log\n'.repeat(4096));
+      capture.write(diagnostic.slice(0, split));
+      capture.write(diagnostic.slice(split));
+      capture.write('more build log\n'.repeat(4096));
+      expect(capture.denied).toBe(true);
+      expect(isEvidenceSandboxRuntimeFailure('/usr/bin/sandbox-exec', {
+        reason: 'exit', exitCode: 1, compilerOutputDenied: capture.denied,
+      })).toBe(true);
+    }
+    const ordinary = createCompilerOutputDiagnosticCapture();
+    ordinary.write("error TS2322: Type 'string' is not assignable to type 'number'.\n");
+    expect(ordinary.denied).toBe(false);
+  });
+
+  test('does not infer compiler environment failure from ordinary errors or a successful operation', () => {
+    for (const diagnostic of [
+      "error TS2322: Type 'string' is not assignable to type 'number'.",
+      'assertion failed: operation not permitted',
+      "error TS5033: Could not write file '/snapshot/out.js': unknown compiler failure.",
+    ]) {
+      expect(isEvidenceSandboxRuntimeFailure('/usr/bin/sandbox-exec', {
+        reason: 'exit', exitCode: 1, stdout: diagnostic, stderr: diagnostic,
+      })).toBe(false);
+    }
+    expect(isEvidenceSandboxRuntimeFailure('/usr/bin/sandbox-exec', {
+      reason: 'exit', exitCode: 0,
+      stdout: "error TS5033: Could not write file '/snapshot/out.js': operation not permitted.",
     })).toBe(false);
   });
 
@@ -1393,6 +1448,44 @@ describe('review evidence contracts', () => {
     expect(evidence.records[1]).toMatchObject({ status: 'verified-pass', fresh: true });
     expect(evidence.records[1]!.snapshotDigestBefore)
       .toBe(evidence.records[1]!.snapshotDigestAfter);
+  });
+
+  test('compiler output denial cannot satisfy RED and redirecting the cache preserves the read-only snapshot', async () => {
+    const repo = gitFixture();
+    // A real filesystem write in the sealed runner, with the compiler's
+    // diagnostic protocol. This checks stream capture, not just the parser.
+    const script = [
+      "const fs = require('node:fs'); const path = require('node:path');",
+      "const output = path.resolve(process.argv[1] === 'temp' ? process.env.TMPDIR : '.', '.tsbuildinfo');",
+      "process.stdout.write('build log\\n'.repeat(4096));",
+      "try { fs.writeFileSync(output, 'cache'); } catch (error) {",
+      "  process.stdout.write(`error TS5033: Could not write file '${output}': ${error.message}.\\n`);",
+      "  process.exit(1);",
+      "}",
+    ].join('\n');
+    const value = manifest();
+    value.providers[0]!.operations = [
+      operation('denied-cache', ['node', '-e', script, 'snapshot'], 'candidate', 'zero'),
+      { ...operation('denied-cache-red', ['node', '-e', script, 'snapshot'], 'candidate', 'nonzero'), expectedExitCode: 1 },
+      operation('temp-cache', ['node', '-e', script, 'temp'], 'candidate', 'zero'),
+      operation('type-error', ['node', '-e', "console.log(\"error TS2322: Type 'string' is not assignable to type 'number'.\");process.exit(1)"], 'candidate', 'zero'),
+    ];
+    // Diagnostics still matter when the caller requests a tiny report body.
+    value.providers[0]!.operations[0]!.maxOutputBytes = 1;
+    const validated = reviewEvidenceManifestSchema.validate(value);
+    const input = { source: 'git diff', diff: '', changedFiles: [] };
+    const evidence = await executeEvidencePlan(
+      context(repo), input, validated, createCandidateBinding(repo, input, validated),
+    );
+    expect(evidence.records.map((entry) => [entry.status, entry.fresh, entry.exitStatus])).toEqual([
+      ['runtime-incomplete', false, 1],
+      ['runtime-incomplete', false, 1],
+      ['verified-pass', true, 0],
+      ['verified-failure', true, 1],
+    ]);
+    for (const entry of evidence.records) expect(entry.snapshotDigestAfter).toBe(entry.snapshotDigestBefore);
+    expect(evidence.completeness).toMatchObject({ complete: false, hostEligible: false });
+    expect(existsSync(join(repo, '.tsbuildinfo'))).toBe(false);
   });
 
   test('each operation receives an independent HOME and TMPDIR', async () => {

--- a/goldband-loop/workflows/review-evidence-sandbox.ts
+++ b/goldband-loop/workflows/review-evidence-sandbox.ts
@@ -148,9 +148,26 @@ function balancedExpression(source: string, start: number): string | undefined {
 	return undefined;
 }
 
+const COMPILER_OUTPUT_PERMISSION_FAILURE = /^error TS5033: Could not write file '[^\r\n]+': [^\r\n]*(?:operation not permitted|permission denied|read-only file system)\b[^\r\n]*$/im;
+
+export function createCompilerOutputDiagnosticCapture() {
+	let tail = "";
+	let denied = false;
+	return {
+		write(chunk: string) {
+			if (denied) return;
+			const window = tail + chunk;
+			denied = COMPILER_OUTPUT_PERMISSION_FAILURE.test(window);
+			// Keep split diagnostics across chunks without retaining the build log.
+			tail = window.slice(-16 * 1024);
+		},
+		get denied() { return denied; },
+	};
+}
+
 export function isEvidenceSandboxRuntimeFailure(
 	sandboxCommand: string,
-	result: { reason: string; exitCode: number; stderr?: string },
+	result: { reason: string; exitCode: number; stderr?: string; stdout?: string; compilerOutputDenied?: boolean },
 	brokered = false,
 ): boolean {
 	if (
@@ -169,8 +186,16 @@ export function isEvidenceSandboxRuntimeFailure(
 		result.exitCode === 71 && /^(?:sandbox-exec:|sandbox_init:)/im.test(stderr);
 	const dynamicLoaderFailedBeforeMain =
 		result.exitCode !== 0 && /^dyld\[\d+\]:/m.test(stderr);
+	// TypeScript reports output failures on stdout as well as stderr. An
+	// unwritable output (including --noEmit's incremental cache) is incomplete
+	// evidence, even when its exit code happens to match a declared RED result.
+	// Do not classify arbitrary mentions of sandbox/EPERM or type errors here.
+	const compilerOutputDenied = result.exitCode !== 0 &&
+		(result.compilerOutputDenied || COMPILER_OUTPUT_PERMISSION_FAILURE.test(
+			`${result.stdout ?? ""}\n${stderr}`,
+		));
 	return (
-		brokerFailed || sandboxInitializationFailed || dynamicLoaderFailedBeforeMain
+		brokerFailed || sandboxInitializationFailed || dynamicLoaderFailedBeforeMain || compilerOutputDenied
 	);
 }
 

--- a/goldband-loop/workflows/review-evidence.ts
+++ b/goldband-loop/workflows/review-evidence.ts
@@ -49,6 +49,7 @@ import type { ReviewContractResolution } from './review-contract-resolution';
 import {
   evidenceSandboxCommand,
   isEvidenceSandboxRuntimeFailure,
+  createCompilerOutputDiagnosticCapture,
   sealedEvidenceExecutionUnavailable,
 } from './review-evidence-sandbox';
 import { resolveReviewWorkspace, workspacePath } from './review-workspace';
@@ -3197,6 +3198,7 @@ async function executePreparedOperation(
       reason: capture.result.reason,
       exitCode: capture.result.exitCode,
       stderr: capture.stderrDiagnosticHead,
+      compilerOutputDenied: capture.compilerOutputDenied,
     },
     runner.sandbox.brokered,
   );
@@ -3226,10 +3228,13 @@ async function captureEvidenceCommand(
   result: EvidenceCommandResult;
   outputDigest: string;
   stderrDiagnosticHead: string;
+  compilerOutputDenied: boolean;
 }> {
   const stdoutHash = createHash('sha256');
   const stderrHash = createHash('sha256');
   let stderrDiagnosticHead = '';
+  const stdoutDiagnostics = createCompilerOutputDiagnosticCapture();
+  const stderrDiagnostics = createCompilerOutputDiagnosticCapture();
   const result = await superviseCommand(runner.sandbox.command, runner.sandbox.args, {
     cwd: options.executionCwd,
     env: runner.env,
@@ -3241,10 +3246,16 @@ async function captureEvidenceCommand(
       stderrMaxBytes: options.operation.maxOutputBytes,
     },
     label: `review evidence ${options.provider.id}:${options.operation.id}`,
-    stdout: { write(chunk: string) { stdoutHash.update(chunk); } },
+    stdout: {
+      write(chunk: string) {
+        stdoutHash.update(chunk);
+        stdoutDiagnostics.write(chunk);
+      },
+    },
     stderr: {
       write(chunk: string) {
         stderrHash.update(chunk);
+        stderrDiagnostics.write(chunk);
         const remaining = MAX_EVIDENCE_RUNTIME_DIAGNOSTIC_CHARS - stderrDiagnosticHead.length;
         if (remaining > 0) stderrDiagnosticHead += chunk.slice(0, remaining);
       },
@@ -3254,6 +3265,7 @@ async function captureEvidenceCommand(
     result,
     outputDigest: sha256(`${stdoutHash.digest('hex')}:${stderrHash.digest('hex')}`),
     stderrDiagnosticHead,
+    compilerOutputDenied: stdoutDiagnostics.denied || stderrDiagnostics.denied,
   };
 }
 
@@ -3300,7 +3312,7 @@ function summarizeEvidenceExecution(
   } else if (!integrity.runtimeUnchanged) {
     error = 'runner incomplete: executable runtime libraries changed during evidence execution';
   } else if (integrity.sandboxDenied) {
-    error = 'runner incomplete: sandbox-exec denied or could not initialize the operation';
+    error = 'runner incomplete: operation initialization or compiler output access failed; keep the snapshot read-only and direct build caches to TMPDIR';
   }
   return boundText([output, error].filter(Boolean).join('\n'), operation.maxOutputBytes);
 }

--- a/goldband-loop/workflows/review.ts
+++ b/goldband-loop/workflows/review.ts
@@ -1674,7 +1674,7 @@ function deterministicEvidenceFindings(evidence: ReviewEvidenceBundle): ReviewFi
       summary: `Typed evidence operation ${record.id} violated its declared contract.`,
       evidence: `exit=${record.exitStatus ?? 'incomplete'} outputDigest=${record.outputDigest} candidate=${record.candidateDigest}`,
       failureScenario: record.cellIds.map((cellId) => cells.get(cellId)?.behavior ?? cellId).join('; '),
-      recommendation: `Replay the project-owned operation and repair the candidate at provider ${record.providerId ?? record.owner}.`,
+      recommendation: `Replay the project-owned operation at provider ${record.providerId ?? record.owner} and inspect its diagnostics to distinguish a candidate defect from a runner or environment failure before choosing a repair.`,
       suggestedVerification: record.replayCommand?.join(' '),
       reproductionStep: record.replayCommand?.join(' '),
       classification: 'verified-failure',

--- a/goldband.review-evidence.json
+++ b/goldband.review-evidence.json
@@ -201,11 +201,11 @@
     },
     {
       "id": "sandbox-error-signature",
-      "behavior": "Only an explicit sandbox launcher failure signature is classified runtime-incomplete.",
+      "behavior": "Explicit runner initialization or compiler output permission failures are runtime-incomplete, never valid RED evidence.",
       "kind": "exception",
-      "input": "a successful command whose ordinary output contains the word sandbox",
-      "preconditions": "the local Seatbelt runner launched successfully",
-      "expected": "ordinary program output cannot impersonate a sandbox launcher failure",
+      "input": "launcher failures, TypeScript output permission diagnostics on stdout or stderr, ordinary type errors, and successful output mentioning sandbox",
+      "preconditions": "the operation runs through the local Seatbelt runner",
+      "expected": "known environment failures block completion regardless of expected exit; ordinary output and type errors do not impersonate them",
       "risk": "medium",
       "disposition": "automated",
       "providerIds": ["review-evidence-tests"]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -117,6 +117,18 @@
         "description": "Native async typecheck worker with debounce"
       }
     ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${HOOKS_DIR}/scripts/hooks/hook-router.js\""
+          }
+        ],
+        "description": "Actionable Goldband review failure guidance"
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/hooks/plugin-hooks.json
+++ b/hooks/plugin-hooks.json
@@ -57,6 +57,18 @@
       "description": "Native async typecheck worker with debounce"
     }
   ],
+  "PostToolUseFailure": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hooks/hook-router.js\""
+        }
+      ],
+      "description": "Actionable Goldband review failure guidance"
+    }
+  ],
   "Stop": [
     {
       "hooks": [

--- a/hooks/scripts/hooks/hook-router.js
+++ b/hooks/scripts/hooks/hook-router.js
@@ -62,7 +62,10 @@ function dispatchByEvent(input) {
     return evaluatePreToolUse(input);
   }
 
-  if (hookEventName === 'PostToolUse') {
+  if (
+    hookEventName === 'PostToolUse' ||
+    hookEventName === 'PostToolUseFailure'
+  ) {
     return evaluatePostToolUse(input);
   }
 

--- a/hooks/scripts/lib/hook-router/posttool-policy.js
+++ b/hooks/scripts/lib/hook-router/posttool-policy.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { getPersistentDataPath, writeFile } = require('../utils');
+const { reviewLaunchAdvisory } = require('./review-launch-advisory');
 
 function parseThreshold(envName, fallback) {
   const parsed = parseInt(process.env[envName] || String(fallback), 10);
@@ -142,7 +143,11 @@ function evaluatePostToolUse(input) {
   const toolName = input.tool_name || '';
   const toolInput = input.tool_input || {};
 
-  const contextMessage = evaluateContextWarning(input);
+  const reviewAdvice = reviewLaunchAdvisory(input);
+  const contextMessage =
+    input.hook_event_name === 'PostToolUseFailure'
+      ? null
+      : evaluateContextWarning(input);
   const filePath = toolInput.file_path || '';
 
   const styleWarnings =
@@ -154,7 +159,14 @@ function evaluatePostToolUse(input) {
     decision: 'allow',
     blockedBy: null,
     logs: [...styleWarnings, ...(contextMessage ? [contextMessage] : [])],
-    outputJson: null,
+    outputJson: reviewAdvice
+      ? {
+          hookSpecificOutput: {
+            hookEventName: input.hook_event_name,
+            additionalContext: reviewAdvice,
+          },
+        }
+      : null,
     spawnedProcesses: 0,
   };
 }

--- a/hooks/scripts/lib/hook-router/review-launch-advisory.js
+++ b/hooks/scripts/lib/hook-router/review-launch-advisory.js
@@ -1,0 +1,129 @@
+const REVIEW_GUIDE = 'the installed Goldband workflows/review/code.workflow.md';
+
+function isReviewCommand(command) {
+  if (typeof command !== 'string') return null;
+  // Only executable positions count; quoted documentation and grep arguments
+  // mentioning a review invocation are not review attempts.
+  const tokens =
+    command
+      .replace(/\\\r?\n/g, ' ')
+      .match(/"(?:\\.|[^"\\])*"|'[^']*'|&&|\|\||[;|\n]|[^\s;|]+/g) || [];
+  // Heredoc bodies are data, not executable segments of this advisory's parser.
+  if (tokens.some((token) => token.startsWith('<<'))) return null;
+  const segments = [[]];
+  for (const token of tokens) {
+    if (/^(?:&&|\|\||[;|\n])$/.test(token)) {
+      segments.push([]);
+    } else {
+      segments.at(-1).push(token.replace(/^(["'])(.*)\1$/s, '$2'));
+    }
+  }
+  const commands = segments.filter((segment) => segment.length > 0);
+  if (!commands.some(isReviewArgv)) return null;
+  return commands.length === 1 ? 'single' : 'compound';
+}
+
+function isReviewArgv(argv) {
+  let index = 0;
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(argv[index] || '')) index++;
+  if (['env', 'command', 'exec', 'time'].includes(argv[index])) index++;
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(argv[index] || '')) index++;
+  const name = (value) =>
+    (value || '')
+      .split(/[\\/]/)
+      .pop()
+      .replace(/\.exe$/i, '');
+  if (name(argv[index]) === 'rtk' && argv[index + 1] === 'proxy') index += 2;
+  if (['bun', 'node'].includes(name(argv[index]))) {
+    index++;
+    if (argv[index] === 'run') index++;
+  }
+  const entry = name(argv[index]);
+  return (
+    entry === 'goldband-review' ||
+    (/^goldband(?:\.[cm]?[jt]s)?$/.test(entry) &&
+      argv[index + 1] === 'review' &&
+      argv[index + 2] !== 'contract')
+  );
+}
+
+function toolResult(input) {
+  const response = input.tool_response;
+  const result = response && typeof response === 'object' ? response : {};
+  const texts = [
+    typeof response === 'string' ? response : '',
+    result.stdout,
+    result.stderr,
+    result.output,
+    input.error,
+  ].filter((value) => typeof value === 'string');
+  const exitCode =
+    result.exit_code ??
+    result.exitCode ??
+    /^Exit code (\d+)\b/.exec(input.error || '')?.[1];
+  // Codex can deliver only the command's text, with no exit-code field.
+  // Use the CLI's error prefix or a missing-launcher diagnostic in that case.
+  const launchError = texts.some(
+    (text) =>
+      /^goldband: .+/m.test(text) ||
+      /^(?:.*: )?(?:command not found|Cannot find module|Module not found|No such file or directory)[^\n]*(?:goldband|\bbun\b)/im.test(
+        text,
+      ),
+  );
+  return {
+    texts,
+    launchError,
+    failed:
+      input.hook_event_name === 'PostToolUseFailure' ||
+      (exitCode !== undefined &&
+        Number.isInteger(Number(exitCode)) &&
+        Number(exitCode) !== 0) ||
+      (exitCode === undefined && launchError),
+  };
+}
+
+function runtimeReport(text) {
+  let report = text.trim();
+  if (!report.startsWith('# review/code runtime report')) {
+    try {
+      // A host can merge launcher stderr warnings with the final JSON stdout.
+      const start = report.search(/^\{/m);
+      if (start < 0) return null;
+      const value = JSON.parse(
+        report.slice(start, report.lastIndexOf('}') + 1),
+      );
+      if (value?.workflow !== 'review/code' || typeof value.output !== 'string')
+        return null;
+      report = value.output;
+    } catch {
+      return null;
+    }
+  }
+  return report.startsWith('# review/code runtime report') ? report : null;
+}
+
+function reviewLaunchAdvisory(input) {
+  const command = isReviewCommand(input.tool_input?.command);
+  if (
+    !['PostToolUse', 'PostToolUseFailure'].includes(input.hook_event_name) ||
+    input.tool_name !== 'Bash' ||
+    input.is_interrupt === true ||
+    !command
+  )
+    return null;
+
+  const result = toolResult(input);
+  const report = result.texts.map(runtimeReport).find(Boolean);
+  if (report) {
+    return /^- runtime-evidence-incomplete: true\s*$/m.test(report)
+      ? "Goldband review started but its evidence is incomplete. Read this run's report and evidence artifact; resolve the reported environment blocker before rerunning the same candidate. This is not a successful review."
+      : null;
+  }
+  // A compound shell's exit code can belong to another command, or the review
+  // may never have run. Require a launcher diagnostic before attributing it.
+  return result.failed && (command === 'single' || result.launchError)
+    ? `Goldband review command failed. Read ${REVIEW_GUIDE} for the correct host launcher, then inspect the exact error before retrying. Preserve permission boundaries; no successful review has been established.`
+    : null;
+}
+
+module.exports = { reviewLaunchAdvisory };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:decision-guidance": "bash scripts/verify-decision-guidance.sh",
     "lint:style": "node scripts/check-code-style.mjs",
     "lint:style:staged": "node scripts/check-code-style.mjs --staged",
-    "test:hook-router": "node hooks/scripts/tools/replay-hook-router.js && node scripts/test-claude-hook-router-review-readonly.mjs && node scripts/test-codex-high-risk-policy.mjs && node scripts/test-codex-hook-router.mjs && node scripts/test-workflow-trigger-routing.mjs && node scripts/test-hook-noise-policy.mjs && node scripts/test-claude-config-verification-runtime.mjs",
+    "test:hook-router": "node hooks/scripts/tools/replay-hook-router.js && node scripts/test-claude-hook-router-review-readonly.mjs && node scripts/test-codex-high-risk-policy.mjs && node scripts/test-codex-hook-router.mjs && node scripts/test-workflow-trigger-routing.mjs && node scripts/test-hook-noise-policy.mjs && node scripts/test-review-launch-advisory.mjs && node scripts/test-claude-config-verification-runtime.mjs",
     "test:telemetry": "node scripts/test-telemetry-schema.mjs && node scripts/test-telemetry.mjs && node scripts/test-telemetry-otlp.mjs && node scripts/test-telemetry-miner.mjs",
     "test:hook-router:coverage": "node scripts/check-hook-router-coverage.mjs",
     "test:cross-review": "node scripts/test-cross-review.mjs && node scripts/test-cross-review-regressions.mjs",

--- a/plugin-assets/claude-code-plugin/hooks/hooks.json
+++ b/plugin-assets/claude-code-plugin/hooks/hooks.json
@@ -58,6 +58,18 @@
         "description": "Native async typecheck worker with debounce"
       }
     ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hooks/hook-router.js\""
+          }
+        ],
+        "description": "Actionable Goldband review failure guidance"
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/plugin-assets/claude-code-plugin/hooks/scripts/hooks/hook-router.js
+++ b/plugin-assets/claude-code-plugin/hooks/scripts/hooks/hook-router.js
@@ -62,7 +62,10 @@ function dispatchByEvent(input) {
     return evaluatePreToolUse(input);
   }
 
-  if (hookEventName === 'PostToolUse') {
+  if (
+    hookEventName === 'PostToolUse' ||
+    hookEventName === 'PostToolUseFailure'
+  ) {
     return evaluatePostToolUse(input);
   }
 

--- a/plugin-assets/claude-code-plugin/hooks/scripts/lib/hook-router/posttool-policy.js
+++ b/plugin-assets/claude-code-plugin/hooks/scripts/lib/hook-router/posttool-policy.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { getPersistentDataPath, writeFile } = require('../utils');
+const { reviewLaunchAdvisory } = require('./review-launch-advisory');
 
 function parseThreshold(envName, fallback) {
   const parsed = parseInt(process.env[envName] || String(fallback), 10);
@@ -142,7 +143,11 @@ function evaluatePostToolUse(input) {
   const toolName = input.tool_name || '';
   const toolInput = input.tool_input || {};
 
-  const contextMessage = evaluateContextWarning(input);
+  const reviewAdvice = reviewLaunchAdvisory(input);
+  const contextMessage =
+    input.hook_event_name === 'PostToolUseFailure'
+      ? null
+      : evaluateContextWarning(input);
   const filePath = toolInput.file_path || '';
 
   const styleWarnings =
@@ -154,7 +159,14 @@ function evaluatePostToolUse(input) {
     decision: 'allow',
     blockedBy: null,
     logs: [...styleWarnings, ...(contextMessage ? [contextMessage] : [])],
-    outputJson: null,
+    outputJson: reviewAdvice
+      ? {
+          hookSpecificOutput: {
+            hookEventName: input.hook_event_name,
+            additionalContext: reviewAdvice,
+          },
+        }
+      : null,
     spawnedProcesses: 0,
   };
 }

--- a/plugin-assets/claude-code-plugin/hooks/scripts/lib/hook-router/review-launch-advisory.js
+++ b/plugin-assets/claude-code-plugin/hooks/scripts/lib/hook-router/review-launch-advisory.js
@@ -1,0 +1,129 @@
+const REVIEW_GUIDE = 'the installed Goldband workflows/review/code.workflow.md';
+
+function isReviewCommand(command) {
+  if (typeof command !== 'string') return null;
+  // Only executable positions count; quoted documentation and grep arguments
+  // mentioning a review invocation are not review attempts.
+  const tokens =
+    command
+      .replace(/\\\r?\n/g, ' ')
+      .match(/"(?:\\.|[^"\\])*"|'[^']*'|&&|\|\||[;|\n]|[^\s;|]+/g) || [];
+  // Heredoc bodies are data, not executable segments of this advisory's parser.
+  if (tokens.some((token) => token.startsWith('<<'))) return null;
+  const segments = [[]];
+  for (const token of tokens) {
+    if (/^(?:&&|\|\||[;|\n])$/.test(token)) {
+      segments.push([]);
+    } else {
+      segments.at(-1).push(token.replace(/^(["'])(.*)\1$/s, '$2'));
+    }
+  }
+  const commands = segments.filter((segment) => segment.length > 0);
+  if (!commands.some(isReviewArgv)) return null;
+  return commands.length === 1 ? 'single' : 'compound';
+}
+
+function isReviewArgv(argv) {
+  let index = 0;
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(argv[index] || '')) index++;
+  if (['env', 'command', 'exec', 'time'].includes(argv[index])) index++;
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(argv[index] || '')) index++;
+  const name = (value) =>
+    (value || '')
+      .split(/[\\/]/)
+      .pop()
+      .replace(/\.exe$/i, '');
+  if (name(argv[index]) === 'rtk' && argv[index + 1] === 'proxy') index += 2;
+  if (['bun', 'node'].includes(name(argv[index]))) {
+    index++;
+    if (argv[index] === 'run') index++;
+  }
+  const entry = name(argv[index]);
+  return (
+    entry === 'goldband-review' ||
+    (/^goldband(?:\.[cm]?[jt]s)?$/.test(entry) &&
+      argv[index + 1] === 'review' &&
+      argv[index + 2] !== 'contract')
+  );
+}
+
+function toolResult(input) {
+  const response = input.tool_response;
+  const result = response && typeof response === 'object' ? response : {};
+  const texts = [
+    typeof response === 'string' ? response : '',
+    result.stdout,
+    result.stderr,
+    result.output,
+    input.error,
+  ].filter((value) => typeof value === 'string');
+  const exitCode =
+    result.exit_code ??
+    result.exitCode ??
+    /^Exit code (\d+)\b/.exec(input.error || '')?.[1];
+  // Codex can deliver only the command's text, with no exit-code field.
+  // Use the CLI's error prefix or a missing-launcher diagnostic in that case.
+  const launchError = texts.some(
+    (text) =>
+      /^goldband: .+/m.test(text) ||
+      /^(?:.*: )?(?:command not found|Cannot find module|Module not found|No such file or directory)[^\n]*(?:goldband|\bbun\b)/im.test(
+        text,
+      ),
+  );
+  return {
+    texts,
+    launchError,
+    failed:
+      input.hook_event_name === 'PostToolUseFailure' ||
+      (exitCode !== undefined &&
+        Number.isInteger(Number(exitCode)) &&
+        Number(exitCode) !== 0) ||
+      (exitCode === undefined && launchError),
+  };
+}
+
+function runtimeReport(text) {
+  let report = text.trim();
+  if (!report.startsWith('# review/code runtime report')) {
+    try {
+      // A host can merge launcher stderr warnings with the final JSON stdout.
+      const start = report.search(/^\{/m);
+      if (start < 0) return null;
+      const value = JSON.parse(
+        report.slice(start, report.lastIndexOf('}') + 1),
+      );
+      if (value?.workflow !== 'review/code' || typeof value.output !== 'string')
+        return null;
+      report = value.output;
+    } catch {
+      return null;
+    }
+  }
+  return report.startsWith('# review/code runtime report') ? report : null;
+}
+
+function reviewLaunchAdvisory(input) {
+  const command = isReviewCommand(input.tool_input?.command);
+  if (
+    !['PostToolUse', 'PostToolUseFailure'].includes(input.hook_event_name) ||
+    input.tool_name !== 'Bash' ||
+    input.is_interrupt === true ||
+    !command
+  )
+    return null;
+
+  const result = toolResult(input);
+  const report = result.texts.map(runtimeReport).find(Boolean);
+  if (report) {
+    return /^- runtime-evidence-incomplete: true\s*$/m.test(report)
+      ? "Goldband review started but its evidence is incomplete. Read this run's report and evidence artifact; resolve the reported environment blocker before rerunning the same candidate. This is not a successful review."
+      : null;
+  }
+  // A compound shell's exit code can belong to another command, or the review
+  // may never have run. Require a launcher diagnostic before attributing it.
+  return result.failed && (command === 'single' || result.launchError)
+    ? `Goldband review command failed. Read ${REVIEW_GUIDE} for the correct host launcher, then inspect the exact error before retrying. Preserve permission boundaries; no successful review has been established.`
+    : null;
+}
+
+module.exports = { reviewLaunchAdvisory };

--- a/scripts/lib/plugin-distribution.mjs
+++ b/scripts/lib/plugin-distribution.mjs
@@ -58,6 +58,7 @@ const MANAGED_COMMANDS = [
   'codex/hooks/cross-review-gate.js',
   'codex/hooks/module-loader.js',
   'codex/hooks/telemetry-schema.cjs',
+  'codex/hooks/review-launch-advisory.js',
 ];
 
 export function buildPluginArtifacts() {
@@ -113,6 +114,11 @@ export function buildPluginArtifacts() {
 }
 
 function addSharedAdapterArtifacts(artifacts) {
+  addFileArtifact(
+    artifacts,
+    'hooks/scripts/lib/hook-router/review-launch-advisory.js',
+    path.join(ROOT_DIR, 'codex', 'hooks', 'review-launch-advisory.js'),
+  );
   addFileArtifact(
     artifacts,
     'scripts/lib/telemetry-schema.cjs',
@@ -213,6 +219,7 @@ function buildExpectedAssets({ commands, hookConfig, rules, sourceSkills }) {
         'codex/hooks/module-loader.js',
         'codex/hooks/telemetry.js',
         'codex/hooks/telemetry-schema.cjs',
+        'codex/hooks/review-launch-advisory.js',
       ],
       reason:
         'Codex plugins exist but package Codex skills/apps/MCP, not Claude Code settings. Root Codex install remains install.sh.',

--- a/scripts/test-hook-noise-policy.mjs
+++ b/scripts/test-hook-noise-policy.mjs
@@ -62,7 +62,6 @@ function testPassiveLifecycleHooksAreNotRegistered() {
   ).hooks;
   const passiveEvents = [
     'SessionStart',
-    'PostToolUseFailure',
     'PreCompact',
     'PostCompact',
     'SessionEnd',
@@ -72,6 +71,8 @@ function testPassiveLifecycleHooksAreNotRegistered() {
     assert.equal(claude[eventName], undefined, `${eventName} is passive noise`);
     assert.equal(plugin[eventName], undefined, `${eventName} is plugin noise`);
   }
+  assert.equal(claude.PostToolUseFailure[0].matcher, 'Bash');
+  assert.equal(plugin.PostToolUseFailure[0].matcher, 'Bash');
   assert.equal(
     codex.SessionStart,
     undefined,

--- a/scripts/test-review-launch-advisory.mjs
+++ b/scripts/test-review-launch-advisory.mjs
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const {
+  reviewLaunchAdvisory,
+} = require('../hooks/scripts/lib/hook-router/review-launch-advisory.js');
+const root = path.resolve(import.meta.dirname, '..');
+const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'review-advisory-'));
+const report =
+  '# review/code runtime report\n\n- runtime-evidence-incomplete: true\n- completion-authorized: false\n';
+const output = JSON.stringify({ workflow: 'review/code', output: report });
+const input = (command, tool_response) => ({
+  hook_event_name: 'PostToolUse',
+  tool_name: 'Bash',
+  tool_input: { command },
+  tool_response,
+});
+
+try {
+  for (const command of [
+    'goldband review code',
+    'goldband-review',
+    'cd /repo && goldband review code --host claude',
+    'env LANG=C /usr/local/bin/goldband review code',
+    'rtk proxy goldband review code',
+    '/Users/example/.bun/bin/bun "/path with spaces/goldband.js" review code',
+    'bun.exe C:\\tools\\goldband.js review code',
+    'bun /tmp/goldband.js \\\n review code',
+  ]) {
+    const message = reviewLaunchAdvisory(
+      input(command, {
+        exit_code: 1,
+        stderr: 'goldband: review code requires --host claude or --host codex',
+      }),
+    );
+    assert.match(
+      message,
+      /installed Goldband workflows\/review\/code.workflow.md/,
+    );
+    assert.match(message, /Preserve permission boundaries/);
+  }
+  for (const command of [
+    'npm test',
+    'goldband review contract validate',
+    "echo 'goldband review code'",
+    "rg 'goldband review code' README.md",
+    'cat /path/goldband.js',
+    'goldband plan create',
+    "cat <<'EOF'\ngoldband review code\nEOF",
+    'echo x; false && goldband review code',
+    'goldband review code; false',
+  ]) {
+    assert.equal(
+      reviewLaunchAdvisory(input(command, { exit_code: 1 })),
+      null,
+      command,
+    );
+  }
+  for (const response of [
+    {
+      exit_code: 0,
+      stdout: output,
+      stderr: 'Goldband review: temporary state root warning',
+    },
+    { exitCode: 0, output },
+    output,
+    { stdout: report },
+    `Goldband review: durable state root is not writable in this sandbox; evidence will use sandbox-safe temporary root /tmp/review.\n${output}`,
+    `${output}\nGoldband review: temporary state root warning\n`,
+  ]) {
+    const message = reviewLaunchAdvisory(
+      input('goldband review code --host codex', response),
+    );
+    assert.match(message, /started but its evidence is incomplete/);
+    assert.doesNotMatch(message, /correct host launcher/);
+  }
+  assert.equal(
+    reviewLaunchAdvisory(input('goldband review code', { exit_code: 0 })),
+    null,
+  );
+  assert.equal(
+    reviewLaunchAdvisory(
+      input('goldband review code', {
+        exit_code: 1,
+        stdout: output.replace('incomplete: true', 'incomplete: false'),
+      }),
+    ),
+    null,
+    'actual review findings are not launcher errors',
+  );
+  assert.equal(
+    reviewLaunchAdvisory({
+      ...input('goldband review code', { exit_code: 1 }),
+      is_interrupt: true,
+    }),
+    null,
+  );
+  assert.equal(
+    reviewLaunchAdvisory({
+      ...input('goldband review code', { exit_code: 1 }),
+      hook_event_name: 'PreToolUse',
+    }),
+    null,
+  );
+
+  const failed = spawnSync(
+    'bun',
+    ['goldband-loop/bin/goldband.ts', 'review', 'code'],
+    {
+      cwd: root,
+      encoding: 'utf8',
+    },
+  );
+  assert.equal(failed.status, 1, failed.stderr);
+  assert.match(failed.stderr, /requires --host/);
+  assert.match(
+    reviewLaunchAdvisory(
+      input('bun goldband-loop/bin/goldband.ts review code', failed.stderr),
+    ),
+    /correct host launcher/,
+    'live Codex PostToolUse delivers plain text without an exit code',
+  );
+  const codexEvent = input('bun goldband-loop/bin/goldband.ts review code', {
+    exit_code: failed.status,
+    stdout: failed.stdout,
+    stderr: failed.stderr,
+  });
+  const claudeEvent = {
+    ...codexEvent,
+    hook_event_name: 'PostToolUseFailure',
+    tool_response: undefined,
+    error: `Exit code ${failed.status}\n${failed.stderr}`,
+    is_interrupt: false,
+  };
+
+  const copiedHooks = path.join(temp, 'codex-hooks');
+  fs.cpSync(path.join(root, 'codex/hooks'), copiedHooks, { recursive: true });
+  for (const [router, event] of [
+    ['codex/hooks/hook-router.js', codexEvent],
+    [
+      'codex/hooks/hook-router.js',
+      { ...codexEvent, tool_response: failed.stderr },
+    ],
+    [path.join(copiedHooks, 'hook-router.js'), codexEvent],
+    ['hooks/scripts/hooks/hook-router.js', claudeEvent],
+    [
+      'plugin-assets/claude-code-plugin/hooks/scripts/hooks/hook-router.js',
+      claudeEvent,
+    ],
+  ]) {
+    const run = (payload) =>
+      spawnSync(process.execPath, [router], {
+        cwd: root,
+        input: JSON.stringify(payload),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          GOLDBAND_DATA_DIR: temp,
+          CLAUDE_PLUGIN_DATA: temp,
+          HOOK_ROUTER_METRICS_DISABLED: '1',
+        },
+      });
+    const launched = run(event);
+    assert.equal(launched.status, 0, launched.stderr);
+    const advice = JSON.parse(launched.stdout).hookSpecificOutput;
+    assert.equal(advice.hookEventName, event.hook_event_name);
+    assert.match(advice.additionalContext, /correct host launcher/);
+    const incomplete = run(
+      input('goldband review code --host codex', {
+        exit_code: 0,
+        stdout: output,
+      }),
+    );
+    assert.equal(incomplete.status, 0, incomplete.stderr);
+    assert.match(
+      JSON.parse(incomplete.stdout).hookSpecificOutput.additionalContext,
+      /evidence is incomplete/,
+    );
+  }
+  console.log(
+    'ok - review launch advice, incomplete reports, silent unrelated commands, and isolated host adapters',
+  );
+} finally {
+  fs.rmSync(temp, { recursive: true, force: true });
+}


### PR DESCRIPTION
Compiler output permission errors now produce incomplete review evidence instead of a candidate failure. Claude and Codex hooks provide scoped guidance when Goldband review fails to start, and direct incomplete runs to their report.

Validation: independent review completed; hook router suite, installer checks, generated distribution checks, and configuration verification passed. The local nested Seatbelt integration was blocked by the host sandbox; the macOS CI job covers that integration.
