### PR TITLE
feat(review): add semantic-only mode and harden Python evidence runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Codex:       $goldband system health
 
 程式碼審查需要先為目標專案設定驗證契約；請從[審查入門](docs/review-evidence-manifest.md#quick-start)開始。需要本機隔離執行測試的正式審查目前僅支援 macOS；Linux／Windows 缺少這類證據時會回報未完成。測試或安裝成功也不代表審查、部署已完成。
 
-Claude／Codex 的 Python 審查 gate 必須宣告 `pythonRuntime`：目前只支援 macOS Python 3.14 + uv，且 candidate 需有 `pyproject.toml`、`uv.lock` 與完整離線依賴；缺少條件會阻擋執行。
+Claude／Codex 的 Python 審查 gate 必須宣告 `pythonRuntime`：目前只支援 macOS Python 3.14 + uv，且 candidate 需有 `pyproject.toml`、`uv.lock` 與完整離線依賴；缺少條件會阻擋執行。主機工具支援系統、Homebrew（含 `opt`）、MacPorts，以及標準使用者 uv／Python 與 pyenv 實際版本目錄；shell shim 不受支援，詳見 [Python runtime 安裝位置](docs/review-evidence-manifest.md#python-314--uv-runtime)。
 
 ## 更新與移除
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Codex:       $goldband system health
 
 一般實作涉及大量處理、資料實體化、快取、平行執行或效能改善宣稱時，Claude／Codex 的指引會導向共用 `performance-optimization` skill，檢查有研究案例支持的 agent 陷阱，不需先跑 planning。Review 會檢查改善證據與實際路徑；這些指引不代表自動量測 CPU／RAM，也不要求所有修改都跑 benchmark。
 
-程式碼審查需要先為目標專案設定驗證契約；請從[審查入門](docs/review-evidence-manifest.md#quick-start)開始。需要本機隔離執行測試的正式審查目前僅支援 macOS；Linux／Windows 缺少這類證據時會回報未完成。測試或安裝成功也不代表審查、部署已完成。
+包含執行驗證的程式碼審查需要先為目標專案設定驗證契約；純語意 `--semantic-only` 不需要。請從[審查入門](docs/review-evidence-manifest.md#quick-start)開始。需要本機隔離執行測試的正式審查目前僅支援 macOS；Linux／Windows 缺少這類證據時會回報未完成。測試或安裝成功也不代表審查、部署已完成。
 
 Claude／Codex 的 Python 審查 gate 必須宣告 `pythonRuntime`：目前只支援 macOS Python 3.14 + uv，且 candidate 需有 `pyproject.toml`、`uv.lock` 與完整離線依賴；缺少條件會阻擋執行。主機工具支援系統、Homebrew（含 `opt`）、MacPorts，以及標準使用者 uv／Python 與 pyenv 實際版本目錄；shell shim 不受支援，詳見 [Python runtime 安裝位置](docs/review-evidence-manifest.md#python-314--uv-runtime)。
 
@@ -107,6 +107,28 @@ claude plugin uninstall goldband@goldband    # 移除 Claude plugin
 ## 授權
 
 [MIT License](LICENSE)。
+
+### 純語意與完整審查
+
+「只看程式」使用 `$goldband review code --semantic-only`（Claude 使用
+`/goldband review code --semantic-only`）。兩端沿用 installed launcher 與唯讀 host：
+讀取完整 scoped diff、必要 impact context、shared rubric 與 applicable Rules；不讀取或驗證
+manifest、不執行 evidence providers、candidate tests、dependency preparation 或下載套件。
+缺少 Python、uv、offline wheels 或資料庫不會阻擋此模式；host 本身仍須可用且已認證。
+
+「包含執行驗證」使用預設 `$goldband review code`。缺少或無效 evidence contract、執行前提
+不足時仍 fail closed，不會自動切換純語意模式。
+
+純語意 artifact 使用 `phase: semantic-only`、`evidenceStatus: not-declared`、
+`completionAuthorized: false`，沒有 behavior contract digest 或 runtime receipt。
+所有 findings 僅為 `semantic-concern`；零 finding 顯示 `No semantic concerns found`，不代表
+完整審查或測試通過。既有 blockers 以 `prior-blockers-open` 唯讀顯示，不能關閉或覆寫。
+`--semantic-only` 與 `--evidence-manifest`、`--closure-artifact`、`--work-id`、`--ticket-id` 互斥。
+
+同一 installed authority 內，相同 candidate、canonical scope、Rules／policy 的純語意重複呼叫會在 host 前拒絕，包含並行
+呼叫及先前 host 失敗的重試；此成本紀錄與 acceptance lineage 分開，不阻擋後續完整審查。
+Claude／Codex 各自安裝的 authority 延續既有隔離邊界，去重與 prior blocker 投影不跨 authority。
+結果格式見 [`review-semantic-result.schema.json`](schemas/review-semantic-result.schema.json)。
 
 ### Project review evidence
 

--- a/docs/generated/capabilities.md
+++ b/docs/generated/capabilities.md
@@ -7,7 +7,7 @@ Public inventory: 20 actions. Experimental actions are excluded from routing and
 
 | Capability | Action | Outcome | Runtime owner | Runtime | Dispatch | Risk |
 | --- | --- | --- | --- | --- | --- | --- |
-| `review` | `code` | Evidence-first code review. | `review-runtime` | `typed` | `trusted-launcher` | `medium` |
+| `review` | `code` | Evidence-backed or explicit semantic-only code review. | `review-runtime` | `typed` | `trusted-launcher` | `medium` |
 | `review` | `security` | Review security and trust boundaries. | `prompt-contract-dispatch` | `compatibility` | `prompt-contract` | `medium` |
 | `investigate` | `code` | Investigate code or runtime behavior. | `prompt-contract-dispatch` | `compatibility` | `prompt-contract` | `medium` |
 | `qa` | `app` | Run product QA and record evidence. | `qa-runtime` | `typed` | `host-runtime` | `medium` |

--- a/docs/review-evidence-manifest.md
+++ b/docs/review-evidence-manifest.md
@@ -346,9 +346,20 @@ Python gate 必須明確宣告，不能猜測專案路徑或 lockfile：
 project directory。`argv` 第一項必須和 declared interpreter 相同；目前不接受
 其他 Python 版本、resolver 或 online mode。
 
-Runtime 只從受信任的 macOS system／Homebrew package roots 選取 host
-`python3.14` 與 `uv`，先 attestation，再在 Seatbelt 內執行 interpreter inspection
-與 cache discovery；不會直接執行 caller `PATH` 的任意 shim。驗證 candidate
+Runtime 從 `PATH` 第一個可執行的 `python3.14` 與 `uv` 選取 host 工具，
+同時驗證入口、父目錄與最終 symlink 目標。支援 macOS system／Python.org
+framework、Homebrew `bin`／`Cellar`／`opt`、MacPorts `bin`／`Library/Frameworks`，
+以及 OS 帳號家目錄下的 `.local/bin`；Python 另支援 `.local/share/uv/python`
+與 `.pyenv/versions`。家目錄使用 OS 帳號資訊，隔離 self-test 的 `HOME` 不會改變
+受信任目錄。自訂 XDG／安裝 prefix 不會自動取得信任。
+
+工具必須是原生 macOS executable；pyenv 等 shell shim 不受支援，請將實際
+version 的 `bin` 放在 `PATH` 前方。已找到但不受支援的工具會列出 selected／resolved
+路徑及原因，不會默默改用下一份安裝。Repository 內工具、指回 repository 或其他
+不受信任位置的 symlink 仍拒絕。指定的 local Python／installed-runtime self-tests
+只保留已驗證工具的入口目錄與原有系統 PATH，維持原先選取次序；不繼承整份 caller PATH。
+
+先 attestation，再在 Seatbelt 內執行 interpreter inspection 與 cache discovery；驗證 candidate
 lockfiles 後，把 ambient uv cache clone 到 operation 專屬 writable root，以 `--frozen --offline
 --no-install-project --no-editable --link-mode copy` 建立一次性 environment。執行
 identity 綁定 interpreter、uv、兩個 contract files、materialized environment

--- a/goldband-loop/bin/goldband.ts
+++ b/goldband-loop/bin/goldband.ts
@@ -110,7 +110,7 @@ type TrustedLauncherHandlers = {
 function printUsage(stream: Pick<Console, "log">): void {
 	stream.log("Usage:");
 	stream.log(
-		"  goldband review code --host <claude|codex> [--work-id <id> --ticket-id <id>] [--evidence-manifest <file>] [--closure-artifact <initial-review-artifact>] [--staged|--worktree|--base <ref>|--diff-file <file>] [--include-untracked] [--review-host-timeout-seconds <60-1800>] [--review-pass-timeout-seconds <60-1800>] [--review-claude-max-budget-usd <0.01-100.00>]",
+		"  goldband review code --host <claude|codex> [--work-id <id> --ticket-id <id>] [--semantic-only] [--evidence-manifest <file>] [--closure-artifact <initial-review-artifact>] [--staged|--worktree|--base <ref>|--diff-file <file>] [--include-untracked] [--review-host-timeout-seconds <60-1800>] [--review-pass-timeout-seconds <60-1800>] [--review-claude-max-budget-usd <0.01-100.00>]",
 	);
 	stream.log(
 		"  goldband review contract help",
@@ -229,7 +229,20 @@ function finish(name: string | undefined, args: string[]): number {
 	return 0;
 }
 
+function assertSemanticReviewArgs(args: string[]): void {
+  const count = args.filter((arg) => arg === "--semantic-only").length;
+  if (count > 1) throw new Error("--semantic-only may be supplied only once");
+  if (count && args.some((arg) => ["--evidence-manifest", "--closure-artifact", "--work-id", "--ticket-id"].includes(arg))) {
+    throw new Error("--semantic-only is incompatible with --evidence-manifest, --closure-artifact, --work-id, and --ticket-id");
+  }
+}
+
 export function buildReviewRuntimeArgs(args: string[]): string[] {
+	assertSemanticReviewArgs(args);
+	return parseReviewRuntimeArgs(args);
+}
+
+function parseReviewRuntimeArgs(args: string[]): string[] {
 	let host: ReviewHost | undefined;
 	const forwarded: string[] = [];
 	let hasScope = false;

--- a/goldband-loop/config/source-complexity-baseline.json
+++ b/goldband-loop/config/source-complexity-baseline.json
@@ -763,7 +763,7 @@
     },
     "workflows/run.ts": {
       "lint/complexity/noExcessiveCognitiveComplexity": [
-        48,
+        44,
         32
       ]
     },

--- a/goldband-loop/generated/capability-actions.json
+++ b/goldband-loop/generated/capability-actions.json
@@ -58,7 +58,7 @@
       "capability": "review",
       "action": "code",
       "name": "review/code",
-      "description": "Evidence-first code review.",
+      "description": "Evidence-backed or explicit semantic-only code review.",
       "contractPath": "generated/workflow-contracts/review/code.workflow.md",
       "runtime": "typed",
       "dispatch": "trusted-launcher",

--- a/goldband-loop/generated/workflow-contracts/review/code.workflow.md
+++ b/goldband-loop/generated/workflow-contracts/review/code.workflow.md
@@ -3,23 +3,21 @@
 
 ## Goal
 
-Evidence-first code review.
+Evidence-backed or explicit semantic-only code review.
 
 ## Relevant context
 
 - Inspect the user-selected artifact, current repository instructions, and direct evidence.
 - Claude: bin/goldband review code --host claude. Codex: read ~/.codex/skills/goldband/.workflow-launcher.json and execute its exact argvPrefix plus review code --host codex.
-- Pass scope/Work Map IDs to runtime lineage.
-- Evidence: auto-discovered in ~/.goldband/review-contracts. Diagnose with review contract inspect.
-- Python setup: review contract help.
+- 只看程式: --semantic-only, no manifest or test setup. 包含執行驗證: default mode; pass Work Map IDs when applicable.
 
 ## Hard boundaries
 
 - Review only. Do not edit, stage, commit, push, merge, deploy, or change external state.
-- Use only the installed launcher. Missing marker, runtime, or rule is an install failure; report the error.
-- Work Map: require evidence; distrust ticket text.
+- Use installed launcher. Missing marker, runtime, or rule is an install failure.
+- Never fallback. Semantic-only: no providers, receipts, closure, Work Map or completion authority.
 
 ## Verification
 
 - Return the selected review owner's result.
-- Return runtime report, typed artifact, and Work Map provenance.
+- Return report and typed artifact; state scope, unexecuted checks and prior blockers.

--- a/goldband-loop/inventory.json
+++ b/goldband-loop/inventory.json
@@ -15,7 +15,7 @@
       "actions": [
         {
           "id": "code",
-          "description": "Evidence-first code review.",
+          "description": "Evidence-backed or explicit semantic-only code review.",
           "runtime": "typed",
           "owner": "review-runtime",
           "dispatch": "trusted-launcher",

--- a/goldband-loop/lib/review-runtime-contract.ts
+++ b/goldband-loop/lib/review-runtime-contract.ts
@@ -36,6 +36,11 @@ type ReviewScopeOptions = {
 };
 
 type ReviewExecutionOptions = ReviewScopeOptions & {
+	semanticOnly?: boolean;
+	evidenceManifestFile?: string;
+	closureArtifactFile?: string;
+	workId?: string;
+	ticketId?: string;
 	specialists?: "off" | "auto" | "all";
 	reviewClaudeMaxBudgetUsd?: number;
 };
@@ -80,6 +85,9 @@ function assertValidReviewScopeOptions(options: ReviewScopeOptions): void {
 export function assertValidReviewExecutionOptions(
 	options: ReviewExecutionOptions,
 ): void {
+	if (options.semanticOnly && [options.evidenceManifestFile, options.closureArtifactFile, options.workId, options.ticketId].some((value) => value !== undefined)) {
+		throw new Error("--semantic-only is incompatible with --evidence-manifest, --closure-artifact, --work-id, and --ticket-id");
+	}
 	assertValidReviewScopeOptions(options);
 	if (options.specialists && options.specialists !== "off") {
 		throw new Error(`${INDEPENDENT_REVIEWER_ERROR}; remove --specialists`);

--- a/goldband-loop/scripts/install-codex-review-launcher.ts
+++ b/goldband-loop/scripts/install-codex-review-launcher.ts
@@ -30,6 +30,7 @@ const REVIEW_ASSETS = [
 ] as const;
 
 const REVIEW_AUTHORING_ASSETS = [
+	{ source: "../schemas/review-semantic-result.schema.json", target: "review/schemas/review-semantic-result.schema.json" },
 	{ source: "../docs/review-evidence-manifest.md", target: "review/review-evidence-manifest.md" },
 	{ source: "../examples/review-evidence/minimal-local-gate.json", target: "review/examples/minimal-local-gate.json" },
 	{ source: "../schemas/review-evidence-manifest.schema.json", target: "review/schemas/review-evidence-manifest.schema.json" },

--- a/goldband-loop/setup
+++ b/goldband-loop/setup
@@ -869,9 +869,15 @@ create_internal_workflow_docs() {
 install_review_authoring_assets() {
   local goldband_dir="$1"
   local runtime_root="$2"
-  local repo_root guide_source example_source manifest_schema_source behavior_schema_source
+  local repo_root guide_source example_source manifest_schema_source behavior_schema_source semantic_schema_source
   repo_root="$(cd "$goldband_dir/.." && pwd -P)"
 
+  semantic_schema_source="$repo_root/schemas/review-semantic-result.schema.json"
+  [ -f "$semantic_schema_source" ] || semantic_schema_source="$goldband_dir/review/schemas/review-semantic-result.schema.json"
+  [ -f "$semantic_schema_source" ] || {
+    echo "goldband setup failed: missing semantic review schema" >&2
+    exit 1
+  }
   guide_source="$repo_root/docs/review-evidence-manifest.md"
   example_source="$repo_root/examples/review-evidence/minimal-local-gate.json"
   manifest_schema_source="$repo_root/schemas/review-evidence-manifest.schema.json"
@@ -899,6 +905,7 @@ install_review_authoring_assets() {
   }
 
   mkdir -p "$runtime_root/review/examples" "$runtime_root/review/schemas"
+  _link_or_copy "$semantic_schema_source" "$runtime_root/review/schemas/review-semantic-result.schema.json"
   _link_or_copy \
     "$guide_source" \
     "$runtime_root/review/review-evidence-manifest.md"

--- a/goldband-loop/test/codex-review-launcher-install.test.ts
+++ b/goldband-loop/test/codex-review-launcher-install.test.ts
@@ -66,6 +66,7 @@ describe("Codex trusted workflow launcher install", () => {
 					"done",
 					'test -n "$output"',
 					'if [ -n "${GOLDBAND_TEST_HOST_CALL_LOG:-}" ]; then printf "%s\\n" codex >> "$GOLDBAND_TEST_HOST_CALL_LOG"; fi',
+					'if [ -n "${GOLDBAND_TEST_MUTATE_POLICY:-}" ]; then printf "\\nPolicy changed during host call.\\n" >> "$GOLDBAND_TEST_MUTATE_POLICY"; fi',
 					'prompt="$(cat)"',
 					'if printf \'%s\' "$prompt" | grep -q CLOSURE_INPUT_START; then',
 					'  printf \'%s\\n\' \'{"contractReview":{"preserved":true,"summary":"Fixture assessment confirms declared static coverage replaces unavailable evidence."},"results":[{"findingId":"S-001","status":"closed","summary":"repair verified","evidenceIds":["installed-gate:pass"]}]}\' > "$output"',
@@ -89,6 +90,7 @@ describe("Codex trusted workflow launcher install", () => {
 					"  exit 0",
 					"fi",
 					'if [ -n "${GOLDBAND_TEST_HOST_CALL_LOG:-}" ]; then printf "%s\\n" claude >> "$GOLDBAND_TEST_HOST_CALL_LOG"; fi',
+					'if [ -n "${GOLDBAND_TEST_MUTATE_POLICY:-}" ]; then printf "\\nPolicy changed during host call.\\n" >> "$GOLDBAND_TEST_MUTATE_POLICY"; fi',
 					"cat >/dev/null",
 					'printf \'%s\\n\' \'{"result":"{\\"findings\\":[]}","usage":{"input_tokens":10,"output_tokens":2}}\'',
 				].join("\n"),
@@ -154,6 +156,7 @@ describe("Codex trusted workflow launcher install", () => {
 			expect(existsSync(join(runtimeRoot, "review", "examples", "minimal-local-gate.json"))).toBe(true);
 			expect(existsSync(join(runtimeRoot, "review", "schemas", "review-evidence-manifest.schema.json"))).toBe(true);
 			expect(existsSync(join(runtimeRoot, "review", "schemas", "review-behavior-matrix.schema.json"))).toBe(true);
+			expect(existsSync(join(runtimeRoot, "review", "schemas", "review-semantic-result.schema.json"))).toBe(true);
 			expect(readFileSync(join(runtimeRoot, "review", "review-evidence-manifest.md"), "utf8"))
 				.toContain("Python 3.14 + uv runtime");
 			expect(readFileSync(join(runtimeRoot, "review", "schemas", "review-evidence-manifest.schema.json"), "utf8"))
@@ -1038,6 +1041,7 @@ describe("Codex trusted workflow launcher install", () => {
 			expect(browser.status).toBe(0);
 			expect(browser.stdout).toContain("browser-ok:status");
 			expect(browser.stdout).toContain('"status": "completed"');
+			verifySemanticOnlyInstalled(runInstalledReview, fixture, trustedBin);
 		} finally {
 			rmSync(fixture, { recursive: true, force: true });
 		}
@@ -1420,4 +1424,111 @@ function workflowStepEventCount(file: string, step: string): number {
 		.map((line) => JSON.parse(line) as { step?: string })
 		.filter((event) => event.step === step)
 		.length;
+}
+
+function verifySemanticOnlyInstalled(
+  run: (cwd: string, args: string[], env?: NodeJS.ProcessEnv) => ReturnType<typeof spawnSync>,
+  fixture: string,
+  trustedBin: string,
+) {
+  for (const host of ['codex', 'claude']) {
+    const repo = join(fixture, `semantic-${host}`);
+    const state = join(fixture, `semantic-state-${host}`);
+    const calls = join(fixture, `semantic-calls-${host}.log`);
+    mkdirSync(repo);
+    const git = (args: string[]) => {
+      const result = spawnSync('git', args, { cwd: repo, encoding: 'utf8' });
+      expect(result.status, result.stderr).toBe(0);
+    };
+    git(['init', '-q']);
+    writeFileSync(join(repo, 'subject.py'), 'safe()\n');
+    git(['add', '.']);
+    git(['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-qm', 'baseline']);
+    writeFileSync(join(repo, 'subject.py'), 'changed()\n');
+    const env = { GOLDBAND_HOME: state, GOLDBAND_TEST_HOST_CALL_LOG: calls,
+      GOLDBAND_TEST_CLEAN_REVIEW: '1', PATH: `${trustedBin}:${process.env.PATH ?? ''}` };
+    const args = ['--host', host, '--worktree'];
+    const missing = run(repo, args, env);
+    expect(missing.status).not.toBe(0);
+    expect(String(missing.stderr)).toContain('evidence contract is required');
+    expect(existsSync(calls)).toBe(false);
+    const semantic = run(repo, [...args, '--semantic-only'], env);
+    expect(semantic.status, String(semantic.stderr)).toBe(0);
+    const result = JSON.parse(String(semantic.stdout));
+    expect(result.output).toContain('No semantic concerns found');
+    const artifact = JSON.parse(readFileSync(result.artifacts.find((file: string) => file.endsWith('-semantic-only.json')), 'utf8'));
+    expect(artifact).toMatchObject({ phase: 'semantic-only', completionAuthorized: false, providerCallCount: 0, hostCallCount: 1 });
+    expect(artifact.runtimeReceipt).toBeUndefined();
+    expect(artifact.binding.behaviorContractDigest).toBeUndefined();
+    expect(existsSync(join(state, 'tmp'))).toBe(false);
+    const duplicate = run(repo, [...args, '--semantic-only'], env);
+    expect(duplicate.status).not.toBe(0);
+    expect(String(duplicate.stderr)).toContain('duplicate semantic-only');
+    expect(readFileSync(calls, 'utf8').trim().split('\n')).toHaveLength(1);
+
+    writeFileSync(join(repo, 'goldband.review-evidence.json'), 'invalid JSON');
+    writeFileSync(join(repo, 'subject.py'), 'invalid_manifest_candidate()\n');
+    const invalid = run(repo, [...args, '--semantic-only'], env);
+    expect(invalid.status, String(invalid.stderr)).toBe(0);
+    const manifest = JSON.parse(readFileSync(resolve(sourceRoot, '../examples/review-evidence/minimal-local-gate.json'), 'utf8'));
+    manifest.providers[0].applicability = { kind: 'global', reason: 'Installed missing Python environment fixture.' };
+    manifest.providers[0].operations[0].argv = ['python3.14', 'subject.py'];
+    manifest.providers[0].operations[0].pythonRuntime = {
+      interpreter: 'python3.14', resolver: 'uv', projectFile: 'pyproject.toml', lockFile: 'uv.lock',
+    };
+    writeFileSync(join(repo, 'goldband.review-evidence.json'), JSON.stringify(manifest));
+    git(['add', 'goldband.review-evidence.json']);
+    git(['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-qm', 'missing Python prerequisites']);
+    const unavailable = run(repo, [...args, '--semantic-only'], env);
+    expect(unavailable.status, String(unavailable.stderr)).toBe(0);
+    expect(existsSync(join(state, 'tmp'))).toBe(false);
+    expect(existsSync(join(repo, '.venv'))).toBe(false);
+    expect(readFileSync(calls, 'utf8').trim().split('\n')).toHaveLength(3);
+    const evidence = run(repo, [...args, '--evidence-manifest', 'goldband.review-evidence.json'], env);
+    expect(evidence.status, String(evidence.stderr)).toBe(0);
+    const evidenceResult = JSON.parse(String(evidence.stdout));
+    expect(evidenceResult.output).toContain('runtime incomplete');
+    expect(evidenceResult.output).toContain('Semantic host calls: 0');
+    expect(evidenceResult.output).toContain('completion-authorized: false');
+    expect(readFileSync(calls, 'utf8').trim().split('\n')).toHaveLength(3);
+    for (const forbidden of ['--evidence-manifest', '--closure-artifact', '--work-id', '--ticket-id']) {
+      const denied = run(repo, [...args, '--semantic-only', forbidden, 'x'], env);
+      expect(denied.status).not.toBe(0);
+      expect(String(denied.stderr)).toContain('incompatible');
+    }
+    verifySemanticPolicyIdentity(run, repo, args, env, join(fixture, 'codex', 'goldband', 'workflow-runtime'));
+  }
+}
+
+function verifySemanticPolicyIdentity(
+  run: (cwd: string, args: string[], env?: NodeJS.ProcessEnv) => ReturnType<typeof spawnSync>,
+  repo: string, args: string[], env: NodeJS.ProcessEnv, runtimeRoot: string,
+) {
+  const manifestFile = join(runtimeRoot, 'review', 'rules', 'manifest.json');
+  const rubricFile = join(runtimeRoot, 'review', 'shared-rubric.md');
+  const originalManifest = readFileSync(manifestFile, 'utf8');
+  const originalRubric = readFileSync(rubricFile, 'utf8');
+  try {
+    const manifest = JSON.parse(originalManifest);
+    for (const rule of manifest.rules) rule.reviewCriteria[0] += ' Preserve explicit semantic-only boundaries.';
+    writeFileSync(manifestFile, JSON.stringify(manifest));
+    const criteriaChanged = run(repo, [...args, '--semantic-only'], env);
+    expect(criteriaChanged.status, String(criteriaChanged.stderr)).toBe(0);
+    const criteriaResult = JSON.parse(String(criteriaChanged.stdout));
+    const criteriaArtifact = JSON.parse(readFileSync(criteriaResult.artifacts.find((file: string) => file.endsWith('-semantic-only.json')), 'utf8'));
+    writeFileSync(rubricFile, `${originalRubric}\nInspect omitted failure paths.\n`);
+    const rubricChanged = run(repo, [...args, '--semantic-only'], env);
+    expect(rubricChanged.status, String(rubricChanged.stderr)).toBe(0);
+    const rubricResult = JSON.parse(String(rubricChanged.stdout));
+    const rubricArtifact = JSON.parse(readFileSync(rubricResult.artifacts.find((file: string) => file.endsWith('-semantic-only.json')), 'utf8'));
+    expect(rubricArtifact.policyIdentityDigest).not.toBe(criteriaArtifact.policyIdentityDigest);
+    expect(rubricArtifact.identity).not.toBe(criteriaArtifact.identity);
+    writeFileSync(join(repo, 'subject.py'), 'policy_mutation_candidate()\n');
+    const duringHost = run(repo, [...args, '--semantic-only'], { ...env, GOLDBAND_TEST_MUTATE_POLICY: rubricFile });
+    expect(duringHost.status).not.toBe(0);
+    expect(String(duringHost.stderr)).toContain('candidate or Rules/policy changed');
+  } finally {
+    writeFileSync(manifestFile, originalManifest);
+    writeFileSync(rubricFile, originalRubric);
+  }
 }

--- a/goldband-loop/test/review-evidence.test.ts
+++ b/goldband-loop/test/review-evidence.test.ts
@@ -4245,6 +4245,13 @@ describe('Python host tool discovery', () => {
     expect(resolveHostPythonTool(command, repository, { home, path: dirname(tool) })).toBe(tool);
   });
 
+  test('preserves OS home aliases while validating their canonical targets', () => {
+    const { root, home, repository } = pythonToolFixture();
+    const native = nativeToolFixture(join(home, '.local/bin/uv'));
+    const homeAlias = join(root, 'home-alias'); symlinkSync(home, homeAlias);
+    expect(resolveHostPythonTool('uv', repository, { home: homeAlias, path: join(homeAlias, '.local/bin') })).toBe(native);
+  });
+
   test('validates both the selected alias and its canonical target', () => {
     const { home, repository, root } = pythonToolFixture();
     const native = nativeToolFixture(join(home, '.local/share/uv/python/cpython-3.14/bin/python3.14'));

--- a/goldband-loop/test/review-evidence.test.ts
+++ b/goldband-loop/test/review-evidence.test.ts
@@ -1712,8 +1712,12 @@ describe('review evidence contracts', () => {
     visit(cache);
     const archiveLink = links.find((path) => existsSync(join(path, 'fixture_dep', '__init__.py')));
     expect(archiveLink).toBeDefined();
-    expect(readlinkSync(archiveLink!)).toStartWith('/');
     const archive = realpathSync(archiveLink!);
+    // uv versions may create relative links; explicitly seed the absolute-link
+    // relocation case this regression must exercise.
+    rmSync(archiveLink!);
+    symlinkSync(archive, archiveLink!);
+    expect(readlinkSync(archiveLink!)).toStartWith('/');
     const value = manifest();
     value.providers[0]!.operations[0] = {
       ...operation('cached-python-gate', ['python3.14', '-c', 'import fixture_dep; print(fixture_dep.VALUE)'], 'candidate', 'zero'),

--- a/goldband-loop/test/review-evidence.test.ts
+++ b/goldband-loop/test/review-evidence.test.ts
@@ -8,6 +8,9 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
+  readlinkSync,
+  lstatSync,
   realpathSync,
   renameSync,
   rmSync,
@@ -26,6 +29,7 @@ import {
   evidenceRuntimeReadAccess,
   isEvidenceSandboxRuntimeFailure,
   loadReviewEvidenceManifest,
+  materializePythonUvCache,
   readClosureArtifact,
   reviewFindingCellIds,
   reviewEvidenceManifestSchema,
@@ -44,7 +48,7 @@ import {
   type ReviewEvidenceManifest,
 } from '../workflows/review-evidence';
 import { getWorkflow } from '../workflows/registry';
-import { createCompilerOutputDiagnosticCapture } from '../workflows/review-evidence-sandbox';
+import { evidenceSandboxCommand, createCompilerOutputDiagnosticCapture } from '../workflows/review-evidence-sandbox';
 import { readReviewCiResult, reviewCandidateTree, collectReviewCiEvidence, validateReviewCiProvenance } from '../workflows/review-ci-evidence';
 import { assertReviewContractBoundary } from '../workflows/review-lineage';
 import { reviewContractChanges, validateReviewContractAssessment } from '../workflows/review-contract-changes';
@@ -1594,6 +1598,155 @@ describe('review evidence contracts', () => {
     expect(repeated.records[0]!.executionIdentityDigest)
       .toBe(evidence.records[0]!.executionIdentityDigest);
   });
+
+  test('copied uv archive links are readable in the real sandbox without ambient cache access', () => {
+    if (!hostBoundaryPrerequisite(process.platform === 'darwin', 'platform=darwin')) return;
+    const root = mkdtempSync(join(tmpdir(), 'uv-cache-boundary-'));
+    roots.push(root);
+    const source = join(root, 'ambient');
+    const target = join(root, 'copied');
+    const archive = join(source, 'archive-v0', 'fixture');
+    mkdirSync(archive, { recursive: true });
+    mkdirSync(join(source, 'wheels-v5'), { recursive: true });
+    writeFileSync(join(archive, 'payload'), 'cached wheel bytes\n');
+    symlinkSync(archive, join(source, 'wheels-v5', 'absolute'));
+    symlinkSync('../archive-v0/fixture', join(source, 'wheels-v5', 'relative'));
+    symlinkSync(source, join(source, 'root-alias'));
+    symlinkSync(join(source, 'root-alias', 'archive-v0', 'fixture'), join(source, 'wheels-v5', 'alias-chain'));
+    symlinkSync('cycle-b', join(source, 'cycle-a'));
+    symlinkSync('cycle-a', join(source, 'cycle-b'));
+    symlinkSync(root, join(source, 'unused-external'));
+    symlinkSync(join(source, 'missing'), join(source, 'unused-broken'));
+    const deniedDirectory = join(root, 'denied');
+    mkdirSync(deniedDirectory);
+    writeFileSync(join(deniedDirectory, 'payload'), 'unreadable external bytes');
+    symlinkSync(join(deniedDirectory, 'payload'), join(source, 'unused-denied'));
+    chmodSync(deniedDirectory, 0o000);
+    try {
+      materializePythonUvCache(source, target);
+    } finally {
+      chmodSync(deniedDirectory, 0o700);
+    }
+    for (const name of ['absolute', 'relative', 'alias-chain']) {
+      const file = join(target, 'wheels-v5', name, 'payload');
+      const command = evidenceSandboxCommand({
+        cwd: target,
+        writableRoots: [],
+        argv: ['/bin/cat', file],
+        runtimeAccess: evidenceRuntimeReadAccess('/bin/cat'),
+      });
+      const result = spawnSync(command.command, command.args, { encoding: 'utf8' });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('cached wheel bytes\n');
+    }
+    const denied = evidenceSandboxCommand({
+      cwd: target,
+      writableRoots: [],
+      argv: ['/bin/cat', join(archive, 'payload')],
+      runtimeAccess: evidenceRuntimeReadAccess('/bin/cat'),
+    });
+    const result = spawnSync(denied.command, denied.args, { encoding: 'utf8' });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/Operation not permitted|Permission denied/);
+    expect(existsSync(join(target, 'unused-external'))).toBe(false);
+    expect(existsSync(join(target, 'unused-broken'))).toBe(false);
+    expect(existsSync(join(target, 'unused-denied'))).toBe(false);
+    expect(readlinkSync(join(source, 'unused-denied'))).toBe(join(deniedDirectory, 'payload'));
+    expect(readdirSync(target)).not.toContain('cycle-a');
+    expect(readdirSync(target)).not.toContain('cycle-b');
+    expect(readlinkSync(join(source, 'unused-external'))).toBe(root);
+    expect(readlinkSync(join(source, 'unused-broken'))).toBe(join(source, 'missing'));
+  });
+
+  test('offline Python evidence consumes relocated uv registry archives and binds used bytes', async () => {
+    if (!hostBoundaryPrerequisite(process.platform === 'darwin', 'platform=darwin')) return;
+    const python = spawnSync('/usr/bin/which', ['python3.14'], { encoding: 'utf8' }).stdout.trim();
+    const uv = spawnSync('/usr/bin/which', ['uv'], { encoding: 'utf8' }).stdout.trim();
+    if (!hostBoundaryPrerequisite(Boolean(python) && Boolean(uv), 'Python 3.14 and uv executables')) return;
+    const repo = gitFixture();
+    const fixture = mkdtempSync(join(tmpdir(), 'uv-registry-fixture-'));
+    roots.push(fixture);
+    const wheelName = 'fixture_dep-1.0.0-py3-none-any.whl';
+    const wheel = join(fixture, wheelName);
+    const cache = join(fixture, 'cache');
+    writeFixtureWheel(python, wheel);
+    const wheelBytes = readFileSync(wheel);
+    const hash = createHash('sha256').update(wheelBytes).digest('hex');
+    const server = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      fetch(request) {
+        return new URL(request.url).pathname.endsWith('.whl')
+          ? new Response(wheelBytes, { headers: { 'Content-Type': 'application/octet-stream' } })
+          : new Response(`<a href="/${wheelName}#sha256=${hash}">${wheelName}</a>`, {
+            headers: { 'Content-Type': 'text/html' },
+          });
+      },
+    });
+    try {
+      writeFileSync(join(repo, 'pyproject.toml'), [
+        '[project]', 'name="cached-evidence-fixture"', 'version="0.1.0"',
+        'requires-python=">=3.14,<3.15"', 'dependencies=["fixture-dep==1.0.0"]',
+        '[[tool.uv.index]]', `url="http://127.0.0.1:${server.port}/simple"`, '',
+      ].join('\n'));
+      const seed = Bun.spawn([uv, 'sync', '--no-python-downloads', '--no-managed-python', '--no-config', '--index', `http://127.0.0.1:${server.port}/simple`, '--project', repo, '--python', python, '--cache-dir', cache], {
+        stdout: 'pipe', stderr: 'pipe',
+      });
+      const [exit, stderr] = await Promise.all([seed.exited, new Response(seed.stderr).text()]);
+      if (exit !== 0) throw new Error(stderr);
+    } finally {
+      await server.stop(true);
+    }
+    rmSync(join(repo, '.venv'), { recursive: true, force: true });
+    git(repo, ['add', 'pyproject.toml', 'uv.lock']);
+    git(repo, ['commit', '-m', 'add cached Python fixture']);
+    const links: string[] = [];
+    const visit = (directory: string) => {
+      for (const entry of readdirSync(directory)) {
+        const path = join(directory, entry);
+        if (lstatSync(path).isSymbolicLink()) links.push(path);
+        else if (lstatSync(path).isDirectory()) visit(path);
+      }
+    };
+    visit(cache);
+    const archiveLink = links.find((path) => existsSync(join(path, 'fixture_dep', '__init__.py')));
+    expect(archiveLink).toBeDefined();
+    expect(readlinkSync(archiveLink!)).toStartWith('/');
+    const archive = realpathSync(archiveLink!);
+    const value = manifest();
+    value.providers[0]!.operations[0] = {
+      ...operation('cached-python-gate', ['python3.14', '-c', 'import fixture_dep; print(fixture_dep.VALUE)'], 'candidate', 'zero'),
+      pythonRuntime: { interpreter: 'python3.14', resolver: 'uv', projectFile: 'pyproject.toml', lockFile: 'uv.lock' },
+    };
+    const validated = reviewEvidenceManifestSchema.validate(value);
+    const input = { source: 'git diff', diff: '', changedFiles: [] };
+    const run = () => executeEvidencePlan(context(repo), input, validated, createCandidateBinding(repo, input, validated));
+    const previousCache = process.env.UV_CACHE_DIR;
+    process.env.UV_CACHE_DIR = cache;
+    try {
+      const first = await run();
+      expect(first.records[0]).toMatchObject({ status: 'verified-pass', fresh: true, exitStatus: 0 });
+      expect(first.records[0]!.outputSummary).toContain('42');
+      writeFileSync(join(archive, 'fixture_dep', '__init__.py'), 'VALUE = 43\n');
+      const changed = await run();
+      expect(changed.records[0]).toMatchObject({ status: 'verified-pass', fresh: true });
+      expect(changed.records[0]!.outputSummary).toContain('43');
+      expect(changed.records[0]!.executionIdentityDigest).not.toBe(first.records[0]!.executionIdentityDigest);
+      const external = join(fixture, 'outside-archive');
+      renameSync(archive, external);
+      for (const target of [external, join(cache, 'missing-archive')]) {
+        rmSync(archiveLink!);
+        symlinkSync(target, archiveLink!);
+        const unavailable = await run();
+        expect(unavailable.records[0]).toMatchObject({ status: 'runtime-incomplete', fresh: false });
+        expect(unavailable.records[0]!.exitStatus).toBeUndefined();
+        expect(unavailable.records[0]!.outputSummary).toContain('before project gate');
+      }
+    } finally {
+      if (previousCache === undefined) delete process.env.UV_CACHE_DIR;
+      else process.env.UV_CACHE_DIR = previousCache;
+    }
+  }, 120_000);
 
   test('binds the one lock wheel selected by installed compatibility tags', () => {
     const selectedHash = `sha256:${'a'.repeat(64)}`;

--- a/goldband-loop/test/review-evidence.test.ts
+++ b/goldband-loop/test/review-evidence.test.ts
@@ -1,3 +1,4 @@
+import { isHostPythonToolPath, localReviewPythonPath, resolveHostPythonTool } from '../workflows/review-python-tools';
 import { afterEach, describe, expect, setDefaultTimeout, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
@@ -4218,5 +4219,113 @@ describe('candidate-bound GitHub review evidence', () => {
     expect(evidence.records[0]!.ciProvenance).toBeUndefined();
     expect(evidence.records[0]!.outputSummary).toContain('CI evidence incomplete');
     await expect(collectReviewCiEvidence(repo, repo, provider, 'goldband-loop')).rejects.toThrow('invocation directory');
+  });
+});
+
+function pythonToolFixture() {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'python-host-tools-'))); roots.push(root);
+  const home = join(root, 'home'); const repository = join(root, 'repository');
+  mkdirSync(home); mkdirSync(repository);
+  return { root, home, repository };
+}
+function nativeToolFixture(path: string) {
+  mkdirSync(dirname(path), { recursive: true });
+  // Discovery fixture only; never executed. Real runtime integration is separate.
+  writeFileSync(path, Buffer.from('cffaedfe00000000', 'hex')); chmodSync(path, 0o755);
+  return path;
+}
+
+describe('Python host tool discovery', () => {
+  test.each([
+    ['uv', '.local/bin/uv'], ['python3.14', '.local/bin/python3.14'],
+    ['python3.14', '.local/share/uv/python/cpython-3.14/bin/python3.14'],
+    ['python3.14', '.pyenv/versions/3.14.0/bin/python3.14'],
+  ] as const)('accepts the supported native %s at %s', (command, location) => {
+    const { home, repository } = pythonToolFixture(); const tool = nativeToolFixture(join(home, location));
+    expect(resolveHostPythonTool(command, repository, { home, path: dirname(tool) })).toBe(tool);
+  });
+
+  test('validates both the selected alias and its canonical target', () => {
+    const { home, repository, root } = pythonToolFixture();
+    const native = nativeToolFixture(join(home, '.local/share/uv/python/cpython-3.14/bin/python3.14'));
+    const alias = join(home, '.local/bin/python3.14'); mkdirSync(dirname(alias), { recursive: true }); symlinkSync(native, alias);
+    expect(resolveHostPythonTool('python3.14', repository, { home, path: dirname(alias) })).toBe(native);
+    rmSync(alias); symlinkSync(nativeToolFixture(join(root, 'untrusted/python3.14')), alias);
+    expect(() => resolveHostPythonTool('python3.14', repository, { home, path: dirname(alias) })).toThrow('trusted host package root');
+    rmSync(alias); symlinkSync(nativeToolFixture(join(repository, 'bin/python3.14')), alias);
+    expect(() => resolveHostPythonTool('python3.14', repository, { home, path: dirname(alias) })).toThrow('source checkout');
+  });
+
+  test('rejects a repository alias even when it points at a supported host tool', () => {
+    const { home, repository } = pythonToolFixture(); symlinkSync(nativeToolFixture(join(home, '.local/bin/uv')), join(repository, 'uv'));
+    expect(() => resolveHostPythonTool('uv', repository, { home, path: repository })).toThrow('source checkout');
+  });
+
+  test('rejects an intermediate directory symlink escaping the trusted root', () => {
+    const { home, repository, root } = pythonToolFixture(); const external = nativeToolFixture(join(root, 'untrusted/uv'));
+    mkdirSync(join(home, '.local')); symlinkSync(dirname(external), join(home, '.local/bin'));
+    expect(() => resolveHostPythonTool('uv', repository, { home, path: join(home, '.local/bin') })).toThrow('trusted host package root');
+  });
+
+  test('rejects a shim without executing it or falling through to a later native binary', () => {
+    const { home, repository } = pythonToolFixture(); const shim = nativeToolFixture(join(home, '.local/bin/python3.14'));
+    writeFileSync(shim, '#!/bin/sh\nexit 99\n'); const native = nativeToolFixture(join(home, '.pyenv/versions/3.14.0/bin/python3.14'));
+    expect(() => resolveHostPythonTool('python3.14', repository, { home, path: `${dirname(shim)}:${dirname(native)}` })).toThrow('scripts and version-manager shims are unsupported');
+  });
+
+  test('rejects pyenv shims and arbitrary PATH roots with selected/target diagnostics', () => {
+    const { home, repository, root } = pythonToolFixture();
+    for (const location of [join(home, '.pyenv/shims/python3.14'), join(root, 'arbitrary/python3.14')]) {
+      nativeToolFixture(location);
+      expect(() => resolveHostPythonTool('python3.14', repository, { home, path: dirname(location) })).toThrow(`selected=${location}; resolved=${location}`);
+      expect(() => resolveHostPythonTool('python3.14', repository, { home, path: dirname(location) })).toThrow('trusted host package root');
+    }
+  });
+
+  test('distinguishes a missing executable from a refused installation', () => {
+    const { home, repository } = pythonToolFixture();
+    expect(() => resolveHostPythonTool('uv', repository, { home, path: home })).toThrow('executable is unavailable: uv');
+  });
+
+  test('local self-tests preserve selected directories, including user installations', () => {
+    const { home, repository } = pythonToolFixture();
+    const python = nativeToolFixture(join(home, '.pyenv/versions/3.14.0/bin/python3.14')); const uv = nativeToolFixture(join(home, '.local/bin/uv'));
+    expect(localReviewPythonPath(repository, { home, path: `${dirname(python)}:${dirname(uv)}` })).toEqual([dirname(python), dirname(uv)]);
+    expect(localReviewPythonPath(repository, { home, path: home })).toEqual([]);
+  });
+
+  test('a fresh runtime cannot gain trust through a caller-controlled HOME', () => {
+    if (process.platform !== 'darwin') return;
+    const { home, repository } = pythonToolFixture();
+    const fake = nativeToolFixture(join(home, '.local/bin/uv'));
+    const modulePath = join(import.meta.dir, '../workflows/review-python-tools.ts');
+    const script = `import { resolveHostPythonTool } from ${JSON.stringify(modulePath)}; resolveHostPythonTool('uv', ${JSON.stringify(repository)});`;
+    const result = spawnSync(process.execPath, ['-e', script], {
+      encoding: 'utf8', env: { HOME: home, PATH: dirname(fake) },
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('trusted host package root');
+    expect(result.stderr).toContain(`selected=${fake}`);
+  });
+
+  test('host identity remains independent of the isolated child HOME', () => {
+    const { repository } = pythonToolFixture(); const previous = process.env.HOME; process.env.HOME = repository;
+    try {
+      const uv = Bun.which('uv'); if (!uv || process.platform !== 'darwin') return;
+      expect(resolveHostPythonTool('uv', repository)).toBe(realpathSync(uv));
+    } finally { if (previous === undefined) delete process.env.HOME; else process.env.HOME = previous; }
+  });
+
+  test.each([
+    '/opt/homebrew/bin/python3.14', '/opt/homebrew/opt/python@3.14/bin/python3.14',
+    '/opt/homebrew/Cellar/python@3.14/3.14.0/bin/python3.14',
+    '/usr/local/opt/python@3.14/bin/python3.14', '/opt/local/bin/python3.14',
+    '/opt/local/Library/Frameworks/Python.framework/Versions/3.14/bin/python3.14',
+    '/Library/Frameworks/Python.framework/Versions/3.14/bin/python3.14',
+  ])('recognizes supported system installation path %s without requiring that package manager', (path) => {
+    const { home } = pythonToolFixture();
+    expect(isHostPythonToolPath(path, 'python3.14', home)).toBe(true);
+    expect(isHostPythonToolPath('/opt/homebrew/opt-poison/python3.14', 'python3.14', home)).toBe(false);
+    expect(isHostPythonToolPath('/opt/local/bin-poison/python3.14', 'python3.14', home)).toBe(false);
   });
 });

--- a/goldband-loop/test/review-local-evidence.test.ts
+++ b/goldband-loop/test/review-local-evidence.test.ts
@@ -2,9 +2,9 @@ import { spawnSync } from 'node:child_process';
 import { getWorkflow } from '../workflows/registry';
 import Ajv2020 from 'ajv/dist/2020';
 import { afterEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { createCandidateBinding, executeEvidencePlan, reviewEvidenceManifestSchema, type CandidateBinding } from '../workflows/review-evidence';
 import { assertReviewContractBoundary } from '../workflows/review-lineage';
 import { reviewCandidateTree } from '../workflows/review-ci-evidence';
@@ -115,5 +115,41 @@ describe('pre-push local self-test evidence', () => {
     expect(record.candidateDigest).toBe(binding.candidateDigest);
     expect(record.environment).toBe('local-host/macos-self-tests');
     expect(record.ciProvenance).toBeUndefined();
+  });
+});
+
+
+describe('local Python self-test tool selection', () => {
+  test.each(['supported', 'rejected'] as const)('records %s host tools before starting the self-test', async (scenario) => {
+    if (process.platform !== 'darwin') return;
+    const root = mkdtempSync(join(tmpdir(), 'review-local-python-')); roots.push(root);
+    const candidate = join(root, 'candidate');
+    mkdirSync(join(candidate, 'goldband-loop/test'), { recursive: true });
+    const provider = manifests().after.providers.find((p) => p.id === 'review-evidence-tests')!;
+    const previousPath = process.env.PATH;
+    const python = Bun.which('python3.14');
+    if (!python) {
+      if (process.env.GOLDBAND_REQUIRE_REVIEW_HOST_BOUNDARY === '1') throw new Error('required review host boundary prerequisite is unavailable: Python 3.14 executable');
+      return;
+    }
+    const selected = dirname(python);
+    const poison = join(root, 'poison'); mkdirSync(poison);
+    writeFileSync(join(poison, 'python3.14'), '#!/bin/sh\nexit 99\n'); chmodSync(join(poison, 'python3.14'), 0o755);
+    const source = `import { test, expect } from 'bun:test'; test('selected tool', () => { expect(Bun.which('python3.14')).toBe(${JSON.stringify(join(selected, 'python3.14'))}); expect(process.env.HOME).not.toBe(${JSON.stringify(process.env.HOME)}); });`;
+    for (const file of ['review-evidence.test.ts', 'review-evidence-platform.test.ts']) writeFileSync(join(candidate, 'goldband-loop/test', file), source);
+    process.env.PATH = `${scenario === 'supported' ? selected : poison}:${previousPath ?? ''}`;
+    try {
+      const binding = { repository: candidate, candidateDigest: 'a'.repeat(64), baseDigest: 'b'.repeat(64), scopeDigest: 'c'.repeat(64) } as CandidateBinding;
+      const record = await runLocalReviewEvidence({ provider, operation: provider.operations[0]!, snapshotRoot: candidate,
+        runnerRoot: join(root, 'runner'), binding, dependencyDigest: 'd'.repeat(64), executionOffset: '',
+      }, () => reviewCandidateTree(candidate));
+      expect(record.status, record.outputSummary).toBe(scenario === 'supported' ? 'verified-pass' : 'runtime-incomplete');
+      expect(record.fresh).toBe(scenario === 'supported');
+      if (scenario === 'rejected') {
+        expect(record.exitStatus).toBeUndefined();
+        expect(record.outputSummary).toContain(`selected=${poison}/python3.14`);
+        expect(record.outputSummary).toContain('trusted host package root');
+      }
+    } finally { if (previousPath === undefined) delete process.env.PATH; else process.env.PATH = previousPath; }
   });
 });

--- a/goldband-loop/test/review-semantic.test.ts
+++ b/goldband-loop/test/review-semantic.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, expect, spyOn, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Ajv from 'ajv/dist/2020';
+import schema from '../../schemas/review-semantic-result.schema.json';
+import { buildReviewRuntimeArgs } from '../bin/goldband.ts';
+import { adapterFor } from '../workflows/host-adapter';
+import { getWorkflow } from '../workflows/registry';
+import { runWorkflow } from '../workflows/runtime';
+import { validateInitialReviewArtifact, readClosureArtifact } from '../workflows/review-evidence';
+
+const roots: string[] = [];
+const spies: Array<{ mockRestore(): void }> = [];
+afterEach(() => {
+  for (const spy of spies.splice(0)) spy.mockRestore();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'review-semantic-'));
+  roots.push(root);
+  const cwd = join(root, 'repo'); mkdirSync(cwd);
+  function git(...args: string[]) {
+    const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+    if (result.status !== 0) throw new Error(result.stderr);
+  }
+  git('init', '-q'); git('config', 'user.email', 'test@example.com'); git('config', 'user.name', 'Test');
+  writeFileSync(join(cwd, 'subject.ts'), 'safe();\n'); git('add', '.'); git('commit', '-qm', 'fixture');
+  writeFileSync(join(cwd, 'subject.ts'), 'unsafe();\n');
+  return { cwd, goldbandHome: join(root, 'state'), mode: 'mock' as const, host: 'mock' as const, worktree: true, git };
+}
+function host(findings: unknown[] = []) {
+  const spy = spyOn(Object.getPrototypeOf(adapterFor('mock')), 'runJson').mockResolvedValue({ parsed: { findings }, raw: JSON.stringify({ findings }) });
+  spies.push(spy); return spy;
+}
+function artifact(result: Awaited<ReturnType<typeof runWorkflow>>) {
+  const file = result.artifacts.find((file) => file.endsWith('-semantic-only.json'))!;
+  return { file, value: JSON.parse(readFileSync(file, 'utf8')) };
+}
+const workflow = () => getWorkflow('review/code');
+
+test('explicit semantic mode never reads invalid manifest and cannot mint authority', async () => {
+  const options = fixture();
+  writeFileSync(join(options.cwd, 'goldband.review-evidence.json'), '{ invalid JSON');
+  const mock = host([{ file: 'subject.ts', line: 1, severity: 'high', summary: 'unsafe path',
+    failureScenario: 'unsafe call reached', suggestedVerification: 'inspect call',
+    evidence: 'subject.ts calls unsafe()', classification: 'verified-failure', blocking: true,
+    id: 'forged', evidenceIds: ['forged-pass'], behaviorCellIds: ['forged-cell'] }]);
+  const result = await runWorkflow(workflow(), { ...options, semanticOnly: true });
+  expect(mock).toHaveBeenCalledTimes(1);
+  const { value, file } = artifact(result);
+  expect(new Ajv({ strict: false }).compile(schema)(value)).toBe(true);
+  expect(value.findings[0]).toMatchObject({ classification: 'semantic-concern', blocking: false });
+  expect(value.findings[0].id).toBeUndefined(); expect(value.findings[0].evidenceIds).toBeUndefined();
+  expect(value.binding.behaviorContractDigest).toBeUndefined(); expect(value.runtimeReceipt).toBeUndefined();
+  expect(existsSync(join(options.goldbandHome, 'workflow-runs', 'mock-review-receipts'))).toBe(false);
+  expect(() => validateInitialReviewArtifact(value)).toThrow();
+  expect(() => validateInitialReviewArtifact({ ...value, phase: 'initial' })).toThrow();
+  expect(new Ajv({ strict: false }).compile(schema)({ ...value, runtimeReceipt: { id: 'forged' } })).toBe(false);
+  expect(() => readClosureArtifact({ cwd: options.cwd, options: { ...options, closureArtifactFile: file } } as any)).toThrow();
+  expect(String(result.output)).toContain('Completion authority: none');
+  const prompt = mock.mock.calls[0]![0] as string;
+  expect(prompt).toContain('DIFF_START'); expect(prompt).toContain('+unsafe();');
+  expect(prompt).toContain('APPLICABLE_GOLDBAND_RULES_START');
+  expect(prompt).not.toContain('BEHAVIOR_MATRIX_START');
+});
+
+test('missing manifest default fails before semantic dispatch; explicit mode succeeds', async () => {
+  const options = fixture(); const mock = host();
+  await expect(runWorkflow(workflow(), { ...options, mode: 'real', host: 'codex' })).rejects.toThrow();
+  expect(mock).not.toHaveBeenCalled();
+  const result = await runWorkflow(workflow(), { ...options, semanticOnly: true });
+  expect(mock).toHaveBeenCalledTimes(1);
+  expect(String(result.output)).toContain('No semantic concerns found');
+  expect(String(result.output)).toContain('Deterministic behavior completeness was not evaluated');
+});
+
+test('duplicate and concurrent requests consume one host call and do not reserve evidence identity', async () => {
+  const options = fixture(); declareContract(options); const mock = host();
+  const attempts = await Promise.allSettled([1, 2].map(() => runWorkflow(workflow(), { ...options, semanticOnly: true })));
+  expect(attempts.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+  expect(attempts.filter((result) => result.status === 'rejected')).toHaveLength(1);
+  await expect(runWorkflow(workflow(), { ...options, semanticOnly: true })).rejects.toThrow('duplicate semantic-only');
+  expect(mock).toHaveBeenCalledTimes(1);
+  // Default mock fixture has a runtime-owned contract, so the same candidate can enter evidence review.
+  await runWorkflow(workflow(), { ...options, evidenceManifestFile: 'goldband.review-evidence.json' });
+  expect(mock).toHaveBeenCalledTimes(2);
+});
+
+test('host failure or changed candidate is never reported as successful or retried', async () => {
+  const options = fixture(); const mock = host();
+  mock.mockRejectedValueOnce(new Error('host unavailable'));
+  await expect(runWorkflow(workflow(), { ...options, semanticOnly: true })).rejects.toThrow('host unavailable');
+  await expect(runWorkflow(workflow(), { ...options, semanticOnly: true })).rejects.toThrow('duplicate semantic-only');
+  expect(mock).toHaveBeenCalledTimes(1);
+  writeFileSync(join(options.cwd, 'subject.ts'), 'different();\n');
+  mock.mockImplementationOnce(async () => {
+    writeFileSync(join(options.cwd, 'subject.ts'), 'changed-during-review();\n');
+    return { parsed: { findings: [] }, raw: '{}' };
+  });
+  await expect(runWorkflow(workflow(), { ...options, semanticOnly: true })).rejects.toThrow('candidate or Rules/policy changed');
+});
+
+test('authoritative prior blockers are visible and byte-for-byte unchanged', async () => {
+  const options = fixture();
+  declareContract(options);
+  const mock = host([{ file: 'subject.ts', line: 1, severity: 'high', summary: 'unsafe call', evidence: 'unsafe is called', failureScenario: 'unsafe call reached', suggestedVerification: 'inspect call', classification: 'semantic-concern' }]);
+  const initial = await runWorkflow(workflow(), { ...options, evidenceManifestFile: 'goldband.review-evidence.json' });
+  const lineageFile = initial.artifacts.find((file) => file.includes('review-lineages') && file.endsWith('.json'))!;
+  const before = readFileSync(lineageFile, 'utf8');
+  const lineage = JSON.parse(before);
+  expect(lineage.unresolvedFindings.some((item: any) => item.blocking)).toBe(true);
+  const receiptRoot = join(options.goldbandHome, 'workflow-runs', 'mock-review-receipts');
+  const receiptFiles = readdirSync(receiptRoot).sort();
+  mock.mockResolvedValue({ parsed: { findings: [] }, raw: '{}' });
+  const result = await runWorkflow(workflow(), { ...options, semanticOnly: true });
+  expect(String(result.output)).toContain('prior-blockers-open');
+  expect(String(result.output)).toContain(lineage.unresolvedFindings[0].findingId);
+  expect(readFileSync(lineageFile, 'utf8')).toBe(before);
+  expect(readdirSync(receiptRoot).sort()).toEqual(receiptFiles);
+  expect(artifact(result).value.completionAuthorized).toBe(false);
+});
+
+for (const flag of ['--evidence-manifest', '--closure-artifact', '--work-id', '--ticket-id']) {
+  test(`semantic-only rejects ${flag} before dispatch`, async () => {
+    expect(() => buildReviewRuntimeArgs(['--host', 'codex', '--semantic-only', flag, 'x'])).toThrow('incompatible');
+    const options = fixture(); const mock = host();
+    const key = { '--evidence-manifest': 'evidenceManifestFile', '--closure-artifact': 'closureArtifactFile', '--work-id': 'workId', '--ticket-id': 'ticketId' }[flag]!;
+    await expect(runWorkflow(workflow(), { ...options, semanticOnly: true, [key]: 'x' })).rejects.toThrow('incompatible');
+    expect(mock).not.toHaveBeenCalled();
+  });
+}
+
+function declareContract(options: ReturnType<typeof fixture>) {
+  const manifest = { schemaVersion: 2, behaviorMatrix: [{ id: 'boundary', behavior: 'safe call', kind: 'boundary', input: 'call', preconditions: 'active', expected: 'safe', risk: 'high', disposition: 'not-applicable', providerIds: [], reason: 'static fixture' }], providers: [], authorizations: [] };
+  writeFileSync(join(options.cwd, 'goldband.review-evidence.json'), JSON.stringify(manifest));
+  options.git('add', 'goldband.review-evidence.json'); options.git('commit', '-qm', 'contract');
+}
+
+test('equivalent diff-file locations share canonical semantic identity', async () => {
+  const options = fixture(); const mock = host();
+  const diff = spawnSync('git', ['diff'], { cwd: options.cwd, encoding: 'utf8' }).stdout;
+  writeFileSync(join(options.cwd, 'one.diff'), diff);
+  writeFileSync(join(options.cwd, 'two.diff'), diff);
+  await runWorkflow(workflow(), { ...options, worktree: false, semanticOnly: true, diffFile: 'one.diff' });
+  await expect(runWorkflow(workflow(), { ...options, worktree: false, semanticOnly: true, diffFile: 'two.diff' })).rejects.toThrow('duplicate semantic-only');
+  expect(mock).toHaveBeenCalledTimes(1);
+});
+
+test('semantic findings retain the shared evidence downgrade and concrete-path threshold', async () => {
+  const options = fixture();
+  host([
+    { file: 'subject.ts', severity: 'critical', summary: 'unsupported' },
+    { file: 'subject.ts', severity: 'high', summary: 'no location', evidence: 'code', failureScenario: 'call', suggestedVerification: 'inspect' },
+    { file: 'subject.ts', line: 1, severity: 'high', summary: 'no trigger', evidence: 'code', suggestedVerification: 'inspect' },
+    { file: 'subject.ts', line: 1, severity: 'critical', summary: 'unverified risk', failureScenario: 'unsafe call', suggestedVerification: 'inspect' },
+  ]);
+  const result = await runWorkflow(workflow(), { ...options, semanticOnly: true });
+  const findings = artifact(result).value.findings;
+  expect(findings).toHaveLength(1);
+  expect(findings[0]).toMatchObject({ severity: 'info', classification: 'semantic-concern', blocking: false });
+  expect(findings[0].summary).toContain('[unverified critical]');
+});

--- a/goldband-loop/test/work-map-review.test.ts
+++ b/goldband-loop/test/work-map-review.test.ts
@@ -26,6 +26,23 @@ afterEach(() => {
 });
 
 describe("Work Map review readback", () => {
+	test("semantic-only artifact cannot complete an implemented Work Map ticket", () => {
+		const { store } = fixture();
+		const created = store.create(input(), "codex");
+		const claimed = store.claimTicket({ workId: created.id, ticketId: "ticket-a",
+			expectedRevision: created.revision, owner: "codex", leaseId: "lease-a" });
+		const implemented = store.markImplemented({ workId: created.id, ticketId: "ticket-a",
+			expectedRevision: claimed.revision, actor: "recorder",
+			receipt: { id: "receipt-a", digest: "a".repeat(64), treeDigest: "b".repeat(64) } });
+		const before = fs.readFileSync(store.mapPath(created.id), "utf8");
+		const semantic = { schemaVersion: 1, phase: "semantic-only", evidenceStatus: "not-declared",
+			completionAuthorized: false, findings: [], hostCallCount: 1, providerCallCount: 0 };
+		expect(() => store.verifyTicket({ workId: created.id, ticketId: "ticket-a",
+			expectedRevision: implemented.revision, actor: "review-readback", review: semantic as any }))
+			.toThrow("review and verification receipt tree digests differ");
+		expect(fs.readFileSync(store.mapPath(created.id), "utf8")).toBe(before);
+	});
+
 	test("requested changes return an implemented ticket to claimed", () => {
 		const { store } = fixture();
 		const created = store.create(input(), "codex");

--- a/goldband-loop/workflows/capability-registry.generated.ts
+++ b/goldband-loop/workflows/capability-registry.generated.ts
@@ -22,7 +22,7 @@ export const CAPABILITY_ACTIONS: CapabilityActionRecord[] = [
     "capability": "review",
     "action": "code",
     "name": "review/code",
-    "description": "Evidence-first code review.",
+    "description": "Evidence-backed or explicit semantic-only code review.",
     "contractPath": "generated/workflow-contracts/review/code.workflow.md",
     "runtime": "typed",
     "dispatch": "trusted-launcher",

--- a/goldband-loop/workflows/review-evidence.ts
+++ b/goldband-loop/workflows/review-evidence.ts
@@ -25,6 +25,7 @@ import {
   realpathSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
   type Dirent,
 } from 'node:fs';
@@ -72,7 +73,7 @@ const MAX_REVIEW_EVIDENCE_TOTAL_BYTES = 1024 * 1024;
 const MAX_REVIEW_EVIDENCE_OPERATIONS = 64;
 const MAX_EVIDENCE_RUNTIME_DIAGNOSTIC_CHARS = 16 * 1024;
 const DEFAULT_REVIEW_EVIDENCE_MANIFEST = 'goldband.review-evidence.json';
-const EVIDENCE_RUNNER_POLICY = 'per-operation-sealed-runtime-readonly-snapshot-default-deny-read-write-network-v56';
+const EVIDENCE_RUNNER_POLICY = 'per-operation-sealed-runtime-readonly-snapshot-default-deny-read-write-network-v57';
 // coverage.py 7.15.4's conditional process_startup(slug="pth") hook. Review
 // changed hook bytes before extending support; package ownership alone cannot
 // authorize arbitrary startup code. Keep the hook for subprocess measurement.
@@ -2269,7 +2270,7 @@ function materializePythonEnvironment(
   const tempRoot = join(pythonRoot, 'tmp');
   for (const root of [pythonRoot, homeRoot, tempRoot]) mkdirSync(root, { recursive: true, mode: 0o700 });
   const cacheRoot = join(pythonRoot, 'uv-cache');
-  materializeCandidate(inputs.ambientCacheRoot, cacheRoot);
+  materializePythonUvCache(inputs.ambientCacheRoot, cacheRoot);
   const cacheAccess = ambientUvCacheReadAccess(cacheRoot);
   const preparationAccess = mergeEvidenceRuntimeReadAccess([
     inputs.preparedUv.access,
@@ -2615,6 +2616,42 @@ function sandboxedUvCacheRoot(
     throw new Error(`uv cache discovery failed: ${boundText(result.stderr || result.stdout, 4096)}`);
   }
   return result.stdout.trim();
+}
+
+export function materializePythonUvCache(source: string, target: string): void {
+  materializeCandidate(source, target);
+  const sourceRoot = realpathSync(source);
+  const targetRoot = realpathSync(target);
+  const pending = [targetRoot];
+  while (pending.length > 0) {
+    const directory = pending.pop()!;
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const copiedPath = join(directory, entry.name);
+      if (entry.isDirectory()) pending.push(copiedPath);
+      if (!entry.isSymbolicLink()) continue;
+      relocatePythonCacheLink(sourceRoot, targetRoot, copiedPath);
+    }
+  }
+}
+
+function relocatePythonCacheLink(sourceRoot: string, targetRoot: string, copiedPath: string): void {
+  const sourcePath = join(sourceRoot, relative(targetRoot, copiedPath));
+  let resolved: string;
+  try {
+    resolved = realpathSync(resolve(dirname(sourcePath), readlinkSync(copiedPath)));
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (!['ENOENT', 'ENOTDIR', 'ELOOP', 'EACCES', 'EPERM'].includes(code ?? '')) throw error;
+    // Unused unavailable cache entries must not block a locked offline operation.
+    // If selected, uv must report the missing input rather than follow it.
+    rmSync(copiedPath);
+    return;
+  }
+  const destination = relative(sourceRoot, resolved);
+  rmSync(copiedPath);
+  if (destination === '..' || destination.startsWith(`..${sep}`) || isAbsolute(destination)) return;
+  // Resolve against the source boundary, but only grant access to copied bytes.
+  symlinkSync(relative(dirname(copiedPath), join(targetRoot, destination)) || '.', copiedPath);
 }
 
 function ambientUvCacheReadAccess(cacheRoot: string): EvidenceRuntimeReadAccess {

--- a/goldband-loop/workflows/review-evidence.ts
+++ b/goldband-loop/workflows/review-evidence.ts
@@ -423,6 +423,18 @@ export function createCandidateBinding(
   manifest: ReviewEvidenceManifest,
   requestedBase?: string,
 ): CandidateBinding {
+  return {
+    ...createReviewCandidateBinding(cwd, input, requestedBase),
+    behaviorContractDigest: sha256(stableJson(manifest)),
+  };
+}
+
+/** Candidate identity does not require or infer an evidence contract. */
+export function createReviewCandidateBinding(
+  cwd: string,
+  input: ReviewDiffInput,
+  requestedBase?: string,
+): Omit<CandidateBinding, 'behaviorContractDigest'> {
   const repository = canonicalRepository(cwd);
   const baseRef = requestedBase
     ? gitOutput(cwd, ['merge-base', requestedBase, 'HEAD'], true) || requestedBase
@@ -446,7 +458,6 @@ export function createCandidateBinding(
         ? undefined
         : input.source.replace(/ \+ untracked$/, ''),
     })),
-    behaviorContractDigest: sha256(stableJson(manifest)),
     changedFiles: [...input.changedFiles],
     redactedUntrackedFiles: hiddenUntracked,
   };

--- a/goldband-loop/workflows/review-evidence.ts
+++ b/goldband-loop/workflows/review-evidence.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { resolveHostPythonTool } from './review-python-tools';
 import {
   createHash,
   createHmac,
@@ -73,7 +74,7 @@ const MAX_REVIEW_EVIDENCE_TOTAL_BYTES = 1024 * 1024;
 const MAX_REVIEW_EVIDENCE_OPERATIONS = 64;
 const MAX_EVIDENCE_RUNTIME_DIAGNOSTIC_CHARS = 16 * 1024;
 const DEFAULT_REVIEW_EVIDENCE_MANIFEST = 'goldband.review-evidence.json';
-const EVIDENCE_RUNNER_POLICY = 'per-operation-sealed-runtime-readonly-snapshot-default-deny-read-write-network-v57';
+const EVIDENCE_RUNNER_POLICY = 'per-operation-sealed-runtime-readonly-snapshot-default-deny-read-write-network-v58';
 // coverage.py 7.15.4's conditional process_startup(slug="pth") hook. Review
 // changed hook bytes before extending support; package ownership alone cannot
 // authorize arbitrary startup code. Keep the hook for subprocess measurement.
@@ -2219,20 +2220,12 @@ function preparePythonRuntimeInputs(
   if (dirname(projectFile) !== dirname(lockFile)) {
     throw new Error('declared pyproject.toml and uv.lock must share one project directory');
   }
-  const selectedPython = resolveTrustedPythonTool(
-    contract.interpreter,
-    options.binding.repository,
-    'Python interpreter',
-  );
+  const selectedPython = resolveHostPythonTool(contract.interpreter, options.binding.repository);
   const sourceCommand = realpathSync(selectedPython);
   const source = inspectPythonRuntime(sourceCommand, options.snapshotRoot);
   const sourceAccess = pythonRuntimeReadAccess(sourceCommand, source);
   const sourceIdentity = sourceAccess.identityDigest;
-  const uvCommand = resolveTrustedPythonTool(
-    contract.resolver,
-    options.binding.repository,
-    'uv resolver',
-  );
+  const uvCommand = resolveHostPythonTool(contract.resolver, options.binding.repository);
   const uvAccess = evidenceRuntimeReadAccess(uvCommand);
   const preparedUv = cachedEvidenceRuntime(options, uvCommand, uvAccess);
   const ambientCacheRoot = pythonLockNeedsOfflineCache(lockFile)
@@ -2414,33 +2407,6 @@ function rejectRepositoryRuntime(command: string, repository: string, label: str
   ) {
     throw new Error(`${label} must not come from the source checkout or its virtual environment`);
   }
-}
-
-const TRUSTED_PYTHON_TOOL_ROOTS = [
-  '/opt/homebrew/bin',
-  '/opt/homebrew/Cellar',
-  '/usr/local/bin',
-  '/usr/local/Cellar',
-  '/usr/bin',
-  '/bin',
-  '/Library/Frameworks',
-];
-
-function resolveTrustedPythonTool(command: string, repository: string, label: string): string {
-  const selected = resolveExecutable(command);
-  rejectRepositoryRuntime(selected, repository, label);
-  const canonical = realpathSync(selected);
-  if (![selected, canonical].every(pathIsInTrustedPythonToolRoot)) {
-    throw new Error(`${label} must resolve from a trusted host package root`);
-  }
-  return selected;
-}
-
-function pathIsInTrustedPythonToolRoot(path: string): boolean {
-  const absolute = resolve(path);
-  return TRUSTED_PYTHON_TOOL_ROOTS.some(
-    (root) => absolute === root || absolute.startsWith(`${root}${sep}`),
-  );
 }
 
 type PythonRuntimeInspection = {

--- a/goldband-loop/workflows/review-lineage.ts
+++ b/goldband-loop/workflows/review-lineage.ts
@@ -422,6 +422,43 @@ export function readReviewLineageForTest(
   return readSignedLineage(file, key);
 }
 
+/** Read-only projection; never prepares, supersedes, or finalizes acceptance lineage. */
+export function projectPriorReviewBlockers(options: {
+  storeRoot: string;
+  key: Buffer;
+  repository: string;
+  baseDigest: string;
+  changedFiles: string[];
+}): Array<{ lineageId: string; findingId: string; artifactFile?: string }> {
+  const root = join(options.storeRoot, 'review-lineages');
+  const stat = lstatSync(root, { throwIfNoEntry: false });
+  if (!stat) return [];
+  if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error('unsafe review lineage store');
+  const blockers: Array<{ lineageId: string; findingId: string; artifactFile?: string }> = [];
+  for (const name of readdirSync(root).filter((name) => name.endsWith('.json')).sort()) {
+    const lineage = readSignedLineage(join(root, name), options.key);
+    if (!lineage || !semanticScopeOverlaps(lineage, options)) continue;
+    for (const finding of lineage.unresolvedFindings.filter((finding) => finding.blocking)) {
+      blockers.push({ lineageId: lineage.id, findingId: finding.findingId,
+        artifactFile: lineage.authoritativeArtifact?.file });
+    }
+  }
+  return blockers;
+}
+
+function semanticScopeOverlaps(lineage: ReviewLineagePayload, options: {
+  repository: string; baseDigest: string; changedFiles: string[];
+}): boolean {
+  if (lineage.repository !== options.repository || lineage.baseDigest !== options.baseDigest) return false;
+  const scope = lineage.scopeSummary ?? verifiedArtifactScope(lineage)?.changedFiles;
+  // Unknown legacy scope cannot prove that blockers are unrelated.
+  return !scope || scope.some((path) => options.changedFiles.includes(path));
+}
+
+export function reviewPolicyIdentity(cwd: string, baseRef: string): string {
+  return sha256(stableJson(readBaseReviewPolicy(cwd, baseRef)));
+}
+
 function assertMonotonicContract(
   predecessor: ReviewEvidenceManifest,
   current: ReviewEvidenceManifest,

--- a/goldband-loop/workflows/review-local-evidence.ts
+++ b/goldband-loop/workflows/review-local-evidence.ts
@@ -1,3 +1,4 @@
+import { localReviewPythonPath } from './review-python-tools';
 import { REVIEW_HOST_EVIDENCE_POLICY } from '../lib/review-runtime-contract';
 import { createHash } from 'node:crypto';
 import { mkdirSync, readFileSync } from 'node:fs';
@@ -79,10 +80,12 @@ export async function runLocalReviewEvidence(options: LocalOperation, snapshotDi
   const output = createHash('sha256');
   const diagnostics = localPrerequisiteDiagnostics();
   const startedAt = new Date().toISOString();
-  const result = await superviseCommand(process.execPath, operation.argv.slice(1), {
+  const tools = localPythonPrerequisites(options);
+  if (tools.error) { diagnostics.write(tools.error); output.update(tools.error); }
+  const result = tools.error ? { exitCode: 1, reason: 'prerequisite-unavailable', stdout: '', stderr: tools.error } : await superviseCommand(process.execPath, operation.argv.slice(1), {
     cwd: options.snapshotRoot,
     env: {
-      PATH: `${dirname(process.execPath)}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`,
+      PATH: [...tools.directories, dirname(process.execPath), '/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin'].join(':'),
       HOME: home, TMPDIR: temporary, TMP: temporary, TEMP: temporary,
       GOLDBAND_HOME: join(home, '.goldband'), LANG: 'C.UTF-8', CI: '1',
       GOLDBAND_REQUIRE_REVIEW_HOST_BOUNDARY: '1',
@@ -136,4 +139,13 @@ function localPrerequisiteDiagnostics() {
     },
     unavailable: () => unavailable,
   };
+}
+
+function localPythonPrerequisites(options: LocalOperation): { directories: string[]; error?: string } {
+  if (!['review-evidence-tests', 'installed-runtime-tests'].includes(options.provider.id)) return { directories: [] };
+  try {
+    return { directories: localReviewPythonPath(options.binding.repository) };
+  } catch (error) {
+    return { directories: [], error: `required review host boundary prerequisite is unavailable: ${error instanceof Error ? error.message : String(error)}` };
+  }
 }

--- a/goldband-loop/workflows/review-python-tools.ts
+++ b/goldband-loop/workflows/review-python-tools.ts
@@ -32,7 +32,7 @@ function hostAccountHome(): string {
   if (result.status !== 0 || /^uid: (.+)$/m.exec(result.stdout ?? '')?.[1] !== uid || !home || !isAbsolute(home)) {
     throw new Error('Python host tool discovery cannot resolve the macOS account home by uid');
   }
-  accountHome = realpathSync(home);
+  accountHome = home;
   return accountHome;
 }
 

--- a/goldband-loop/workflows/review-python-tools.ts
+++ b/goldband-loop/workflows/review-python-tools.ts
@@ -1,0 +1,110 @@
+import { spawnSync } from 'node:child_process';
+import { accessSync, closeSync, constants, openSync, readSync, realpathSync, statSync } from 'node:fs';
+import { userInfo } from 'node:os';
+import { dirname, isAbsolute, join, resolve, sep } from 'node:path';
+
+const SYSTEM_TOOL_ROOTS = [
+  '/opt/homebrew/bin', '/opt/homebrew/Cellar', '/opt/homebrew/opt',
+  '/usr/local/bin', '/usr/local/Cellar', '/usr/local/opt',
+  '/usr/bin', '/bin', '/Library/Frameworks',
+  '/opt/local/bin', '/opt/local/Library/Frameworks',
+];
+
+// Host identity, not HOME (which is replaced for local self-tests). No manifest
+// or environment override may add trusted roots. The explicit home is a test seam.
+type HostToolEnvironment = { path: string; home: string };
+function hostEnvironment(): HostToolEnvironment {
+  return { path: process.env.PATH ?? '/usr/bin:/bin', home: hostAccountHome() };
+}
+
+let accountHome: string | undefined;
+function hostAccountHome(): string {
+  if (accountHome) return accountHome;
+  if (process.platform !== 'darwin') return userInfo().homedir;
+  // Bun's os.userInfo().homedir follows HOME, unlike Node. Query the OS account
+  // by uid so a caller/isolated HOME cannot grant trust to another directory.
+  const uid = String(process.getuid!());
+  const result = spawnSync('/usr/bin/dscacheutil', ['-q', 'user', '-a', 'uid', uid], {
+    encoding: 'utf8', timeout: 10_000, maxBuffer: 16 * 1024,
+    env: { PATH: '/usr/bin:/bin', LANG: 'C.UTF-8' },
+  });
+  const home = /^dir: (.+)$/m.exec(result.stdout ?? '')?.[1];
+  if (result.status !== 0 || /^uid: (.+)$/m.exec(result.stdout ?? '')?.[1] !== uid || !home || !isAbsolute(home)) {
+    throw new Error('Python host tool discovery cannot resolve the macOS account home by uid');
+  }
+  accountHome = realpathSync(home);
+  return accountHome;
+}
+
+function within(path: string, root: string): boolean {
+  return path === root || path.startsWith(`${root}${sep}`);
+}
+
+function toolRoots(home: string, command: string): string[] {
+  const homes = [...new Set([resolve(home), realpathSync(home)])];
+  return [...SYSTEM_TOOL_ROOTS, ...homes.flatMap((root) => [
+    join(root, '.local/bin'),
+    ...(command === 'python3.14' ? [join(root, '.local/share/uv/python'), join(root, '.pyenv/versions')] : []),
+  ])];
+}
+
+export function isHostPythonToolPath(path: string, command: 'python3.14' | 'uv', home: string): boolean {
+  return toolRoots(home, command).some((root) => within(resolve(path), root));
+}
+
+function selectedTool(command: string, path: string): string | undefined {
+  for (const directory of path.split(':').filter(Boolean)) {
+    const candidate = resolve(directory, command);
+    try {
+      accessSync(candidate, constants.X_OK);
+      if (statSync(candidate).isFile()) return candidate;
+    } catch { /* Continue only when the executable is absent or inaccessible. */ }
+  }
+  return undefined;
+}
+
+/** Resolve only the first PATH match; never silently substitute another tool. */
+export function resolveHostPythonTool(
+  command: 'python3.14' | 'uv', repository: string, environment = hostEnvironment(),
+): string {
+  const selected = selectedTool(command, environment.path);
+  if (!selected) throw new Error(`review evidence executable is unavailable: ${command}`);
+  const canonical = realpathSync(selected);
+  const label = command === 'uv' ? 'uv resolver' : 'Python interpreter';
+  const detail = `${label}: selected=${selected}; resolved=${canonical}`;
+  const repositoryRoot = realpathSync(repository);
+  const selectedParent = join(realpathSync(dirname(selected)), command);
+  if ([selected, selectedParent, canonical].some((path) => within(path, repositoryRoot))) {
+    throw new Error(`${detail}; must not come from the source checkout or its virtual environment`);
+  }
+  if (![selected, selectedParent, canonical].every((path) => isHostPythonToolPath(path, command, environment.home))) {
+    throw new Error(`${detail}; must resolve from a trusted host package root; use a supported host installation's native executable, not a shim (see docs/review-evidence-manifest.md)`);
+  }
+  assertNativeTool(canonical, detail);
+  return canonical;
+}
+
+function assertNativeTool(path: string, detail: string): void {
+  const descriptor = openSync(path, 'r');
+  const magic = Buffer.alloc(4);
+  try { readSync(descriptor, magic, 0, magic.length, 0); } finally { closeSync(descriptor); }
+  // Mach-O and universal Mach-O. Reject scripts/shims before interpreter inspection.
+  if (!['feedface', 'cefaedfe', 'feedfacf', 'cffaedfe', 'cafebabe', 'bebafeca', 'cafebabf', 'bfbafeca'].includes(magic.toString('hex'))) {
+    throw new Error(`${detail}; requires a native macOS executable; scripts and version-manager shims are unsupported`);
+  }
+}
+
+/** Keep local host tests' tool selection consistent with sealed Python evidence. */
+export function localReviewPythonPath(repository: string, environment = hostEnvironment()): string[] {
+  const directories: string[] = [];
+  for (const command of ['python3.14', 'uv'] as const) {
+    // Missing prerequisites are reported by the relevant self-test. A found but
+    // rejected executable must fail here, rather than falling back to Homebrew.
+    if (!selectedTool(command, environment.path)) continue;
+    resolveHostPythonTool(command, repository, environment);
+    const directory = dirname(selectedTool(command, environment.path)!);
+    if (!directories.includes(directory)) directories.push(directory);
+  }
+  return [...new Set(environment.path.split(':').filter(Boolean).map((directory) => resolve(directory)))]
+    .filter((directory) => directories.includes(directory));
+}

--- a/goldband-loop/workflows/review-semantic.ts
+++ b/goldband-loop/workflows/review-semantic.ts
@@ -1,0 +1,172 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { stateRoot } from './evidence';
+import { adapterFor, HostRunError, type HostExecutionPolicy, type HostUsage } from './host-adapter';
+import { createReviewCandidateBinding, reviewLineageAuthority } from './review-evidence';
+import { aggregateReviewFindings, unwrapFindings } from './review-engine';
+import { reviewInputSchema, type ReviewDiffInput, type ReviewImpactContext } from './review-impact';
+import { projectPriorReviewBlockers, reviewLineageScopeDigest, reviewPolicyIdentity } from './review-lineage';
+import { coreReviewRules, createReviewRulesSnapshot, type RulesBundle } from './review-rules';
+import { createReviewTimeBudget, type ReviewTimeoutPolicy } from './review-timeouts';
+import { resolveReviewWorkspace } from './review-workspace';
+import { findingsSchema } from './schema';
+import type { ReviewFinding, WorkflowContext } from './types';
+
+type SemanticReviewArtifact = {
+  schemaVersion: 1;
+  phase: 'semantic-only';
+  evidenceStatus: 'not-declared';
+  completionAuthorized: false;
+  providerCallCount: 0;
+  hostCallCount: 1;
+  runId: string;
+  binding: ReturnType<typeof createReviewCandidateBinding>;
+  canonicalScopeDigest: string;
+  policyIdentityDigest: string;
+  identity: string;
+  priorBlockers: ReturnType<typeof projectPriorReviewBlockers>;
+  findings: ReviewFinding[];
+};
+
+type SemanticReviewDependencies = {
+  collectDiff(ctx: WorkflowContext): ReviewDiffInput;
+  buildReviewPrompt(ctx: WorkflowContext, diff: string, context: {
+    rules: ReturnType<typeof coreReviewRules>; impact: ReviewImpactContext; policyText: string;
+  }): string;
+  buildReviewPolicyText(ctx: WorkflowContext, rules: ReturnType<typeof coreReviewRules>): string;
+  hasConcreteFailurePath(finding: ReviewFinding): boolean;
+  reviewHost(ctx: WorkflowContext): 'mock' | 'claude' | 'codex';
+  recordReviewHostUsage(ctx: WorkflowContext, host: string, usage?: HostUsage, policy?: HostExecutionPolicy): void;
+  recordReviewPromptTelemetry(ctx: WorkflowContext, host: string, prompt: string,
+    bundle: RulesBundle, rules: string, diff: string, policy: ReviewTimeoutPolicy, impact: ReviewImpactContext): void;
+  findingsJsonSchema: object;
+};
+
+const runs = new Map<string, SemanticReviewArtifact>();
+
+export async function runSemanticReview(ctx: WorkflowContext, deps: SemanticReviewDependencies): Promise<ReviewFinding[]> {
+  const input = reviewInputSchema.validate(ctx.input);
+  if (input.impact.changedFiles.length === 0) throw new Error('semantic-only review candidate is empty');
+  const cwd = resolveReviewWorkspace(ctx.cwd).repositoryRoot;
+  const binding = createReviewCandidateBinding(cwd, input, ctx.options.base);
+  const { rules, policyText, policyIdentityDigest } = semanticPolicy(ctx, deps, input, binding.baseRef);
+  const canonicalScopeDigest = reviewLineageScopeDigest(binding.scopeDigest, { changedFiles: binding.changedFiles });
+  const identity = digest({ mode: 'semantic-only', repository: binding.repository,
+    baseDigest: binding.baseDigest, candidateDigest: binding.candidateDigest,
+    canonicalScopeDigest, policyIdentityDigest });
+  const authority = reviewLineageAuthority(ctx);
+  const priorOptions = { storeRoot: authority.receiptRoot, key: authority.key, ...binding };
+  projectPriorReviewBlockers(priorOptions);
+  const budget = createReviewTimeBudget(ctx.options, undefined, ctx.passStartedAtMonotonicMs);
+  const host = deps.reviewHost(ctx);
+  const adapter = adapterFor(host);
+  const prompt = deps.buildReviewPrompt(ctx, input.diff, { rules, impact: input.impact, policyText });
+  deps.recordReviewPromptTelemetry(ctx, host, prompt, rules.bundle, rules.text, input.diff, budget.policy, input.impact);
+  const timeoutMs = budget.nextHostTimeoutMs();
+  // A durable exclusive attempt is the one-shot cost boundary, including failures
+  // and concurrent processes. It is separate from acceptance lineage and receipts.
+  const attempts = join(dirname(authority.receiptRoot), 'semantic-review-attempts');
+  mkdirSync(attempts, { recursive: true, mode: 0o700 });
+  try {
+    writeFileSync(join(attempts, `${identity}.json`), JSON.stringify({ identity, runId: ctx.runId }), { flag: 'wx', mode: 0o600 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') throw new Error('duplicate semantic-only review identity; no new semantic host call authorized');
+    throw error;
+  }
+  let result;
+  try {
+    result = await adapter.runJson(prompt, {
+      type: 'object', properties: { findings: deps.findingsJsonSchema },
+      required: ['findings'], additionalProperties: false,
+    }, cwd, { timeoutMs, claudeMaxBudgetUsd: ctx.options.reviewClaudeMaxBudgetUsd });
+  } catch (error) {
+    if (error instanceof HostRunError) deps.recordReviewHostUsage(ctx, host, error.usage, error.executionPolicy);
+    throw error;
+  }
+  deps.recordReviewHostUsage(ctx, host, result.usage, result.executionPolicy);
+  const current = createReviewCandidateBinding(cwd, deps.collectDiff(ctx), ctx.options.base);
+  if (digest(current) !== digest(binding) || semanticPolicy(ctx, deps, input, binding.baseRef).policyIdentityDigest !== policyIdentityDigest) {
+    throw new Error('semantic-only candidate or Rules/policy changed during review');
+  }
+  const findings = semanticFindings(unwrapFindings(result.parsed), deps.hasConcreteFailurePath);
+  runs.set(ctx.runId, {
+    schemaVersion: 1, phase: 'semantic-only', evidenceStatus: 'not-declared',
+    completionAuthorized: false, providerCallCount: 0, hostCallCount: 1,
+    runId: ctx.runId, binding, canonicalScopeDigest, policyIdentityDigest, identity,
+    priorBlockers: projectPriorReviewBlockers(priorOptions), findings,
+  });
+  return findings;
+}
+
+function semanticFindings(value: unknown, hasConcreteFailurePath: SemanticReviewDependencies['hasConcreteFailurePath']): ReviewFinding[] {
+  const concerns: ReviewFinding[] = findingsSchema.validate(value).map((finding) => {
+    // Project allowed semantic fields; model IDs and provenance never become authority.
+    const { id: _id, evidenceIds: _evidenceIds, behaviorCellIds: _cells,
+      blocking: _blocking, classification: _classification, ...concern } = finding;
+    return { ...concern, category: concern.category === 'deterministic-evidence' ? 'semantic-review' : concern.category,
+      classification: 'semantic-concern', blocking: false };
+  });
+  return aggregateReviewFindings(concerns).filter(hasConcreteFailurePath);
+}
+
+export function renderSemanticReport(ctx: WorkflowContext): string {
+  const artifact = runs.get(ctx.runId);
+  if (!artifact) throw new Error('semantic-only review result is missing');
+  runs.delete(ctx.runId);
+  artifact.findings = findingsSchema.validate(ctx.input);
+  const lines = [
+    '# review/code runtime report', '', 'Phase: semantic-only.',
+    'Deterministic evidence: not-declared. Deterministic behavior completeness was not evaluated.',
+    'No tests, evidence providers, or dependency preparation were executed. Completion authority: none.',
+    `Candidate: ${artifact.binding.candidateDigest}.`,
+    `Reading scope: ${artifact.binding.changedFiles.join(', ')} (scoped diff and necessary impact context).`,
+    'Semantic host calls: 1. Evidence provider calls: 0.', '',
+  ];
+  if (artifact.priorBlockers.length) {
+    lines.push('prior-blockers-open (read-only projection; no acceptance lineage was changed):');
+    for (const blocker of artifact.priorBlockers) lines.push(`- ${blocker.lineageId}: ${blocker.findingId} — ${blocker.artifactFile ?? 'artifact unavailable'}`);
+    lines.push('');
+  }
+  if (!artifact.findings.length) lines.push('No semantic concerns found.');
+  lines.push(...semanticFindingLines(artifact.findings));
+  const dir = join(stateRoot(ctx.options), 'workflow-runs', 'artifacts');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `${ctx.runId}-semantic-only.json`);
+  const reportFile = join(dir, `${ctx.runId}-semantic-only.md`);
+  const report = `${lines.join('\n')}\n`;
+  writeFileSync(file, `${JSON.stringify(artifact, null, 2)}\n`, { flag: 'wx', mode: 0o600 });
+  writeFileSync(reportFile, report, { flag: 'wx', mode: 0o600 });
+  ctx.artifacts.push(file, reportFile);
+  return report;
+}
+
+function semanticPolicy(ctx: WorkflowContext, deps: SemanticReviewDependencies,
+  input: ReturnType<typeof reviewInputSchema.validate>, baseRef: string) {
+  const cwd = resolveReviewWorkspace(ctx.cwd).repositoryRoot;
+  const snapshot = createReviewRulesSnapshot(cwd);
+  const rules = coreReviewRules(cwd, input.diff, snapshot, input.impact.changedFiles);
+  const policyText = deps.buildReviewPolicyText(ctx, rules);
+  const policyIdentityDigest = digest({ policy: reviewPolicyIdentity(cwd, baseRef), policyText,
+    rules: snapshot.manifest.rules.map((rule) => ({
+      id: rule.id, contentHash: snapshot.rulesById[rule.id]?.contentHash,
+    })),
+  });
+  return { rules, policyText, policyIdentityDigest };
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+function semanticFindingLines(findings: ReviewFinding[]): string[] {
+  const lines: string[] = [];
+  for (const finding of findings) {
+    lines.push(`- [semantic-concern] [${finding.severity}] ${finding.file}${finding.line ? `:${finding.line}` : ''}: ${finding.summary}`);
+    if (finding.evidence) lines.push(`  Code observation (not execution evidence): ${finding.evidence}`);
+    if (finding.failureScenario) lines.push(`  Trigger: ${finding.failureScenario}`);
+    if (finding.recommendation) lines.push(`  Fix: ${finding.recommendation}`);
+    if (finding.suggestedVerification) lines.push(`  Suggested verification (not executed): ${finding.suggestedVerification}`);
+  }
+  return lines;
+}

--- a/goldband-loop/workflows/review.ts
+++ b/goldband-loop/workflows/review.ts
@@ -114,6 +114,7 @@ import type {
   WorkflowStep,
 } from './types';
 import { resolveReviewWorkspace } from './review-workspace';
+import { runSemanticReview, renderSemanticReport } from './review-semantic';
 
 export type UntrackedDiffState = {
   includedBytes: number;
@@ -165,14 +166,33 @@ export const reviewSteps: WorkflowStep[] = [
     produces: reviewInputSchema,
     run: collectImpactContext,
   },
-  { name: 'plan-evidence', kind: 'typed', produces: reviewInputSchema, run: planEvidence },
-  { name: 'run-evidence', kind: 'typed', produces: reviewInputSchema, run: runEvidence },
-  { name: 'verify-evidence', kind: 'typed', produces: reviewInputSchema, run: verifyEvidence },
-  { name: 'run-review', kind: 'llm', produces: findingsSchema, run: runReview },
-  { name: 'parse-findings', kind: 'typed', produces: findingsSchema, run: parseFindings },
-  { name: 'verify-findings', kind: 'typed', produces: findingsSchema, run: verifyFindings },
-  { name: 'render-report', kind: 'typed', produces: textSchema, run: renderReport },
+  { name: 'plan-evidence', kind: 'typed', produces: reviewInputSchema, run: reviewModeStep(planEvidence, skipEvidence) },
+  { name: 'run-evidence', kind: 'typed', produces: reviewInputSchema, run: reviewModeStep(runEvidence, skipEvidence) },
+  { name: 'verify-evidence', kind: 'typed', produces: reviewInputSchema, run: reviewModeStep(verifyEvidence, skipEvidence) },
+  { name: 'run-review', kind: 'llm', produces: findingsSchema, run: reviewModeStep(runReview, semanticReview) },
+  { name: 'parse-findings', kind: 'typed', produces: findingsSchema, run: reviewModeStep(parseFindings, semanticParsedFindings) },
+  { name: 'verify-findings', kind: 'typed', produces: findingsSchema, run: reviewModeStep(verifyFindings, semanticParsedFindings) },
+  { name: 'render-report', kind: 'typed', produces: textSchema, run: reviewModeStep(renderReport, renderSemanticReport) },
 ];
+
+function reviewModeStep(evidence: WorkflowStep['run'], semantic: WorkflowStep['run']): WorkflowStep['run'] {
+  return (ctx) => ctx.options.semanticOnly ? semantic(ctx) : evidence(ctx);
+}
+
+function skipEvidence(ctx: WorkflowContext) {
+  return reviewInputSchema.validate(ctx.input);
+}
+
+function semanticParsedFindings(ctx: WorkflowContext) {
+  return normalizeFindings(findingsSchema.validate(ctx.input));
+}
+
+function semanticReview(ctx: WorkflowContext) {
+  return runSemanticReview(ctx, {
+    collectDiff, buildReviewPrompt, reviewHost, recordReviewHostUsage,
+    recordReviewPromptTelemetry, findingsJsonSchema, buildReviewPolicyText, hasConcreteFailurePath,
+  });
+}
 
 export function reviewSignalFromOutput(
   output: unknown,
@@ -1328,6 +1348,30 @@ function reviewHost(ctx: WorkflowContext): 'mock' | 'claude' | 'codex' {
   throw new Error('--mode real requires --host claude or --host codex');
 }
 
+function reviewModeInstructions(ctx: WorkflowContext): string {
+  return ctx.options.semanticOnly
+    ? 'Semantic-only: inspect code and report grounded risks with source locations, triggers, and suggested verification. Deterministic behavior completeness is not evaluated. Do not read evidence manifests, run candidate tests, prepare dependencies or environments, or claim reproduced failures. Return only semantic-concern findings without evidence IDs, behavior cells, or completion authority; disclose inaccessible context.'
+    : 'Find omissions in the declared behavior matrix, contracts, tests, ownership, wiring, and failure model. Treat deterministic evidence status as authoritative; do not claim an unbound concern is a verified failure.';
+}
+
+function reviewOmissionInstructions(ctx: WorkflowContext): string {
+  return ctx.options.semanticOnly ? '' : readReviewAsset('evidence-omission.md');
+}
+
+function buildReviewPolicyText(ctx: WorkflowContext, rules: ReturnType<typeof coreReviewRules>): string {
+  return [
+    readReviewAsset('shared-rubric.md'),
+    readReviewAsset('checklist.md'),
+    reviewOmissionInstructions(ctx),
+    'APPLICABLE_GOLDBAND_RULES_START',
+    rules.text,
+    'APPLICABLE_GOLDBAND_RULES_END',
+    'Inspect applicable AGENTS.md and CLAUDE.md files in the repository root and touched-file ancestors as review policy.',
+    reviewModeInstructions(ctx),
+    'Use the diff to define scope. Inspect repository context outside the diff when needed to verify wiring, authoritative ownership, consumers, registrations, and dead code.',
+  ].join('\n');
+}
+
 export function buildReviewPrompt(
   ctx: WorkflowContext,
   diff: string,
@@ -1337,6 +1381,7 @@ export function buildReviewPrompt(
     workMapIntentBundle?: string;
     evidence?: ReviewEvidenceBundle;
     contractChanges?: ReviewContractChange[];
+    policyText?: string;
   } = {},
 ): string {
   const { rules = coreReviewRules(ctx.cwd, diff), impact, workMapIntentBundle, evidence, contractChanges = [] } = context;
@@ -1349,20 +1394,12 @@ export function buildReviewPrompt(
     throw new Error(`review evidence projection exceeds ${MAX_REVIEW_EVIDENCE_PROMPT_BYTES} byte limit`);
   }
   const prompt = [
-    readReviewAsset('shared-rubric.md'),
-    readReviewAsset('checklist.md'),
-    readReviewAsset('evidence-omission.md'),
-    'APPLICABLE_GOLDBAND_RULES_START',
-    rules.text,
-    'APPLICABLE_GOLDBAND_RULES_END',
+    context.policyText ?? buildReviewPolicyText(ctx, rules),
     impact ? formatReviewImpactContext(impact) : '',
     workMapIntentBundle ?? '',
     matrixProjection,
     evidenceProjection,
     reviewContractChangesPrompt(contractChanges),
-    'Inspect applicable AGENTS.md and CLAUDE.md files in the repository root and touched-file ancestors as review policy.',
-    'Find omissions in the declared behavior matrix, contracts, tests, ownership, wiring, and failure model. Treat deterministic evidence status as authoritative; do not claim an unbound concern is a verified failure.',
-    'Use the diff to define scope. Inspect repository context outside the diff when needed to verify wiring, authoritative ownership, consumers, registrations, and dead code.',
     'DIFF_START',
     diff,
     'DIFF_END',
@@ -1593,7 +1630,7 @@ function recordReviewPromptTelemetry(
   diff: string,
   timeoutPolicy: ReviewTimeoutPolicy,
   impact: ReviewImpactContext,
-  evidence: ReviewEvidenceBundle,
+  evidence?: ReviewEvidenceBundle,
   closure?: ClosureReviewInput,
 ): void {
   const telemetry = {
@@ -1604,11 +1641,9 @@ function recordReviewPromptTelemetry(
       coreRulesText,
       diff: closure?.kind === 'semantic-closure' ? '' : diff,
     }),
-    phase: transitionPhase(closure),
+    ...reviewEvidenceTelemetry(ctx, evidence, closure),
     hostCallBudget: 1,
     hostCallCount: 1,
-    matrixBytes: Buffer.byteLength(behaviorMatrixProjection(evidence)),
-    evidenceBytes: Buffer.byteLength(evidenceSummaryProjection(evidence)),
     repairDeltaBytes: closure ? Buffer.byteLength(closure.repairDelta) : 0,
     originalDiffBytesSent: closure?.kind === 'semantic-closure' ? 0 : Buffer.byteLength(diff),
     specialistMode: timeoutPolicy.specialistMode,
@@ -1624,6 +1659,14 @@ function recordReviewPromptTelemetry(
   mkdirSync(dir, { recursive: true });
   const file = join(dir, `${ctx.runId}-review-prompt.json`);
   writeFileSync(file, `${JSON.stringify(telemetry, null, 2)}\n`);
+}
+
+function reviewEvidenceTelemetry(ctx: WorkflowContext, evidence?: ReviewEvidenceBundle, closure?: ClosureReviewInput) {
+  return {
+    phase: ctx.options.semanticOnly ? 'semantic-only' : transitionPhase(closure),
+    matrixBytes: evidence ? Buffer.byteLength(behaviorMatrixProjection(evidence)) : 0,
+    evidenceBytes: evidence ? Buffer.byteLength(evidenceSummaryProjection(evidence)) : 0,
+  };
 }
 
 function requiredEvidenceRunState(runId: string): ReviewEvidenceRunState {

--- a/goldband-loop/workflows/run.ts
+++ b/goldband-loop/workflows/run.ts
@@ -28,14 +28,12 @@ function parseArgs(args: string[]): { capability: string; action: string; option
   let loop = false;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+    if (setBooleanOption(arg, options)) continue;
     if (arg === '--input') options.inputFile = takeValue(args, ++index, arg);
     else if (arg === '--base') options.base = takeValue(args, ++index, arg);
     else if (arg === '--mode') options.mode = takeValue(args, ++index, arg) as WorkflowRunOptions['mode'];
     else if (arg === '--host') options.host = takeValue(args, ++index, arg) as WorkflowRunOptions['host'];
     else if (arg === '--diff-file') options.diffFile = takeValue(args, ++index, arg);
-    else if (arg === '--staged') options.staged = true;
-    else if (arg === '--worktree') options.worktree = true;
-    else if (arg === '--include-untracked') options.includeUntracked = true;
     else if (arg === '--specialists') options.specialists = takeValue(args, ++index, arg) as WorkflowRunOptions['specialists'];
     else if (arg === '--review-host-timeout-seconds') options.reviewHostTimeoutMs = takeSeconds(args, ++index, arg);
     else if (arg === '--review-pass-timeout-seconds') options.reviewPassTimeoutMs = takeSeconds(args, ++index, arg);
@@ -53,6 +51,14 @@ function parseArgs(args: string[]): { capability: string; action: string; option
   validateOptions(capability, action, options);
 
   return { capability, action, options, loop };
+}
+
+function setBooleanOption(arg: string | undefined, options: WorkflowRunOptions): boolean {
+  const key = { '--staged': 'staged', '--worktree': 'worktree',
+    '--include-untracked': 'includeUntracked', '--semantic-only': 'semanticOnly' }[arg ?? ''];
+  if (!key) return false;
+  options[key as 'staged' | 'worktree' | 'includeUntracked' | 'semanticOnly'] = true;
+  return true;
 }
 
 function validateOptions(
@@ -89,7 +95,7 @@ function validateOptions(
     usageError('review timeout and budget options are only valid for review/code');
   }
   if (
-    (options.evidenceManifestFile || options.closureArtifactFile) &&
+    (options.semanticOnly || options.evidenceManifestFile || options.closureArtifactFile) &&
     `${capability}/${action}` !== 'review/code'
   ) {
     usageError('evidence manifest and closure artifact options are only valid for review/code');
@@ -162,7 +168,7 @@ function usageError(message: string): never {
 }
 
 function usage(): void {
-  console.error('Usage: bun run workflows/run.ts <capability> <action> [--loop] [--max-iterations <n>] [--input <file>] [--base <ref>] [--mode mock|real] [--host mock|claude|codex] [--work-id <id> --ticket-id <id>] [--evidence-manifest <file>] [--closure-artifact <initial-review-artifact>] [--review-host-timeout-seconds <60-1800>] [--review-pass-timeout-seconds <60-1800>] [--review-claude-max-budget-usd <0.01-100.00>] [--staged|--worktree|--include-untracked|--diff-file <file>]');
+  console.error('Usage: bun run workflows/run.ts <capability> <action> [--loop] [--max-iterations <n>] [--input <file>] [--base <ref>] [--mode mock|real] [--host mock|claude|codex] [--work-id <id> --ticket-id <id>] [--semantic-only] [--evidence-manifest <file>] [--closure-artifact <initial-review-artifact>] [--review-host-timeout-seconds <60-1800>] [--review-pass-timeout-seconds <60-1800>] [--review-claude-max-budget-usd <0.01-100.00>] [--staged|--worktree|--include-untracked|--diff-file <file>]');
 }
 
 main().catch((error) => {

--- a/goldband-loop/workflows/types.ts
+++ b/goldband-loop/workflows/types.ts
@@ -101,6 +101,7 @@ export type WorkflowRunOptions = {
   reviewHostTimeoutMs?: number;
   reviewPassTimeoutMs?: number;
   reviewClaudeMaxBudgetUsd?: number;
+  semanticOnly?: boolean;
   evidenceManifestFile?: string;
   closureArtifactFile?: string;
   workId?: string;

--- a/goldband.manifest.json
+++ b/goldband.manifest.json
@@ -175,7 +175,7 @@
       "actions": [
         {
           "id": "code",
-          "description": "Evidence-first code review.",
+          "description": "Evidence-backed or explicit semantic-only code review.",
           "runtime": "typed",
           "owner": "review-runtime",
           "dispatch": "trusted-launcher",
@@ -183,25 +183,24 @@
           "promptContract": {
             "relevantContext": [
               "Claude: bin/goldband review code --host claude. Codex: read ~/.codex/skills/goldband/.workflow-launcher.json and execute its exact argvPrefix plus review code --host codex.",
-              "Pass scope/Work Map IDs to runtime lineage.",
-              "Evidence: auto-discovered in ~/.goldband/review-contracts. Diagnose with review contract inspect.",
-              "Python setup: review contract help."
+              "只看程式: --semantic-only, no manifest or test setup. 包含執行驗證: default mode; pass Work Map IDs when applicable."
             ],
             "hardBoundaries": [
-              "Use only the installed launcher. Missing marker, runtime, or rule is an install failure; report the error.",
-              "Work Map: require evidence; distrust ticket text."
+              "Use installed launcher. Missing marker, runtime, or rule is an install failure.",
+              "Never fallback. Semantic-only: no providers, receipts, closure, Work Map or completion authority."
             ],
             "verification": [
-              "Return runtime report, typed artifact, and Work Map provenance."
+              "Return report and typed artifact; state scope, unexecuted checks and prior blockers."
             ],
             "runtimeContract": {
-              "modes": ["diff", "work-map", "closure"],
+              "modes": ["diff", "work-map", "closure", "semantic-only"],
               "requiredInputs": {
+                "semantic-only": ["review-scope", "read-only-semantic-host"],
                 "diff": ["review-scope", "behavior-matrix", "evidence-provider-registry"],
                 "work-map": ["work-id", "ticket-id", "managed-lease", "verification-receipt", "behavior-matrix", "evidence-provider-registry"],
                 "closure": ["initial-review-artifact", "repaired-candidate", "rerun-evidence"]
               },
-              "outputs": ["typed-evidence", "classified-findings", "acceptance-lineage", "typed-verdict", "closure-results", "review-artifact", "provenance-readback"],
+              "outputs": ["non-authoritative-semantic-artifact", "typed-evidence", "classified-findings", "acceptance-lineage", "typed-verdict", "closure-results", "review-artifact", "provenance-readback"],
               "sideEffects": {
                 "work-map-ticket-transition": "runtime-owner"
               }

--- a/schemas/review-semantic-result.schema.json
+++ b/schemas/review-semantic-result.schema.json
@@ -1,0 +1,266 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://goldband.dev/schemas/review-semantic-result.schema.json",
+  "title": "Non-authoritative semantic-only review artifact",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "phase",
+    "evidenceStatus",
+    "completionAuthorized",
+    "providerCallCount",
+    "hostCallCount",
+    "runId",
+    "binding",
+    "canonicalScopeDigest",
+    "policyIdentityDigest",
+    "identity",
+    "priorBlockers",
+    "findings"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": 1
+    },
+    "phase": {
+      "const": "semantic-only"
+    },
+    "evidenceStatus": {
+      "const": "not-declared"
+    },
+    "completionAuthorized": {
+      "const": false
+    },
+    "providerCallCount": {
+      "const": 0
+    },
+    "hostCallCount": {
+      "const": 1
+    },
+    "runId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "baseRef",
+        "baseDigest",
+        "candidateDigest",
+        "scopeDigest",
+        "changedFiles",
+        "redactedUntrackedFiles"
+      ],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "baseRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "baseDigest": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "candidateDigest": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "scopeDigest": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "changedFiles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "redactedUntrackedFiles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "path",
+              "digest",
+              "size",
+              "mode"
+            ],
+            "properties": {
+              "path": {
+                "type": "string",
+                "minLength": 1
+              },
+              "digest": {
+                "type": "string",
+                "pattern": "^[a-f0-9]{64}$"
+              },
+              "size": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "mode": {
+                "enum": [
+                  "100644",
+                  "100755"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "canonicalScopeDigest": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "policyIdentityDigest": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "identity": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "priorBlockers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "lineageId",
+          "findingId"
+        ],
+        "properties": {
+          "lineageId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "findingId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "artifactFile": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "file",
+          "severity",
+          "summary",
+          "classification"
+        ],
+        "properties": {
+          "file": {
+            "type": "string",
+            "minLength": 1
+          },
+          "line": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 1
+          },
+          "severity": {
+            "enum": [
+              "critical",
+              "high",
+              "medium",
+              "low",
+              "info"
+            ]
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "recommendation": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "category": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ruleId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "policySource": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "classification": {
+            "const": "semantic-concern"
+          },
+          "failureScenario": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reproductionStep": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "suggestedVerification": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "blocking": {
+            "const": false
+          },
+          "specialist": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "contributingSpecialists": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/scripts/lib/workflow-distribution-contract.mjs
+++ b/scripts/lib/workflow-distribution-contract.mjs
@@ -16,6 +16,7 @@ export const SOURCE_INPUTS = [
   'goldband.manifest.json',
   'hooks/scripts/lib/rules-resolver.js',
   'rules',
+  'schemas/review-semantic-result.schema.json',
   'schemas/review-behavior-matrix.schema.json',
   'schemas/review-evidence-manifest.schema.json',
   'shell/install',

--- a/scripts/test-workflow-integration-fixture.sh
+++ b/scripts/test-workflow-integration-fixture.sh
@@ -4,6 +4,7 @@ copy_distribution_fixture_inputs() {
   cp "$ROOT_DIR/docs/review-evidence-manifest.md" "$TMP_ROOT/docs/review-evidence-manifest.md"
   cp "$ROOT_DIR/examples/review-evidence/minimal-local-gate.json" "$TMP_ROOT/examples/review-evidence/minimal-local-gate.json"
   cp "$ROOT_DIR/schemas/review-evidence-manifest.schema.json" "$TMP_ROOT/schemas/review-evidence-manifest.schema.json"
+  cp "$ROOT_DIR/schemas/review-semantic-result.schema.json" "$TMP_ROOT/schemas/review-semantic-result.schema.json"
   cp "$ROOT_DIR/schemas/review-behavior-matrix.schema.json" "$TMP_ROOT/schemas/review-behavior-matrix.schema.json"
 }
 
@@ -82,5 +83,6 @@ EOF_TODOS
   cp "$ROOT_DIR/docs/review-evidence-manifest.md" "$loop_dir/review/review-evidence-manifest.md"
   cp "$ROOT_DIR/examples/review-evidence/minimal-local-gate.json" "$loop_dir/review/examples/minimal-local-gate.json"
   cp "$ROOT_DIR/schemas/review-evidence-manifest.schema.json" "$loop_dir/review/schemas/review-evidence-manifest.schema.json"
+  cp "$ROOT_DIR/schemas/review-semantic-result.schema.json" "$loop_dir/review/schemas/review-semantic-result.schema.json"
   cp "$ROOT_DIR/schemas/review-behavior-matrix.schema.json" "$loop_dir/review/schemas/review-behavior-matrix.schema.json"
 }


### PR DESCRIPTION
Add an explicit `review code --semantic-only` mode so code review can run without evidence manifests or project runtime preparation. Reports retain existing blockers and carry no completion authority; evidence-backed review keeps its existing gates. Claude and Codex launchers, schemas, documentation, and installation contracts are aligned.

Also promote the pending Python evidence fixes for offline uv cache relocation, native user tool installations, and host home aliases. The cache regression now explicitly seeds an absolute symlink instead of depending on the installed uv version.

Validation:
- Final head `f692250cd36f37786a52058a24c8e4d2a4da1c58`: Validate Config (12 jobs), Windows, and Workflow Lint passed.
- Goldband independent review findings S-001/S-002 were fixed and closed by formal scoped closure; the final cache fixture correction received a separate independent semantic review with no findings.
- Claude and Codex installed runtimes updated and verified; working tree clean.

Closes #24.
