### PR TITLE
fix(review): support coverage in sealed Python runtime

### DIFF
--- a/docs/review-evidence-manifest.md
+++ b/docs/review-evidence-manifest.md
@@ -358,14 +358,27 @@ installed tree，以及 candidate-local direct source digest。Registry package 
 未被選用的 ambient cache entry 不作為 identity 或 failure condition。Project 自身不安裝進 environment；gate 從 materialized
 candidate working directory import source。
 
+Interpreter 的原生 stdlib modules（`lib-dynload/*.so`）也會沿用 Mach-O
+dependency attestation，逐檔授權其 transitive dylibs 並綁定 execution identity。
+這涵蓋 coverage 所需的 `_sqlite3`／SQLite 等依賴，不授權整個 Homebrew
+package directory；native module 本身不得逃出已宣告的 stdlib。
+
 在 project gate 前，runtime 會用 materialized interpreter 執行 isolated
 bootstrap／stdlib preflight，並拒絕 source checkout 的 `.venv` 或 tool、跨
-repository symlink、editable/local external install、`.pth`、`.egg-link`、
+repository symlink、editable/local external install、未知的 `.pth`、`.egg-link`、
 `sitecustomize`、`usercustomize` 與 ambient `PYTHONPATH`。缺 interpreter、`uv`、
 lockfile、offline artifact，或 environment/bootstrap 完整性失敗，都會產生
 typed `runtime-incomplete`，不執行 project gate，也不啟動 semantic host。只有
 preflight 通過後，gate 的 declared exit mismatch 才是 fresh
 `verified-failure`。
+
+`.pth` 只支援已核對內容的 coverage conditional startup hook（coverage 7.15.4
+的 `a1_coverage.pth`）：必須位於 environment 的 `site-packages` 根目錄、內容
+符合 runtime 固定的 SHA-256，且唯一的 coverage distribution metadata 與
+`RECORD` 必須吻合。檔案會保留，讓 coverage 的子程序收集功能正常運作；
+這項內容檢查不取代既有的 lock/artifact identity 與 sandbox 邊界。變更過的
+hook 仍會拒絕，不能只靠同名檔案或 package metadata 放行。uv 自帶且內容為
+`import _virtualenv` 的 `_virtualenv.pth` 則沿用既有移除處理。
 
 缺 offline wheel 時，在審查外依 candidate 的 `uv.lock` 備齊 macOS／Python 相容的
 uv cache 後重跑；Linux container 已安裝的套件不能替代它，gate 仍維持 network deny。

--- a/goldband-loop/config/source-complexity-baseline.json
+++ b/goldband-loop/config/source-complexity-baseline.json
@@ -700,13 +700,12 @@
         14
       ],
       "lint/complexity/noExcessiveLinesPerFunction": [
-        94,
+        91,
         87,
         78,
         72,
         67,
-        56,
-        52
+        56
       ],
       "lint/complexity/useMaxParams": [
         7,

--- a/goldband-loop/test/fixtures/python-runtime/a1_coverage.pth
+++ b/goldband-loop/test/fixtures/python-runtime/a1_coverage.pth
@@ -1,0 +1,1 @@
+import sys; exec('import os\n\nif os.getenv("COVERAGE_PROCESS_START") or os.getenv("COVERAGE_PROCESS_CONFIG"):\n try:\n  import coverage\n except:\n  pass\n else:\n  coverage.process_startup(slug="pth")')

--- a/goldband-loop/test/review-evidence.test.ts
+++ b/goldband-loop/test/review-evidence.test.ts
@@ -1939,6 +1939,122 @@ describe('review evidence contracts', () => {
       .toThrow('symlink escape');
   });
 
+  test('preserves the recognized distribution-owned coverage startup hook', () => {
+    const { environment, python, pth } = coverageStartupFixture();
+    const before = readFileSync(pth);
+    expect(validateMaterializedPythonEnvironment(environment, python, '/unrelated-source-checkout'))
+      .toBe(join(environment, 'bin', 'python3.14'));
+    expect(readFileSync(pth)).toEqual(before);
+  });
+
+  test('attests a dylib symlink at its actual location behind a directory alias', () => {
+    const root = mkdtempSync(join(tmpdir(), 'runtime-library-alias-'));
+    roots.push(root);
+    const installed = join(root, 'installed');
+    mkdirSync(installed);
+    const image = join(installed, 'libfixture.1.dylib');
+    writeFileSync(image, 'library fixture');
+    symlinkSync('libfixture.1.dylib', join(installed, 'libfixture.dylib'));
+    symlinkSync(installed, join(root, 'alias'));
+    const requested = join(root, 'alias', 'libfixture.dylib');
+    const paths = runtimeLibraryLiteralPaths(requested, realpathSync(image), []);
+    expect(paths).toContain(join(realpathSync(installed), 'libfixture.dylib'));
+    expect(paths).toContain(realpathSync(image));
+    expect(paths).toContain(requested);
+    expect(paths).not.toContain(installed);
+  });
+
+  test.each([
+    'changed hook', 'changed hook with matching RECORD', 'renamed hook', 'nested hook',
+    'missing owner', 'duplicate owner', 'wrong metadata', 'wrong version',
+    'missing RECORD entry', 'wrong RECORD hash', 'duplicate RECORD entry',
+    'symlink hook', 'symlink metadata', 'additional unknown hook',
+  ])('rejects unsupported coverage startup customization: %s', (scenario) => {
+    const { environment, python, pth, distInfo } = coverageStartupFixture();
+    const record = join(distInfo, 'RECORD');
+    if (scenario.startsWith('changed hook')) {
+      writeFileSync(pth, 'import arbitrary_startup_code\n');
+      if (scenario.endsWith('matching RECORD')) writeFileSync(record, coverageStartupRecord(readFileSync(pth)));
+    } else if (scenario === 'renamed hook') {
+      renameSync(pth, join(dirname(pth), 'other.pth'));
+    } else if (scenario === 'nested hook') {
+      mkdirSync(join(dirname(pth), 'nested'));
+      renameSync(pth, join(dirname(pth), 'nested', 'a1_coverage.pth'));
+    } else if (scenario === 'missing owner') {
+      rmSync(distInfo, { recursive: true });
+    } else if (scenario === 'duplicate owner') {
+      mkdirSync(join(dirname(pth), 'coverage-0.0.0.dist-info'));
+    } else if (scenario === 'wrong metadata' || scenario === 'wrong version') {
+      writeFileSync(join(distInfo, 'METADATA'), scenario === 'wrong metadata'
+        ? 'Name: other\nVersion: 7.15.4\n' : 'Name: coverage\nVersion: 0.0.0\n');
+    } else if (scenario === 'missing RECORD entry') {
+      writeFileSync(record, '');
+    } else if (scenario === 'wrong RECORD hash') {
+      writeFileSync(record, 'a1_coverage.pth,sha256=wrong,205\n');
+    } else if (scenario === 'duplicate RECORD entry') {
+      writeFileSync(record, readFileSync(record, 'utf8').repeat(2));
+    } else if (scenario.startsWith('symlink')) {
+      const target = scenario === 'symlink hook' ? pth : join(distInfo, 'METADATA');
+      renameSync(target, `${target}.original`);
+      symlinkSync(`${target}.original`, target);
+    } else {
+      writeFileSync(join(dirname(pth), 'unknown.pth'), 'import arbitrary_startup_code\n');
+    }
+    expect(() => validateMaterializedPythonEnvironment(environment, python, '/unrelated-source-checkout'))
+      .toThrow();
+  });
+
+  test('runs a coverage startup hook from an offline wheel through the sealed Python gate', async () => {
+    if (!hostBoundaryPrerequisite(process.platform === 'darwin', 'platform=darwin')) return;
+    const python = spawnSync('/usr/bin/which', ['python3.14'], { encoding: 'utf8' }).stdout.trim();
+    const uv = spawnSync('/usr/bin/which', ['uv'], { encoding: 'utf8' }).stdout.trim();
+    if (!hostBoundaryPrerequisite(Boolean(python) && Boolean(uv), 'Python 3.14 and uv executables')) return;
+    const repo = gitFixture();
+    const wheel = join(repo, 'vendor', 'coverage-7.15.4-py3-none-any.whl');
+    mkdirSync(dirname(wheel), { recursive: true });
+    writeCoverageStartupWheel(python, wheel);
+    writeFileSync(join(repo, 'pyproject.toml'), [
+      '[project]', 'name="coverage-startup-fixture"', 'version="0.1.0"',
+      'requires-python=">=3.14,<3.15"', 'dependencies=["coverage"]',
+      '[tool.uv.sources]', 'coverage={path="vendor/coverage-7.15.4-py3-none-any.whl"}', '',
+    ].join('\n'));
+    // The fixture module records startup calls; the real upstream .pth bytes
+    // must remain active in child interpreters, and inert without either flag.
+    writeFileSync(join(repo, 'probe.py'), [
+      'import os, sqlite3, ssl, subprocess, sys',
+      'assert sqlite3.connect(":memory:").execute("select 42").fetchone() == (42,)',
+      'assert ssl.OPENSSL_VERSION',
+      'assert "coverage" not in sys.modules',
+      'for flag in ("COVERAGE_PROCESS_START", "COVERAGE_PROCESS_CONFIG"):',
+      '    env = {**os.environ, flag: "fixture"}',
+      '    subprocess.run([sys.executable, "-c", "import coverage; assert coverage.STARTED == \'pth\'"], env=env, check=True)',
+      'print("coverage startup preserved")', '',
+    ].join('\n'));
+    const locked = spawnSync(uv, ['lock', '--project', repo, '--python', python, '--offline', '--no-cache'], { encoding: 'utf8' });
+    if (locked.status !== 0) throw new Error(locked.stderr);
+    git(repo, ['add', '.']);
+    git(repo, ['commit', '-m', 'add coverage startup fixture']);
+    const value = manifest();
+    value.providers[0]!.operations[0] = {
+      ...operation('coverage-startup', ['python3.14', 'probe.py'], 'candidate', 'zero'),
+      pythonRuntime: { interpreter: 'python3.14', resolver: 'uv', projectFile: 'pyproject.toml', lockFile: 'uv.lock' },
+    };
+    const validated = reviewEvidenceManifestSchema.validate(value);
+    const input = { source: 'git diff', diff: '', changedFiles: [] };
+    const cache = mkdtempSync(join(tmpdir(), 'coverage-startup-cache-'));
+    roots.push(cache);
+    const previousCache = process.env.UV_CACHE_DIR;
+    process.env.UV_CACHE_DIR = cache;
+    try {
+      const evidence = await executeEvidencePlan(context(repo), input, validated, createCandidateBinding(repo, input, validated));
+      expect(evidence.records[0]!.outputSummary).toContain('coverage startup preserved');
+      expect(evidence.records[0]).toMatchObject({ status: 'verified-pass', fresh: true, exitStatus: 0 });
+    } finally {
+      if (previousCache === undefined) delete process.env.UV_CACHE_DIR;
+      else process.env.UV_CACHE_DIR = previousCache;
+    }
+  });
+
   test('sealed Bun runtime can resolve the candidate cwd and a declared --cwd', async () => {
     if (!hostBoundaryPrerequisite(process.platform === 'darwin', 'platform=darwin')) return;
     const repo = gitFixture();
@@ -3473,6 +3589,42 @@ function writeFixtureWheel(python: string, output: string): void {
     'z.close()',
   ].join(';');
   const result = spawnSync(python, ['-I', '-S', '-c', script, output], { encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(result.stderr);
+}
+
+function coverageStartupRecord(content: Buffer): string {
+  const digest = createHash('sha256').update(content).digest('base64url');
+  return `a1_coverage.pth,sha256=${digest},${content.length}\n`;
+}
+
+function coverageStartupFixture() {
+  const environment = mkdtempSync(join(tmpdir(), 'coverage-startup-validation-'));
+  roots.push(environment);
+  const python = join(environment, 'bin', 'python3.14');
+  const sitePackages = join(environment, 'lib', 'python3.14', 'site-packages');
+  const distInfo = join(sitePackages, 'coverage-7.15.4.dist-info');
+  mkdirSync(dirname(python), { recursive: true });
+  mkdirSync(distInfo, { recursive: true });
+  // Structural validation only; the sealed gate test uses a real interpreter.
+  writeFileSync(python, 'fixture interpreter identity');
+  const pth = join(sitePackages, 'a1_coverage.pth');
+  copyFileSync(join(import.meta.dir, 'fixtures/python-runtime/a1_coverage.pth'), pth);
+  writeFileSync(join(distInfo, 'METADATA'), 'Name: coverage\nVersion: 7.15.4\n');
+  writeFileSync(join(distInfo, 'RECORD'), coverageStartupRecord(readFileSync(pth)));
+  return { environment, python, pth, distInfo };
+}
+
+function writeCoverageStartupWheel(python: string, output: string): void {
+  const pth = readFileSync(join(import.meta.dir, 'fixtures/python-runtime/a1_coverage.pth'));
+  const files = {
+    'a1_coverage.pth': pth.toString('utf8'),
+    'coverage/__init__.py': 'STARTED = None\ndef process_startup(*, slug):\n    global STARTED\n    STARTED = slug\n',
+    'coverage-7.15.4.dist-info/METADATA': 'Metadata-Version: 2.1\nName: coverage\nVersion: 7.15.4\n',
+    'coverage-7.15.4.dist-info/WHEEL': 'Wheel-Version: 1.0\nGenerator: goldband-test\nRoot-Is-Purelib: true\nTag: py3-none-any\n',
+    'coverage-7.15.4.dist-info/RECORD': coverageStartupRecord(pth),
+  };
+  const script = 'import json,sys,zipfile\nwith zipfile.ZipFile(sys.argv[1], "w") as z:\n for name, text in json.loads(sys.argv[2]).items(): z.writestr(name, text)';
+  const result = spawnSync(python, ['-I', '-S', '-c', script, output, JSON.stringify(files)], { encoding: 'utf8' });
   if (result.status !== 0) throw new Error(result.stderr);
 }
 

--- a/goldband-loop/workflows/review-evidence.ts
+++ b/goldband-loop/workflows/review-evidence.ts
@@ -3485,12 +3485,9 @@ export function evidenceRuntimeReadAccess(executable: string): EvidenceRuntimeRe
     const visitImage = (image: string, inheritedRpaths: string[]): void => {
       if (visited.has(image)) return;
       visited.add(image);
-      const rpaths = uniqueInOrder([
-        ...machORpaths(image, executableFile),
-        ...inheritedRpaths,
-      ]);
+      const { rpaths, dylibs } = machOLoadCommands(image, executableFile, inheritedRpaths);
       const dependencies: Array<{ image: string; inheritedRpaths: string[] }> = [];
-      for (const edge of machOLoadedDylibs(image)) {
+      for (const edge of dylibs) {
         const { installName } = edge;
         if (isAbsolute(installName) && systemRoots.some((root) =>
           installName === root || installName.startsWith(`${root}${sep}`))) continue;
@@ -3643,8 +3640,15 @@ function otool(image: string, mode: '-L' | '-l'): string {
   return result.stdout;
 }
 
-function machORpaths(image: string, executable: string): string[] {
+function machOLoadCommands(image: string, executable: string, inheritedRpaths: string[]) {
   const loadCommands = otool(image, '-l').split('\n');
+  return {
+    rpaths: uniqueInOrder([...machORpaths(image, executable, loadCommands), ...inheritedRpaths]),
+    dylibs: machOLoadedDylibs(loadCommands),
+  };
+}
+
+function machORpaths(image: string, executable: string, loadCommands: string[]): string[] {
   const rpaths: string[] = [];
   for (let index = 0; index < loadCommands.length; index += 1) {
     if (loadCommands[index]?.trim() !== 'cmd LC_RPATH') continue;
@@ -3659,8 +3663,7 @@ function machORpaths(image: string, executable: string): string[] {
   return uniqueInOrder(rpaths);
 }
 
-function machOLoadedDylibs(image: string): Array<{ installName: string; weak: boolean }> {
-  const loadCommands = otool(image, '-l').split('\n');
+function machOLoadedDylibs(loadCommands: string[]): Array<{ installName: string; weak: boolean }> {
   const installNames: Array<{ installName: string; weak: boolean }> = [];
   const dependencyCommands = new Set([
     'LC_LOAD_DYLIB',

--- a/goldband-loop/workflows/review-evidence.ts
+++ b/goldband-loop/workflows/review-evidence.ts
@@ -72,7 +72,11 @@ const MAX_REVIEW_EVIDENCE_TOTAL_BYTES = 1024 * 1024;
 const MAX_REVIEW_EVIDENCE_OPERATIONS = 64;
 const MAX_EVIDENCE_RUNTIME_DIAGNOSTIC_CHARS = 16 * 1024;
 const DEFAULT_REVIEW_EVIDENCE_MANIFEST = 'goldband.review-evidence.json';
-const EVIDENCE_RUNNER_POLICY = 'per-operation-sealed-runtime-readonly-snapshot-default-deny-read-write-network-v55';
+const EVIDENCE_RUNNER_POLICY = 'per-operation-sealed-runtime-readonly-snapshot-default-deny-read-write-network-v56';
+// coverage.py 7.15.4's conditional process_startup(slug="pth") hook. Review
+// changed hook bytes before extending support; package ownership alone cannot
+// authorize arbitrary startup code. Keep the hook for subprocess measurement.
+const COVERAGE_STARTUP_PTH_SHA256 = 'ef2ed06d19867ec669c09a804060666a9cd5e383af0a9d11aa2de79b77d448e8';
 const MAX_REDACTED_UNTRACKED_BYTES = 256 * 1024;
 const REVIEW_RECEIPT_TRUSTED_CONFIG_ENV = 'GOLDBAND_REVIEW_RECEIPT_TRUSTED_CONFIG';
 const SUPPORTED_REVIEW_HOST_EVIDENCE_LANE = REVIEW_HOST_EVIDENCE_POLICY.reviewHostEvidenceLane;
@@ -2531,6 +2535,7 @@ function pythonRuntimeReadAccess(
   const prefixDigest = directoryContentDigest(prefix, 'Python interpreter runtime');
   return mergeEvidenceRuntimeReadAccess([
     base,
+    ...pythonStdlibExtensionAccess(stdlib),
     {
       roots: [prefix],
       literals: [],
@@ -2548,6 +2553,24 @@ function pythonRuntimeReadAccess(
       })),
     },
   ]);
+}
+
+function pythonStdlibExtensionAccess(stdlib: string): EvidenceRuntimeReadAccess[] {
+  const extensions = join(stdlib, 'lib-dynload');
+  if (!existsSync(extensions)) return [];
+  if (!realpathSync(extensions).startsWith(`${stdlib}${sep}`)) {
+    throw new Error('Python native stdlib directory resolves outside the declared stdlib');
+  }
+  // dlopen dependencies (for example _sqlite3 -> libsqlite3) are not edges of
+  // the interpreter executable. Reuse exact Mach-O attestation for the native
+  // stdlib modules instead of granting reads to their package directories.
+  return readdirSync(extensions).filter((name) => name.endsWith('.so')).sort().map((name) => {
+    const extension = join(extensions, name);
+    if (!realpathSync(extension).startsWith(`${stdlib}${sep}`)) {
+      throw new Error('Python native stdlib module resolves outside the declared stdlib');
+    }
+    return evidenceRuntimeReadAccess(extension);
+  });
 }
 
 function uvCacheRoot(
@@ -2707,14 +2730,13 @@ export function validateMaterializedPythonEnvironment(
   if (!existsSync(environmentPython) || executableContentDigest(environmentPython) !== executableContentDigest(sourceCommand)) {
     throw new Error('materialized Python environment does not use the declared interpreter');
   }
+  let coverageStartupHook: string | undefined;
   visitDirectory(environmentRoot, 'materialized Python environment', (absolute, relativePath, entry) => {
     if (entry.isSymbolicLink()) {
       throw new Error(`materialized Python environment contains a symlink escape: ${relativePath}`);
     }
     const lower = relativePath.toLowerCase();
-    if (lower.endsWith('.pth') || lower.endsWith('.egg-link') || /(^|\/)(sitecustomize|usercustomize)\.py$/.test(lower)) {
-      throw new Error(`materialized Python environment contains forbidden site customization: ${relativePath}`);
-    }
+    if (validatePythonSiteCustomization(absolute, relativePath, entry)) coverageStartupHook = absolute;
     if (!entry.isFile()) return;
     if (lower.endsWith('direct_url.json')) {
       validatePythonDirectUrl(absolute, [environmentRoot, candidateRoot]);
@@ -2724,7 +2746,43 @@ export function validateMaterializedPythonEnvironment(
       throw new Error(`materialized Python environment refers to the source checkout: ${relativePath}`);
     }
   });
+  // Inspect ownership only after the entire tree has passed the symlink and
+  // file-type checks. The existing lock/artifact identity checks still run
+  // before bootstrap or project code can execute.
+  if (coverageStartupHook) validateCoverageStartupOwnership(coverageStartupHook);
   return environmentPython;
+}
+
+function validatePythonSiteCustomization(absolute: string, relativePath: string, entry: Dirent): boolean {
+  const lower = relativePath.toLowerCase();
+  if (!lower.endsWith('.pth') && !lower.endsWith('.egg-link') &&
+    !/(^|\/)(sitecustomize|usercustomize)\.py$/.test(lower)) return false;
+  if (entry.isFile() && relativePath === 'lib/python3.14/site-packages/a1_coverage.pth' &&
+    sha256(readFileSync(absolute)) === COVERAGE_STARTUP_PTH_SHA256) return true;
+  throw new Error(`materialized Python environment contains forbidden site customization: ${relativePath}`);
+}
+
+function validateCoverageStartupOwnership(pth: string): void {
+  const sitePackages = dirname(pth);
+  const distributions = readdirSync(sitePackages, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && /^coverage-[^/]+\.dist-info$/.test(entry.name));
+  if (distributions.length !== 1) {
+    throw new Error('coverage startup hook must belong to exactly one installed coverage distribution');
+  }
+  const distInfo = join(sitePackages, distributions[0]!.name);
+  const metadata = readFileSync(join(distInfo, 'METADATA'), 'utf8');
+  const version = pythonMetadataField(metadata, 'Version');
+  if (pythonMetadataField(metadata, 'Name') !== 'coverage' ||
+    distributions[0]!.name !== `coverage-${version}.dist-info`) {
+    throw new Error('coverage startup hook distribution metadata does not match its owner');
+  }
+  const content = readFileSync(pth);
+  const recordHash = createHash('sha256').update(content).digest('base64url');
+  const records = readFileSync(join(distInfo, 'RECORD'), 'utf8').split(/\r?\n/)
+    .filter((row) => row.startsWith('a1_coverage.pth,'));
+  if (records.length !== 1 || records[0] !== `a1_coverage.pth,sha256=${recordHash},${content.length}`) {
+    throw new Error('coverage startup hook does not match its distribution RECORD');
+  }
 }
 
 function validatePythonDirectUrl(file: string, allowedRoots: string[]): void {
@@ -3530,7 +3588,11 @@ function pathSymlinkLiterals(file: string): string[] {
   for (const part of parts) {
     current = join(current, part);
     const stat = lstatSync(current, { throwIfNoEntry: false });
-    if (stat?.isSymbolicLink()) symlinks.push(current);
+    if (stat?.isSymbolicLink()) {
+      // Seatbelt also checks the link's actual location after resolving parent
+      // directory aliases (Homebrew opt/package -> Cellar/package/version).
+      symlinks.push(current, join(realpathSync(dirname(current)), basename(current)));
+    }
   }
   return symlinks;
 }


### PR DESCRIPTION
Goldband rejected Python environments containing coverage.py's normal `a1_coverage.pth` before project tests could run. Accept the reviewed hook bytes only at the expected location with matching coverage distribution metadata and RECORD, preserving subprocess coverage while rejecting unknown or modified startup hooks.

Also attest native stdlib dependencies and their Homebrew symlink locations so coverage can load SQLite inside the existing sandbox. Library access remains limited to the required files. Read Mach-O load commands once per image and share the output between rpath and dependency parsing, avoiding duplicate subprocess work that caused Python environment preparation tests to exceed their existing timeout on CI.

Validation:
- Independent Goldband review: 0 findings; all 5 evidence checks passed.
- Review regression suite: 149 passed; Work Map tests: 11 passed; installed runtime tests: 9 passed.
- Source lint, complexity, typecheck, exports, and generated-surface checks passed.
- Actual coverage 7.15.4 recorded subprocess line coverage through both COVERAGE_PROCESS_START and COVERAGE_PROCESS_CONFIG in the sealed runtime.
- Full local workflow suite: 412 passed; all 19 PR checks passed.
- The first CI run on the final commit passed the standalone installed-runtime test in 10.7 seconds, but its later full-suite invocation hit the existing 30-second timeout. The unchanged failed job passed on rerun; the full local suite also passed (installed-runtime test: 14.9 seconds). The transient timeout cause remains unconfirmed; no test, assertion, or timeout was relaxed.
